### PR TITLE
feat(chat): add opus 4.7 to chat model picker and gate hyperlinks thr…

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Panes"
-version = "0.54.0"
+version = "0.54.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/src/engines/claude_sidecar.rs
+++ b/src-tauri/src/engines/claude_sidecar.rs
@@ -932,12 +932,47 @@ impl Engine for ClaudeSidecarEngine {
     fn models(&self) -> Vec<ModelInfo> {
         vec![
             ModelInfo {
-                id: "claude-opus-4-6".to_string(),
-                display_name: "Claude Opus 4.6".to_string(),
+                id: "claude-opus-4-7".to_string(),
+                display_name: "Claude Opus 4.7".to_string(),
                 description: "Most intelligent model for agents and coding".to_string(),
                 hidden: false,
                 is_default: false,
                 upgrade: None,
+                availability_nux: None,
+                upgrade_info: None,
+                input_modalities: vec!["text".to_string(), "image".to_string()],
+                supports_personality: false,
+                default_reasoning_effort: "xhigh".to_string(),
+                supported_reasoning_efforts: vec![
+                    ReasoningEffortOption {
+                        reasoning_effort: "low".to_string(),
+                        description: "Quick, efficient responses".to_string(),
+                    },
+                    ReasoningEffortOption {
+                        reasoning_effort: "medium".to_string(),
+                        description: "Balanced reasoning".to_string(),
+                    },
+                    ReasoningEffortOption {
+                        reasoning_effort: "high".to_string(),
+                        description: "Deep, thorough reasoning".to_string(),
+                    },
+                    ReasoningEffortOption {
+                        reasoning_effort: "xhigh".to_string(),
+                        description: "Extended exploration for agentic coding".to_string(),
+                    },
+                    ReasoningEffortOption {
+                        reasoning_effort: "max".to_string(),
+                        description: "Absolute highest capability, no constraints".to_string(),
+                    },
+                ],
+            },
+            ModelInfo {
+                id: "claude-opus-4-6".to_string(),
+                display_name: "Claude Opus 4.6".to_string(),
+                description: "Previous generation flagship for agents and coding".to_string(),
+                hidden: false,
+                is_default: false,
+                upgrade: Some("claude-opus-4-7".to_string()),
                 availability_nux: None,
                 upgrade_info: None,
                 input_modalities: vec!["text".to_string(), "image".to_string()],
@@ -964,7 +999,7 @@ impl Engine for ClaudeSidecarEngine {
                 description: "Best balance of speed and intelligence".to_string(),
                 hidden: false,
                 is_default: true,
-                upgrade: Some("claude-opus-4-6".to_string()),
+                upgrade: Some("claude-opus-4-7".to_string()),
                 availability_nux: None,
                 upgrade_info: None,
                 input_modalities: vec!["text".to_string(), "image".to_string()],

--- a/src/components/chat/ModelPicker.tsx
+++ b/src/components/chat/ModelPicker.tsx
@@ -53,6 +53,7 @@ function shortEffortLabel(t: TFunction<"chat">, effort: string): string {
     case "medium": return t("modelPicker.effort.mediumShort");
     case "high": return t("modelPicker.effort.highShort");
     case "xhigh": return t("modelPicker.effort.xhighShort");
+    case "max": return t("modelPicker.effort.maxShort");
     default: return effort.charAt(0).toUpperCase() + effort.slice(1);
   }
 }
@@ -65,6 +66,7 @@ function effortDisplayLabel(t: TFunction<"chat">, effort: string): string {
     case "medium": return t("modelPicker.effort.medium");
     case "high": return t("modelPicker.effort.high");
     case "xhigh": return t("modelPicker.effort.xhigh");
+    case "max": return t("modelPicker.effort.max");
     default: return effort.charAt(0).toUpperCase() + effort.slice(1);
   }
 }

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -29,13 +29,15 @@
       "low": "Low",
       "medium": "Medium",
       "high": "High",
-      "xhigh": "Max",
+      "xhigh": "XHigh",
+      "max": "Max",
       "noneShort": "None",
       "minimalShort": "Min",
       "lowShort": "Lo",
       "mediumShort": "Med",
       "highShort": "Hi",
-      "xhighShort": "Max"
+      "xhighShort": "XHi",
+      "maxShort": "Max"
     }
   },
   "attachments": {

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -29,13 +29,15 @@
       "low": "Baixo",
       "medium": "Médio",
       "high": "Alto",
-      "xhigh": "Máximo",
+      "xhigh": "XAlto",
+      "max": "Máximo",
       "noneShort": "Nen",
       "minimalShort": "Min",
       "lowShort": "Bx",
       "mediumShort": "Med",
       "highShort": "Alt",
-      "xhighShort": "Máx"
+      "xhighShort": "XAlt",
+      "maxShort": "Máx"
     }
   },
   "attachments": {

--- a/src/lib/fileLinkNavigation.test.ts
+++ b/src/lib/fileLinkNavigation.test.ts
@@ -268,20 +268,13 @@ describe("fileLinkNavigation", () => {
     expect(extractTextLinkMatches("relative src/App.tsx should stay plain")).toEqual([]);
   });
 
-  it("opens local links internally on normal click and shift-click", async () => {
+  it("opens local links internally only on shift-click", async () => {
     await expect(
       navigateLinkTarget("/workspace/apps/app/src/main.ts#L12C4", { shiftKey: false }),
-    ).resolves.toBe("internal");
+    ).resolves.toBe("ignored");
 
-    expect(mockOpenFileAtLocation).toHaveBeenCalledWith(
-      "/workspace/apps/app",
-      "src/main.ts",
-      { line: 12, column: 4 },
-    );
-    expect(mockSetLayoutMode).toHaveBeenCalledWith("ws-1", "editor");
-
-    mockOpenFileAtLocation.mockClear();
-    mockSetLayoutMode.mockClear();
+    expect(mockOpenFileAtLocation).not.toHaveBeenCalled();
+    expect(mockSetLayoutMode).not.toHaveBeenCalled();
 
     await expect(
       navigateLinkTarget("/workspace/apps/app/src/main.ts#L12C4", { shiftKey: true }),
@@ -295,9 +288,15 @@ describe("fileLinkNavigation", () => {
     expect(mockSetLayoutMode).toHaveBeenCalledWith("ws-1", "editor");
   });
 
-  it("opens external links through the shell", async () => {
+  it("opens external links through the shell only on shift-click", async () => {
     await expect(
       navigateLinkTarget("https://example.com/docs", { shiftKey: false }),
+    ).resolves.toBe("ignored");
+
+    expect(mockOpenExternal).not.toHaveBeenCalled();
+
+    await expect(
+      navigateLinkTarget("https://example.com/docs", { shiftKey: true }),
     ).resolves.toBe("external");
 
     expect(mockOpenExternal).toHaveBeenCalledWith("https://example.com/docs");

--- a/src/lib/fileLinkNavigation.ts
+++ b/src/lib/fileLinkNavigation.ts
@@ -247,6 +247,10 @@ export async function navigateLinkTarget(
   rawTarget: string,
   options: { shiftKey: boolean },
 ): Promise<LinkNavigationResult> {
+  if (!options.shiftKey) {
+    return "ignored";
+  }
+
   const workspaceState = useWorkspaceStore.getState();
   const activeWorkspaceId = workspaceState.activeWorkspaceId;
   const activeWorkspace = activeWorkspaceId


### PR DESCRIPTION
## Summary
Enables Claude Opus 4.7 as the new top-tier Claude chat model with the full five-level effort scale (low/medium/high/xhigh/max). Renames the ambiguous `xhigh` UI label (previously shown as "Max"/"Máximo") to its literal form so the new `max` effort can be distinguished from `xhigh`. Also requires Shift+click to follow links or file references from chat/terminal output so accidental clicks no longer jump into the editor or open external browsers.

## Changes
- src-tauri/src/engines/claude_sidecar.rs — added `claude-opus-4-7` as the new top-tier Opus (default effort `xhigh`, full low→max scale). Kept `claude-opus-4-6` (re-described as previous-gen) and re-pointed Sonnet 4.6's upgrade target from 4.6 → 4.7.
- src/components/chat/ModelPicker.tsx — added `max` case to `effortDisplayLabel` and `shortEffortLabel` switches.
- src/i18n/resources/en/chat.json, src/i18n/resources/pt-BR/chat.json — relabeled `xhigh` ("Max"/"Máximo" → "XHigh"/"XAlto") and added `max` ("Max"/"Máximo") with matching short labels.
- src/lib/fileLinkNavigation.ts — `navigateLinkTarget` now returns "ignored" unless `options.shiftKey` is true; plain clicks on local file references and external URLs no longer navigate.
- src/lib/fileLinkNavigation.test.ts — updated two tests to assert shift-only opening for both local and external link targets.
- src-tauri/Cargo.lock — picked up the stale 0.54.0 → 0.54.1 package-version bump left behind by the previous release commit.

## Validation
- [x] pnpm typecheck
- [x] pnpm test
- [x] pnpm build
- [x] cd src-tauri && cargo check
No checks intentionally skipped. Did not run `pnpm tauri:dev` to live-smoke Opus 4.7 end-to-end — see "Notes for review" below for the SDK-version caveat that this check would catch.

## UI / UX impact
- [ ] No user-facing UI change
- [ ] Screenshots or screen recording attached

Two visible UX changes:
1. Model picker: Opus 4.7 appears at the top of the Claude engine list, Opus 4.6 is now labeled as previous-gen, Sonnet 4.6 "upgrade available" prompt now points to 4.7.
2. Effort picker: the chip formerly shown as "Max" (for Codex gpt-5.4 at top effort) now reads "XHigh" / "XAlt"; a new "Max" entry appears for Opus 4.7 only.
3. Link activation: clicking a `file://` path, absolute local path, or `https://` link in chat or terminal output no longer opens anything on plain click. Shift+click is required to open. This intentionally gates external web links too, mirroring the local-file gate — flag if external should remain plain-click.

## Localization
- [ ] No new user-facing copy
- [x] Updated both src/i18n/resources/en/ and src/i18n/resources/pt-BR/

Updated `modelPicker.effort.*` keys in both locales: renamed `xhigh`/`xhighShort`, added `max`/`maxShort`. No other user-facing strings were added.

## Notes for review
- Bundled Claude Agent SDK caveat: `src-tauri/sidecar-dist/node_modules/@anthropic-ai/claude-agent-sdk` is v0.2.69 (Claude Code CLI 2.1.69) and its internal model catalog tops out at `claude-opus-4-6`. The SDK's TypeScript signature treats `model` as an opaque string, so Opus 4.7 should pass through to Anthropic's API unchanged, but please live-smoke a Claude chat turn on Opus 4.7 before cutting a release. If it errors with an unknown-model response, bump `@anthropic-ai/claude-agent-sdk` in root `package.json` and rebuild the sidecar (`pnpm build:claude-sidecar`).
- Default effort for Opus 4.7 is set to `xhigh` per Anthropic's Claude Code recommendation (strong agentic autonomy without the runaway tokens of `max`). Happy to drop it to `high` if you'd rather stay conservative.
- The `xhigh` relabel is a visible copy change for existing Codex users — the gpt-5.4 top-effort chip that used to read "Max" is now "XHigh". This felt correct for consistency with Anthropic's published effort names, but worth a quick acknowledgement that it's an intentional shift.
- Shift-to-open gate blocks external URLs on plain click as well as local files. If you want external web links to keep opening on plain click, move the `shiftKey` check inside the local branch of `navigateLinkTarget` instead of at the top.
- No other codex/claude chat fixes were found worth bundling: no open PRs, no feature branches ahead of master, no TODO/FIXME in the engine code paths, existing stashes are unrelated WIP.
