### PR TITLE
Improve file links, panes, and terminal backpressure

### DIFF
--- a/agents_docs/dev notes/file-link-pane-split-and-tab-polish-notes.txt
+++ b/agents_docs/dev notes/file-link-pane-split-and-tab-polish-notes.txt
@@ -1,0 +1,30 @@
+## Summary
+This branch improves Panes' file-link and editor workflow end to end. It adds stronger local file-link parsing and markdown linkification, introduces the workspace pane split model, preserves chat/terminal context when opening files, and adds terminal output backpressure to avoid the memory growth seen when terminal output streams through Tauri/WebKit.
+
+The final UX behavior is that Shift-opening a file link from chat or terminal opens the file editor beside the source pane when needed, instead of replacing the current chat or terminal view. The branch also aligns active tab indicators and removes always-reserved pane close-button space.
+## Changes
+- Added shared local file-link parsing for absolute paths, `file://` URLs, repo-relative paths, line/column suffixes, and markdown-rendered local links.
+- Added editor reveal support so file links open or reuse tabs at the requested line/column.
+- Added workspace pane layout state, split surfaces, surface switching, drag/key split behavior, persistence, and legacy layout-mode syncing.
+- Wired file-opening entry points from chat, terminal, git files/changes, command palette, explorer, and harness flows into workspace pane navigation.
+- Added pull-based terminal output draining/backpressure, capped replay, drain retries, and related IPC/types so terminal output is not emitted as large JS payloads for every chunk.
+- Updated chat rendering so inline file paths, action output, action errors, diff filenames, and code block filenames can be Shift-opened like terminal links while fenced code blocks remain plain code.
+- Preserved the source chat/terminal pane on Shift-open by opening the editor in a sibling split when no visible editor exists.
+- Polished tab/pane UI by moving editor active indicators to the bottom edge and showing pane close-button spacing only while hovering the focused pane.
+- Updated English and Portuguese workspace pane localization.
+- Added regression coverage for file-link parsing, markdown linkification, editor reveal behavior, workspace pane state, source-pane file-link navigation, and command palette interactions.
+## Validation
+- [x] pnpm typecheck
+- [x] pnpm test
+- [x] pnpm build
+- [x] cd src-tauri && cargo check
+`git diff --check` also passed.
+## UI / UX impact
+- [ ] No user-facing UI change
+- [ ] Screenshots or screen recording attached
+This branch changes visible pane layout behavior, file-link opening behavior, tab indicators, and pane close-button hover behavior. No screenshots were captured.
+## Localization
+- [ ] No new user-facing copy
+- [x] Updated both src/i18n/resources/en/ and src/i18n/resources/pt-BR/
+## Notes for review
+Review the full branch scope, not just the final frontend polish commit. The highest-risk areas are terminal output backpressure/replay behavior and workspace pane split/navigation state, especially Shift-opening file links from a terminal-only Panes session running Codex CLI.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Panes"
-version = "0.54.1"
+version = "0.55.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -196,6 +196,26 @@ pub async fn terminal_resume_session(
 }
 
 #[tauri::command]
+pub async fn terminal_drain_output(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    session_id: String,
+    from_seq: Option<u64>,
+    target_bytes: u64,
+) -> Result<TerminalResumeSessionDto, String> {
+    state
+        .terminals
+        .drain_output(
+            &workspace_id,
+            &session_id,
+            from_seq,
+            target_bytes.clamp(1, 1024 * 1024) as usize,
+        )
+        .await
+        .map_err(err_to_string)
+}
+
+#[tauri::command]
 pub async fn terminal_list_notifications(
     state: State<'_, AppState>,
     workspace_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -300,6 +300,7 @@ pub fn run() {
             commands::terminal::terminal_list_sessions,
             commands::terminal::terminal_get_renderer_diagnostics,
             commands::terminal::terminal_resume_session,
+            commands::terminal::terminal_drain_output,
             commands::terminal::terminal_list_notifications,
             commands::terminal::terminal_clear_notification,
             commands::terminal::terminal_set_notification_focus,

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -37,10 +37,12 @@ const TERMINAL_OUTPUT_MAX_EMIT_BYTES: usize = 256 * 1024;
 const TERMINAL_OUTPUT_BUFFER_MAX_BYTES: usize = 4 * 1024 * 1024;
 const TERMINAL_REPLAY_MAX_CHUNKS: usize = 4096;
 const TERMINAL_REPLAY_MAX_BYTES: usize = 8 * 1024 * 1024;
+const TERMINAL_COMPLETED_REPLAY_GRACE_MS: u64 = 60_000;
 
 #[derive(Default)]
 pub struct TerminalManager {
     workspaces: RwLock<HashMap<String, HashMap<String, Arc<TerminalSessionHandle>>>>,
+    completed_replays: RwLock<HashMap<String, HashMap<String, TerminalReplaySnapshot>>>,
 }
 
 struct TerminalSessionHandle {
@@ -57,6 +59,22 @@ struct TerminalSessionHandle {
 struct TerminalReplayState {
     entries: VecDeque<TerminalReplayChunkDto>,
     total_bytes: usize,
+}
+
+#[derive(Clone, Default)]
+struct TerminalReplaySnapshot {
+    latest_seq: u64,
+    entries: Vec<TerminalReplayChunkDto>,
+}
+
+impl TerminalReplaySnapshot {
+    fn replay_since_limited(
+        &self,
+        from_seq: Option<u64>,
+        max_bytes: usize,
+    ) -> TerminalResumeSessionDto {
+        replay_response_from_entries(self.latest_seq, self.entries.iter(), from_seq, max_bytes)
+    }
 }
 
 struct TerminalSessionDiagnosticsState {
@@ -225,13 +243,51 @@ fn trim_string_to_tail(value: &mut String, max_bytes: usize) -> usize {
     before.saturating_sub(value.len())
 }
 
+fn replay_response_from_entries<'a>(
+    latest_seq: u64,
+    entries: impl Iterator<Item = &'a TerminalReplayChunkDto>,
+    from_seq: Option<u64>,
+    max_bytes: usize,
+) -> TerminalResumeSessionDto {
+    let entries = entries.collect::<Vec<_>>();
+    let oldest_available_seq = entries.first().map(|chunk| chunk.seq);
+    let gap = match (from_seq, oldest_available_seq) {
+        (Some(from), Some(oldest)) => from.saturating_add(1) < oldest,
+        _ => false,
+    };
+
+    let mut chunks = Vec::new();
+    let mut total_bytes = 0usize;
+    for chunk in entries
+        .into_iter()
+        .filter(|chunk| from_seq.map(|value| chunk.seq > value).unwrap_or(true))
+    {
+        let chunk_bytes = chunk.data.len();
+        if !chunks.is_empty() && total_bytes.saturating_add(chunk_bytes) > max_bytes {
+            break;
+        }
+        total_bytes = total_bytes.saturating_add(chunk_bytes);
+        chunks.push(chunk.clone());
+        if total_bytes >= max_bytes {
+            break;
+        }
+    }
+
+    TerminalResumeSessionDto {
+        latest_seq,
+        oldest_available_seq,
+        gap,
+        chunks,
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct TerminalOutputEvent {
+struct TerminalOutputReadyEvent {
     session_id: String,
-    seq: u64,
+    latest_seq: u64,
     ts: String,
-    data: String,
+    bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -290,11 +346,36 @@ impl TerminalManager {
         session_id: &str,
         from_seq: Option<u64>,
     ) -> anyhow::Result<TerminalResumeSessionDto> {
-        let session = self
-            .get_session(workspace_id, session_id)
+        if let Some(session) = self.get_session(workspace_id, session_id).await {
+            return Ok(session.replay_since(from_seq));
+        }
+        if let Some(replay) = self
+            .completed_replay_since(workspace_id, session_id, from_seq, usize::MAX)
             .await
-            .ok_or_else(|| anyhow::anyhow!("terminal session not found: {session_id}"))?;
-        Ok(session.replay_since(from_seq))
+        {
+            return Ok(replay);
+        }
+        Err(anyhow::anyhow!("terminal session not found: {session_id}"))
+    }
+
+    pub async fn drain_output(
+        &self,
+        workspace_id: &str,
+        session_id: &str,
+        from_seq: Option<u64>,
+        target_bytes: usize,
+    ) -> anyhow::Result<TerminalResumeSessionDto> {
+        let target_bytes = target_bytes.max(TERMINAL_OUTPUT_MAX_EMIT_BYTES);
+        if let Some(session) = self.get_session(workspace_id, session_id).await {
+            return Ok(session.replay_since_limited(from_seq, target_bytes));
+        }
+        if let Some(replay) = self
+            .completed_replay_since(workspace_id, session_id, from_seq, target_bytes)
+            .await
+        {
+            return Ok(replay);
+        }
+        Err(anyhow::anyhow!("terminal session not found: {session_id}"))
     }
 
     pub async fn create_session(
@@ -468,6 +549,46 @@ impl TerminalManager {
             .get(workspace_id)
             .and_then(|sessions| sessions.get(session_id))
             .cloned()
+    }
+
+    async fn completed_replay_since(
+        &self,
+        workspace_id: &str,
+        session_id: &str,
+        from_seq: Option<u64>,
+        max_bytes: usize,
+    ) -> Option<TerminalResumeSessionDto> {
+        self.completed_replays
+            .read()
+            .await
+            .get(workspace_id)
+            .and_then(|sessions| sessions.get(session_id))
+            .map(|snapshot| snapshot.replay_since_limited(from_seq, max_bytes))
+    }
+
+    async fn store_completed_replay(
+        &self,
+        workspace_id: &str,
+        session_id: &str,
+        snapshot: TerminalReplaySnapshot,
+    ) {
+        self.completed_replays
+            .write()
+            .await
+            .entry(workspace_id.to_string())
+            .or_default()
+            .insert(session_id.to_string(), snapshot);
+    }
+
+    async fn remove_completed_replay(&self, workspace_id: &str, session_id: &str) {
+        let mut replays = self.completed_replays.write().await;
+        let Some(workspace_replays) = replays.get_mut(workspace_id) else {
+            return;
+        };
+        workspace_replays.remove(session_id);
+        if workspace_replays.is_empty() {
+            replays.remove(workspace_id);
+        }
     }
 
     async fn take_session(
@@ -795,6 +916,8 @@ impl TerminalManager {
             return;
         };
         let event_session_id = session.meta.id.clone();
+        self.store_completed_replay(&workspace_id, &event_session_id, session.replay_snapshot())
+            .await;
         let exit = match tokio::task::spawn_blocking(move || session.wait_for_exit()).await {
             Ok(payload) => payload,
             Err(error) => {
@@ -809,6 +932,9 @@ impl TerminalManager {
         let notifications = app.state::<AppState>().notifications.clone();
         notifications
             .clear_for_session(&app, &workspace_id, &event_session_id)
+            .await;
+        tokio::time::sleep(Duration::from_millis(TERMINAL_COMPLETED_REPLAY_GRACE_MS)).await;
+        self.remove_completed_replay(&workspace_id, &event_session_id)
             .await;
     }
 }
@@ -974,6 +1100,14 @@ impl TerminalSessionHandle {
     }
 
     fn replay_since(&self, from_seq: Option<u64>) -> TerminalResumeSessionDto {
+        self.replay_since_limited(from_seq, usize::MAX)
+    }
+
+    fn replay_since_limited(
+        &self,
+        from_seq: Option<u64>,
+        max_bytes: usize,
+    ) -> TerminalResumeSessionDto {
         let latest_seq = self.replay_seq.load(Ordering::Relaxed);
         match self
             .replay_state
@@ -981,24 +1115,7 @@ impl TerminalSessionHandle {
             .map_err(|_| anyhow::anyhow!("terminal replay lock poisoned"))
         {
             Ok(state) => {
-                let oldest_available_seq = state.entries.front().map(|chunk| chunk.seq);
-                let gap = match (from_seq, oldest_available_seq) {
-                    (Some(from), Some(oldest)) => from.saturating_add(1) < oldest,
-                    _ => false,
-                };
-                let chunks = state
-                    .entries
-                    .iter()
-                    .filter(|chunk| from_seq.map(|value| chunk.seq > value).unwrap_or(true))
-                    .cloned()
-                    .collect();
-
-                TerminalResumeSessionDto {
-                    latest_seq,
-                    oldest_available_seq,
-                    gap,
-                    chunks,
-                }
+                replay_response_from_entries(latest_seq, state.entries.iter(), from_seq, max_bytes)
             }
             Err(error) => {
                 log::warn!("failed reading terminal replay chunk: {error}");
@@ -1007,6 +1124,27 @@ impl TerminalSessionHandle {
                     oldest_available_seq: None,
                     gap: false,
                     chunks: Vec::new(),
+                }
+            }
+        }
+    }
+
+    fn replay_snapshot(&self) -> TerminalReplaySnapshot {
+        let latest_seq = self.replay_seq.load(Ordering::Relaxed);
+        match self
+            .replay_state
+            .lock()
+            .map_err(|_| anyhow::anyhow!("terminal replay lock poisoned"))
+        {
+            Ok(state) => TerminalReplaySnapshot {
+                latest_seq,
+                entries: state.entries.iter().cloned().collect(),
+            },
+            Err(error) => {
+                log::warn!("failed snapshotting terminal replay chunk: {error}");
+                TerminalReplaySnapshot {
+                    latest_seq,
+                    entries: Vec::new(),
                 }
             }
         }
@@ -1660,11 +1798,12 @@ fn emit_output(
     chunk: TerminalReplayChunkDto,
 ) {
     let event_name = format!("terminal-output-{workspace_id}");
-    let payload = TerminalOutputEvent {
+    let bytes = chunk.data.len() as u64;
+    let payload = TerminalOutputReadyEvent {
         session_id: session_id.to_string(),
-        seq: chunk.seq,
+        latest_seq: chunk.seq,
         ts: chunk.ts,
-        data: chunk.data,
+        bytes,
     };
     let _ = app.emit(&event_name, payload);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,11 @@ import { useCustomWindowFrameState } from "./lib/customWindowFrame";
 import { runEditMenuAction } from "./lib/nativeEditActions";
 import { createAndActivateWorkspaceThread } from "./lib/newThreadActions";
 import {
+  cycleWorkspaceTerminalLayout,
+  isWorkspaceSurfaceVisible,
+  toggleWorkspaceEditorLayout,
+} from "./lib/workspacePaneNavigation";
+import {
   usesCustomWindowFrame,
   isTerminalInputFocused,
   requestWindowClose,
@@ -336,13 +341,7 @@ export function App() {
           {
             const wsId = useWorkspaceStore.getState().activeWorkspaceId;
             if (!wsId) return;
-            const ws = useTerminalStore.getState().workspaces[wsId];
-            const current = ws?.layoutMode ?? "chat";
-            if (current === "editor") {
-              void useTerminalStore.getState().setLayoutMode(wsId, ws?.preEditorLayoutMode ?? "chat");
-            } else {
-              void useTerminalStore.getState().setLayoutMode(wsId, "editor");
-            }
+            toggleWorkspaceEditorLayout(wsId);
           }
           break;
         case "b":
@@ -357,8 +356,7 @@ export function App() {
           if (!e.shiftKey) {
             // Cmd+F — editor find (only in editor mode)
             const wsIdF = useWorkspaceStore.getState().activeWorkspaceId;
-            const wsFState = wsIdF ? useTerminalStore.getState().workspaces[wsIdF] : undefined;
-            if (wsFState?.layoutMode === "editor") {
+            if (wsIdF && isWorkspaceSurfaceVisible(wsIdF, "editor")) {
               e.preventDefault();
               const fileState = useFileStore.getState();
               const activeTabId = fileState.activeTabId;
@@ -385,8 +383,7 @@ export function App() {
           if (e.shiftKey) return;
           // Cmd+H — editor find & replace (only in editor mode)
           const wsIdH = useWorkspaceStore.getState().activeWorkspaceId;
-          const wsHState = wsIdH ? useTerminalStore.getState().workspaces[wsIdH] : undefined;
-          if (wsHState?.layoutMode !== "editor") return;
+          if (!wsIdH || !isWorkspaceSurfaceVisible(wsIdH, "editor")) return;
           e.preventDefault();
           const fileState = useFileStore.getState();
           const activeTabIdH = fileState.activeTabId;
@@ -412,7 +409,7 @@ export function App() {
           if (e.shiftKey) {
             fireShortcut("toggle-terminal", () => {
               const wsId = useWorkspaceStore.getState().activeWorkspaceId;
-              if (wsId) void useTerminalStore.getState().cycleLayoutMode(wsId);
+              if (wsId) cycleWorkspaceTerminalLayout(wsId);
             });
           } else {
             fireShortcut("new-terminal-tab", () => {
@@ -515,7 +512,7 @@ export function App() {
         case "toggle-terminal":
           fireShortcut("toggle-terminal", () => {
             const wsId = useWorkspaceStore.getState().activeWorkspaceId;
-            if (wsId) void useTerminalStore.getState().cycleLayoutMode(wsId);
+            if (wsId) cycleWorkspaceTerminalLayout(wsId);
           });
           break;
         case "close-window": {

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1313,7 +1313,11 @@ function usagePercentToWidth(percent: number | null): string {
   return `${Math.max(0, Math.min(100, Math.round(percent)))}%`;
 }
 
-export function ChatPanel() {
+interface ChatPanelProps {
+  embedded?: boolean;
+}
+
+export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
   const { t } = useTranslation("chat");
   const renderStartedAtRef = useRef(performance.now());
   renderStartedAtRef.current = performance.now();
@@ -1397,7 +1401,7 @@ export function ChatPanel() {
 
   const isMac = isMacDesktop();
   const customWindowFrame = usesCustomWindowFrame();
-  const useTitlebarSafeInset = isMac && focusMode && !showSidebar;
+  const useTitlebarSafeInset = !embedded && isMac && focusMode && !showSidebar;
   const engines = useEngineStore((s) => s.engines);
   const health = useEngineStore((s) => s.health);
   const ensureEngineHealth = useEngineStore((s) => s.ensureHealth);
@@ -3980,19 +3984,21 @@ export function ChatPanel() {
     return identityByMessageId;
   }, [renderAssistantIdentity, visibleMessages]);
 
-  const workspaceName = activeWorkspace?.name || activeWorkspace?.rootPath.split("/").pop() || "";
+  const workspaceName = activeWorkspace?.name || activeWorkspace?.rootPath?.split("/").pop() || "";
 
   // Compute total diff stats for header display
   const gitFiles = gitStatus?.files ?? [];
   const totalAdded = gitFiles.length;
-  const layoutMode: LayoutMode = activeWorkspaceId
-    ? (terminalWorkspaceState?.layoutMode ?? "chat")
-    : "chat";
+  const layoutMode: LayoutMode = embedded
+    ? "chat"
+    : activeWorkspaceId
+      ? (terminalWorkspaceState?.layoutMode ?? "chat")
+      : "chat";
   const isChatLayoutActive = layoutMode === "chat";
   const isSplitLayoutActive = layoutMode === "split";
   const isTerminalLayoutActive = layoutMode === "terminal";
   const isEditorLayoutActive = layoutMode === "editor";
-  const showFocusModeHeader = focusMode && !showSidebar && (layoutMode === "chat" || layoutMode === "split");
+  const showFocusModeHeader = !embedded && focusMode && !showSidebar && (layoutMode === "chat" || layoutMode === "split");
   const terminalPanelSize = activeWorkspaceId
     ? terminalWorkspaceState?.panelSize ?? 32
     : 32;
@@ -4003,11 +4009,12 @@ export function ChatPanel() {
   // sees the updated value in the same render pass that triggers it.
   if (
     activeWorkspaceId
+    && !embedded
     && (layoutMode === "split" || layoutMode === "terminal" || terminalWorkspaceState?.isOpen)
   ) {
     hasTerminalMountedRef.current = true;
   }
-  if (layoutMode === "editor" && activeWorkspaceId) {
+  if (!embedded && layoutMode === "editor" && activeWorkspaceId) {
     hasEditorMountedRef.current = true;
   }
 
@@ -4053,7 +4060,7 @@ export function ChatPanel() {
         background: "var(--content-bg)",
       }}
     >
-      {(!focusMode || showSidebar) && (
+      {!embedded && (!focusMode || showSidebar) && (
         <div
           onMouseDown={handleDragMouseDown}
           onDoubleClick={handleDragDoubleClick}
@@ -4172,6 +4179,7 @@ export function ChatPanel() {
           </div>
 
           {/* Right-side action buttons */}
+          {!embedded && (
           <div className="no-drag" style={{ display: "flex", alignItems: "center", gap: 4 }}>
             <div className="layout-mode-switcher">
               <button
@@ -4212,6 +4220,7 @@ export function ChatPanel() {
               </button>
             </div>
           </div>
+          )}
         </div>
       )}
 
@@ -4326,6 +4335,7 @@ export function ChatPanel() {
             )}
           </div>
 
+          {!embedded && (
           <div className="no-drag" style={{ display: "flex", alignItems: "center", gap: 4 }}>
             <div className="layout-mode-switcher">
               <button
@@ -4366,6 +4376,7 @@ export function ChatPanel() {
               </button>
             </div>
           </div>
+          )}
         </div>
       )}
 

--- a/src/components/chat/MarkdownContent.tsx
+++ b/src/components/chat/MarkdownContent.tsx
@@ -7,7 +7,11 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import { recordPerfMetric } from "../../lib/perfTelemetry";
-import { classifyLinkTarget, navigateLinkTarget } from "../../lib/fileLinkNavigation";
+import {
+  classifyLinkTarget,
+  getWorkspacePaneLeafIdFromEventTarget,
+  navigateLinkTarget,
+} from "../../lib/fileLinkNavigation";
 import { renderMarkdownToHtml } from "../../workers/markdownParserCore";
 import type {
   MarkdownParseWorkerRequest,
@@ -208,7 +212,10 @@ function handleMarkdownLinkClick(event: ReactMouseEvent<HTMLDivElement>): void {
   if (targetKind === "local") {
     event.stopPropagation();
   }
-  void navigateLinkTarget(rawHref, { shiftKey: event.shiftKey });
+  void navigateLinkTarget(rawHref, {
+    shiftKey: event.shiftKey,
+    sourceLeafId: getWorkspacePaneLeafIdFromEventTarget(event.currentTarget),
+  });
 }
 
 export default function MarkdownContent({

--- a/src/components/chat/MessageBlocks.tsx
+++ b/src/components/chat/MessageBlocks.tsx
@@ -1,4 +1,13 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
 import { useTranslation } from "react-i18next";
 import {
   CheckCircle2,
@@ -66,6 +75,11 @@ import {
   useParsedDiff,
 } from "../shared/DiffViewer";
 import MarkdownContent from "./MarkdownContent";
+import {
+  extractTextLinkMatches,
+  getWorkspacePaneLeafIdFromEventTarget,
+  navigateLinkTarget,
+} from "../../lib/fileLinkNavigation";
 interface Props {
   blocks?: ContentBlock[];
   status?: MessageStatus;
@@ -109,6 +123,59 @@ function handleToggleKeyDown(e: React.KeyboardEvent, toggle: () => void) {
     e.preventDefault();
     toggle();
   }
+}
+
+function handlePlainTextLinkClick(
+  event: ReactMouseEvent<HTMLAnchorElement>,
+  target: string,
+) {
+  if (event.defaultPrevented || event.button !== 0) {
+    return;
+  }
+
+  event.preventDefault();
+  if (!event.shiftKey) {
+    return;
+  }
+
+  event.stopPropagation();
+  void navigateLinkTarget(target, {
+    shiftKey: true,
+    sourceLeafId: getWorkspacePaneLeafIdFromEventTarget(event.currentTarget),
+  });
+}
+
+function LinkifiedPlainText({ text }: { text: string }) {
+  const matches = useMemo(() => extractTextLinkMatches(text), [text]);
+  if (matches.length === 0) {
+    return <>{text}</>;
+  }
+
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+  for (const match of matches) {
+    if (match.startIndex > cursor) {
+      nodes.push(text.slice(cursor, match.startIndex));
+    }
+    nodes.push(
+      <a
+        key={`${match.startIndex}:${match.endIndex}:${match.text}`}
+        href={match.text}
+        className="chat-plain-link"
+        rel="noreferrer noopener"
+        onClick={(event) => handlePlainTextLinkClick(event, match.text)}
+      >
+        {match.text}
+      </a>,
+    );
+    cursor = match.endIndex;
+  }
+
+  if (cursor < text.length) {
+    nodes.push(text.slice(cursor));
+  }
+
+  return <>{nodes}</>;
 }
 
 const actionIcons: Record<string, typeof Terminal> = {
@@ -247,7 +314,7 @@ function MessageDiffBlock({ block }: { block: DiffBlock }) {
         />
         <FileDiff size={12} style={{ color: "var(--text-3)", flexShrink: 0 }} />
         <span style={{ fontSize: 11.5, color: "var(--text-2)", flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-          {filename ?? t("messageBlocks.diffFallback", { scope: String(block.scope ?? "turn") })}
+          <LinkifiedPlainText text={filename ?? t("messageBlocks.diffFallback", { scope: String(block.scope ?? "turn") })} />
         </span>
         {loadingParse && (
           <span style={{ fontSize: 10, color: "var(--text-3)", flexShrink: 0 }}>
@@ -653,7 +720,7 @@ function ActionBlockView({
 
           {outputChunks.length > 0 && (
             <pre className="action-output-pre" style={{ maxHeight: 260 }}>
-              {outputText}
+              <LinkifiedPlainText text={outputText} />
             </pre>
           )}
 
@@ -676,7 +743,7 @@ function ActionBlockView({
                   ? "1px solid rgba(248, 113, 113, 0.2)" : undefined,
               }}
             >
-              {String(block.result.error)}
+              <LinkifiedPlainText text={String(block.result.error)} />
             </pre>
           )}
         </div>
@@ -1338,7 +1405,9 @@ function renderSingleBlock(
           }}
         >
           <FileCode2 size={12} style={{ opacity: 0.5 }} />
-          <span style={{ flex: 1 }}>{block.filename || lang}</span>
+          <span style={{ flex: 1 }}>
+            <LinkifiedPlainText text={block.filename || lang} />
+          </span>
           <CodeBlockCopyButton content={String(block.content ?? "")} />
         </div>
         <pre

--- a/src/components/editor/EditorWithExplorer.tsx
+++ b/src/components/editor/EditorWithExplorer.tsx
@@ -29,7 +29,11 @@ function loadExplorerWidth(): number {
   return DEFAULT_EXPLORER_WIDTH;
 }
 
-export function EditorWithExplorer() {
+interface EditorWithExplorerProps {
+  embedded?: boolean;
+}
+
+export function EditorWithExplorer({ embedded = false }: EditorWithExplorerProps = {}) {
   const showExplorerSetting = useUiStore((s) => s.showExplorer);
   const setExplorerOpen = useUiStore((s) => s.setExplorerOpen);
   const explorerVisible = showExplorerSetting;
@@ -111,7 +115,7 @@ export function EditorWithExplorer() {
         }
       >
         <div style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>
-          <LazyFileEditorPanel />
+          <LazyFileEditorPanel embedded={embedded} />
         </div>
       </Suspense>
     </div>

--- a/src/components/editor/FileEditorPanel.tsx
+++ b/src/components/editor/FileEditorPanel.tsx
@@ -6,6 +6,7 @@ import {
   resolveRelativePathWithinRoot,
 } from "../../lib/fileRootUtils";
 import { ipc } from "../../lib/ipc";
+import { isMarkdownPreviewFile } from "../../lib/editorFileTypes";
 import { useFileStore } from "../../stores/fileStore";
 import { useTerminalStore } from "../../stores/terminalStore";
 import { toast } from "../../stores/toastStore";
@@ -16,13 +17,6 @@ import { ConfirmDialog } from "../shared/ConfirmDialog";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { GitDiffEditorPanel } from "./GitDiffEditorPanel";
 import { MarkdownPreviewPanel } from "./MarkdownPreviewPanel";
-
-const MARKDOWN_PREVIEW_EXTENSIONS = new Set(["md", "mdx", "markdown"]);
-
-function isMarkdownPreviewFile(filePath: string): boolean {
-  const extension = filePath.split(".").pop()?.toLowerCase();
-  return extension ? MARKDOWN_PREVIEW_EXTENSIONS.has(extension) : false;
-}
 
 export function FileEditorPanel() {
   const { t } = useTranslation("app");

--- a/src/components/editor/FileEditorPanel.tsx
+++ b/src/components/editor/FileEditorPanel.tsx
@@ -18,7 +18,11 @@ import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { GitDiffEditorPanel } from "./GitDiffEditorPanel";
 import { MarkdownPreviewPanel } from "./MarkdownPreviewPanel";
 
-export function FileEditorPanel() {
+interface FileEditorPanelProps {
+  embedded?: boolean;
+}
+
+export function FileEditorPanel({ embedded = false }: FileEditorPanelProps = {}) {
   const { t } = useTranslation("app");
   const tabs = useFileStore((s) => s.tabs);
   const activeTabId = useFileStore((s) => s.activeTabId);
@@ -42,7 +46,7 @@ export function FileEditorPanel() {
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const isMac = isMacDesktop();
-  const useTitlebarSafeInset = isMac && focusMode && !showSidebar;
+  const useTitlebarSafeInset = !embedded && isMac && focusMode && !showSidebar;
   const activeTabOwnership = activeTab
     ? (
         (activeTab.gitRepoPath && activeTab.gitFilePath)
@@ -140,15 +144,17 @@ export function FileEditorPanel() {
       const meta = e.metaKey || e.ctrlKey;
       if (!meta || e.key !== "s") return;
 
-      const wsId = useWorkspaceStore.getState().activeWorkspaceId;
-      const wsState = wsId ? useTerminalStore.getState().workspaces[wsId] : undefined;
-      if (wsState?.layoutMode !== "editor") return;
+      if (!embedded) {
+        const wsId = useWorkspaceStore.getState().activeWorkspaceId;
+        const wsState = wsId ? useTerminalStore.getState().workspaces[wsId] : undefined;
+        if (wsState?.layoutMode !== "editor") return;
+      }
 
       if (activeTabId) void saveTab(activeTabId);
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [activeTabId, saveTab]);
+  }, [activeTabId, embedded, saveTab]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>

--- a/src/components/editor/FileExplorer.tsx
+++ b/src/components/editor/FileExplorer.tsx
@@ -29,9 +29,9 @@ import {
   isWithinRoot,
   resolveAbsoluteFilePath,
 } from "../../lib/fileRootUtils";
+import { showWorkspaceSurface } from "../../lib/workspacePaneNavigation";
 import { isMacDesktop } from "../../lib/windowActions";
 import { useFileStore } from "../../stores/fileStore";
-import { useTerminalStore } from "../../stores/terminalStore";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useUiStore } from "../../stores/uiStore";
 import { toast } from "../../stores/toastStore";
@@ -185,7 +185,6 @@ export function FileExplorer() {
   // -- Store bindings --
   const openFile = useFileStore((s) => s.openFile);
   const retargetTabsAfterRename = useFileStore((s) => s.retargetTabsAfterRename);
-  const setLayoutMode = useTerminalStore((s) => s.setLayoutMode);
   const setExplorerOpen = useUiStore((s) => s.setExplorerOpen);
 
   // -- Scroll / virtualization --
@@ -497,10 +496,10 @@ export function FileExplorer() {
       if (!rootPath) return;
       void openFile(rootPath, filePath);
       if (activeWorkspaceId) {
-        void setLayoutMode(activeWorkspaceId, "editor");
+        showWorkspaceSurface(activeWorkspaceId, "editor");
       }
     },
-    [rootPath, openFile, activeWorkspaceId, setLayoutMode],
+    [rootPath, openFile, activeWorkspaceId],
   );
 
   // ---------------------------------------------------------------------------
@@ -921,7 +920,7 @@ export function FileExplorer() {
         await loadDir(creating.parentDir);
         toast.success(t("explorer.toasts.created", { name }));
         void openFile(rootPath, targetPath);
-        if (activeWorkspaceId) void setLayoutMode(activeWorkspaceId, "editor");
+        if (activeWorkspaceId) showWorkspaceSurface(activeWorkspaceId, "editor");
       } else {
         await ipc.createDir(rootPath, targetPath, activeWorkspaceId ?? null);
         await loadDir(creating.parentDir);
@@ -933,7 +932,7 @@ export function FileExplorer() {
       console.warn("[FileExplorer] create failed:", err);
       setCreating(null);
     }
-  }, [creating, createValue, rootPath, activeWorkspaceId, loadDir, openFile, setLayoutMode, t]);
+  }, [creating, createValue, rootPath, activeWorkspaceId, loadDir, openFile, t]);
 
   const cancelCreate = useCallback(() => {
     setCreating(null);

--- a/src/components/git/GitChangesView.tsx
+++ b/src/components/git/GitChangesView.tsx
@@ -18,7 +18,7 @@ import { toast } from "../../stores/toastStore";
 import { useGitStore } from "../../stores/gitStore";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useFileStore } from "../../stores/fileStore";
-import { useTerminalStore } from "../../stores/terminalStore";
+import { showWorkspaceSurface } from "../../lib/workspacePaneNavigation";
 import {
   buildDirectoryFileMap,
   buildTreeRows,
@@ -121,16 +121,15 @@ export function GitChangesView({ repo, showDiff, onError }: Props) {
   } = useGitStore();
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const openGitDiffFile = useFileStore((s) => s.openGitDiffFile);
-  const setLayoutMode = useTerminalStore((s) => s.setLayoutMode);
 
   const handleOpenInEditor = useCallback(
     (filePath: string, source: ChangeSection) => {
       void openGitDiffFile(repo.path, filePath, { source });
       if (activeWorkspaceId) {
-        void setLayoutMode(activeWorkspaceId, "editor");
+        showWorkspaceSurface(activeWorkspaceId, "editor");
       }
     },
-    [repo.path, openGitDiffFile, activeWorkspaceId, setLayoutMode],
+    [repo.path, openGitDiffFile, activeWorkspaceId],
   );
 
   const commitMessage = drafts.commitMessage;

--- a/src/components/git/GitFilesView.tsx
+++ b/src/components/git/GitFilesView.tsx
@@ -10,8 +10,8 @@ import {
   Loader2,
 } from "lucide-react";
 import { ipc } from "../../lib/ipc";
+import { showWorkspaceSurface } from "../../lib/workspacePaneNavigation";
 import { useFileStore } from "../../stores/fileStore";
-import { useTerminalStore } from "../../stores/terminalStore";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import type { FileTreeEntry } from "../../types";
 
@@ -85,7 +85,6 @@ export function GitFilesView({ rootPath }: Props) {
 
   const openFile = useFileStore((s) => s.openFile);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
-  const setLayoutMode = useTerminalStore((s) => s.setLayoutMode);
 
   // Track root path to reset on change
   const prevRootPath = useRef(rootPath);
@@ -157,10 +156,10 @@ export function GitFilesView({ rootPath }: Props) {
     (filePath: string) => {
       void openFile(rootPath, filePath);
       if (activeWorkspaceId) {
-        void setLayoutMode(activeWorkspaceId, "editor");
+        showWorkspaceSurface(activeWorkspaceId, "editor");
       }
     },
-    [rootPath, openFile, activeWorkspaceId, setLayoutMode],
+    [rootPath, openFile, activeWorkspaceId],
   );
 
   // Build flat row list from loaded data

--- a/src/components/git/MultiRepoChangesView.tsx
+++ b/src/components/git/MultiRepoChangesView.tsx
@@ -19,8 +19,8 @@ import { toast } from "../../stores/toastStore";
 import { useGitStore } from "../../stores/gitStore";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useFileStore } from "../../stores/fileStore";
-import { useTerminalStore } from "../../stores/terminalStore";
 import { ipc, listenGitRepoChanged } from "../../lib/ipc";
+import { showWorkspaceSurface } from "../../lib/workspacePaneNavigation";
 import {
   closeGitFlyoutIfFocusLeft,
   GitFlyoutContext,
@@ -327,7 +327,6 @@ function RepoAccordionSection({
   } = useGitStore();
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const openGitDiffFile = useFileStore((s) => s.openGitDiffFile);
-  const setLayoutMode = useTerminalStore((s) => s.setLayoutMode);
 
   const { status, loading } = entry;
 
@@ -624,10 +623,10 @@ function RepoAccordionSection({
     (filePath: string) => {
       void openGitDiffFile(repo.path, filePath, { source: "changes" });
       if (activeWorkspaceId) {
-        void setLayoutMode(activeWorkspaceId, "editor");
+        showWorkspaceSurface(activeWorkspaceId, "editor");
       }
     },
-    [repo.path, openGitDiffFile, activeWorkspaceId, setLayoutMode],
+    [repo.path, openGitDiffFile, activeWorkspaceId],
   );
 
   // ── Render helpers ──

--- a/src/components/layout/ThreeColumnLayout.tsx
+++ b/src/components/layout/ThreeColumnLayout.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { Sidebar } from "../sidebar/Sidebar";
-import { ChatPanel } from "../chat/ChatPanel";
+import { ActiveWorkspacePaneShell } from "../workspace/WorkspacePaneShell";
 import { HarnessPanel } from "../onboarding/HarnessPanel";
 import { WorkspaceSettingsPage } from "../workspace/WorkspaceSettingsPage";
 import { GitPanel } from "../git/GitPanel";
@@ -208,7 +208,7 @@ export function ThreeColumnLayout() {
     ) : activeView === "workspace-settings" ? (
       <WorkspaceSettingsPage />
     ) : (
-      <ChatPanel />
+      <ActiveWorkspacePaneShell />
     )
   );
 

--- a/src/components/onboarding/HarnessPanel.tsx
+++ b/src/components/onboarding/HarnessPanel.tsx
@@ -19,6 +19,7 @@ import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useUiStore } from "../../stores/uiStore";
 import { writeCommandToNewSession } from "../../lib/ipc";
 import { copyTextToClipboard } from "../../lib/clipboard";
+import { showWorkspaceSurface } from "../../lib/workspacePaneNavigation";
 import {
   getHarnessInstallCommand,
   getHarnessTileAction,
@@ -123,9 +124,7 @@ export function HarnessPanel() {
   const launch = useHarnessStore((s) => s.launch);
 
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
-  const setLayoutMode = useTerminalStore((s) => s.setLayoutMode);
   const createSession = useTerminalStore((s) => s.createSession);
-  const terminalWorkspaces = useTerminalStore((s) => s.workspaces);
   const setActiveView = useUiStore((s) => s.setActiveView);
 
   const installedCount = harnesses.filter((h) => h.found).length;
@@ -142,10 +141,7 @@ export function HarnessPanel() {
     async (command: string) => {
       if (!activeWorkspaceId) return;
 
-      const wsState = terminalWorkspaces[activeWorkspaceId];
-      if (!wsState || (wsState.layoutMode !== "terminal" && wsState.layoutMode !== "split")) {
-        await setLayoutMode(activeWorkspaceId, "terminal");
-      }
+      showWorkspaceSurface(activeWorkspaceId, "terminal");
 
       const sessionId = await createSession(activeWorkspaceId);
       if (sessionId) {
@@ -154,7 +150,7 @@ export function HarnessPanel() {
 
       setActiveView("chat");
     },
-    [activeWorkspaceId, terminalWorkspaces, setLayoutMode, createSession, setActiveView],
+    [activeWorkspaceId, createSession, setActiveView],
   );
 
   async function handleLaunch(harnessId: string) {

--- a/src/components/shared/CommandPalette.test.ts
+++ b/src/components/shared/CommandPalette.test.ts
@@ -16,6 +16,7 @@ const mockUiState = vi.hoisted(() => {
 });
 
 const mockSetLayoutMode = vi.hoisted(() => vi.fn());
+const mockShowSurface = vi.hoisted(() => vi.fn());
 const mockWorkspaceState = vi.hoisted(() => ({
   activeWorkspaceId: "ws-1" as string | null,
 }));
@@ -92,6 +93,19 @@ vi.mock("../../stores/terminalStore", () => ({
   useTerminalStore: {
     getState: () => ({
       setLayoutMode: mockSetLayoutMode,
+      workspaces: {},
+    }),
+  },
+}));
+
+vi.mock("../../stores/workspacePaneStore", () => ({
+  collectWorkspacePaneLeaves: vi.fn(() => []),
+  getWorkspacePaneActiveTab: vi.fn(() => null),
+  useWorkspacePaneStore: {
+    getState: () => ({
+      showSurface: mockShowSurface,
+      applyLegacyLayoutMode: vi.fn(),
+      workspaces: {},
     }),
   },
 }));
@@ -122,7 +136,8 @@ describe("CommandPalette view-files command", () => {
     expect(command?.label).toBe("commandPalette.commands.viewFiles");
     expect(mockUiState.setActiveView).toHaveBeenCalledWith("chat");
     expect(mockUiState.setExplorerOpen).toHaveBeenCalledWith(true);
-    expect(mockSetLayoutMode).toHaveBeenCalledWith("ws-1", "editor");
+    expect(mockShowSurface).toHaveBeenCalledWith("ws-1", "editor");
+    expect(mockSetLayoutMode).not.toHaveBeenCalled();
     expect(close).toHaveBeenCalled();
   });
 });

--- a/src/components/shared/CommandPalette.tsx
+++ b/src/components/shared/CommandPalette.tsx
@@ -56,6 +56,10 @@ import {
 } from "../../lib/commandPaletteGit";
 import { formatRelativeTime } from "../../lib/formatters";
 import { createAndActivateWorkspaceThread } from "../../lib/newThreadActions";
+import {
+  applyWorkspaceLayoutMode,
+  showWorkspaceSurface,
+} from "../../lib/workspacePaneNavigation";
 import { useUiStore } from "../../stores/uiStore";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useThreadStore } from "../../stores/threadStore";
@@ -202,7 +206,9 @@ export function getStaticCommands(
     group: "layout",
     keywords: ["chat", "mode", "view", "conversa", "layout"],
     action: ({ activeWorkspaceId, close }) => {
-      if (activeWorkspaceId) void useTerminalStore.getState().setLayoutMode(activeWorkspaceId, "chat");
+      if (activeWorkspaceId) {
+        applyWorkspaceLayoutMode(activeWorkspaceId, "chat");
+      }
       close();
     },
   },
@@ -213,7 +219,9 @@ export function getStaticCommands(
     group: "layout",
     keywords: ["split", "terminal", "half", "dividir", "metade"],
     action: ({ activeWorkspaceId, close }) => {
-      if (activeWorkspaceId) void useTerminalStore.getState().setLayoutMode(activeWorkspaceId, "split");
+      if (activeWorkspaceId) {
+        applyWorkspaceLayoutMode(activeWorkspaceId, "split");
+      }
       close();
     },
   },
@@ -224,7 +232,9 @@ export function getStaticCommands(
     group: "layout",
     keywords: ["terminal", "full", "shell", "inteiro"],
     action: ({ activeWorkspaceId, close }) => {
-      if (activeWorkspaceId) void useTerminalStore.getState().setLayoutMode(activeWorkspaceId, "terminal");
+      if (activeWorkspaceId) {
+        applyWorkspaceLayoutMode(activeWorkspaceId, "terminal");
+      }
       close();
     },
   },
@@ -236,7 +246,9 @@ export function getStaticCommands(
     keywords: ["editor", "code", "file", "arquivo"],
     shortcut: "\u2318E",
     action: ({ activeWorkspaceId, close }) => {
-      if (activeWorkspaceId) void useTerminalStore.getState().setLayoutMode(activeWorkspaceId, "editor");
+      if (activeWorkspaceId) {
+        applyWorkspaceLayoutMode(activeWorkspaceId, "editor");
+      }
       close();
     },
   },
@@ -642,7 +654,7 @@ export function getStaticCommands(
       uiState.setExplorerOpen(true);
       const wsId = useWorkspaceStore.getState().activeWorkspaceId;
       if (wsId) {
-        void useTerminalStore.getState().setLayoutMode(wsId, "editor");
+        showWorkspaceSurface(wsId, "editor");
       }
       close();
     },
@@ -1872,10 +1884,7 @@ export function CommandPalette({ open, onClose }: Props) {
       const command = await useHarnessStore.getState().launch(harness.id);
       if (!command) return;
 
-      const ws = useTerminalStore.getState().workspaces[activeWorkspaceId];
-      if (!ws || (ws.layoutMode !== "terminal" && ws.layoutMode !== "split")) {
-        await useTerminalStore.getState().setLayoutMode(activeWorkspaceId, "terminal");
-      }
+      showWorkspaceSurface(activeWorkspaceId, "terminal");
       const sessionId = await useTerminalStore.getState().createSession(activeWorkspaceId);
       if (sessionId) {
         void writeCommandToNewSession(activeWorkspaceId, sessionId, command);
@@ -1899,7 +1908,7 @@ export function CommandPalette({ open, onClose }: Props) {
         return;
       }
 
-      await useTerminalStore.getState().setLayoutMode(activeWorkspaceId, "chat");
+      showWorkspaceSurface(activeWorkspaceId, "chat");
       setMessageFocusTarget({
         threadId: targetThread.id,
         messageId: result.messageId,
@@ -1960,7 +1969,7 @@ export function CommandPalette({ open, onClose }: Props) {
           if (activeWorkspaceRootPath) {
             await useFileStore.getState().openFile(activeWorkspaceRootPath, item.entry.path);
             if (activeWorkspaceId) {
-              void useTerminalStore.getState().setLayoutMode(activeWorkspaceId, "editor");
+              showWorkspaceSurface(activeWorkspaceId, "editor");
             }
           }
           break;
@@ -1970,7 +1979,7 @@ export function CommandPalette({ open, onClose }: Props) {
           if (thread.workspaceId !== activeWorkspaceId) {
             await useWorkspaceStore.getState().setActiveWorkspace(thread.workspaceId);
           }
-          await useTerminalStore.getState().setLayoutMode(thread.workspaceId, "chat");
+          showWorkspaceSurface(thread.workspaceId, "chat");
           useThreadStore.getState().setActiveThread(thread.id);
           await useChatStore.getState().setActiveThread(thread.id);
           useUiStore.getState().setActiveView("chat");

--- a/src/components/shared/CustomWindowFrame.tsx
+++ b/src/components/shared/CustomWindowFrame.tsx
@@ -1,7 +1,7 @@
 import { Dropdown } from "./Dropdown";
+import { cycleWorkspaceTerminalLayout } from "../../lib/workspacePaneNavigation";
 import { runEditMenuAction } from "../../lib/nativeEditActions";
 import { useOnboardingStore } from "../../stores/onboardingStore";
-import { useTerminalStore } from "../../stores/terminalStore";
 import { useUiStore } from "../../stores/uiStore";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useTranslation } from "react-i18next";
@@ -104,7 +104,7 @@ export function CustomWindowFrame({ frameState }: CustomWindowFrameProps) {
       case "toggle-terminal": {
         const workspaceId = useWorkspaceStore.getState().activeWorkspaceId;
         if (workspaceId) {
-          void useTerminalStore.getState().cycleLayoutMode(workspaceId);
+          cycleWorkspaceTerminalLayout(workspaceId);
         }
         return;
       }

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -19,7 +19,11 @@ import {
   getTerminalAcceleratedRenderingPreferenceVersion,
   listenTerminalAcceleratedRenderingChanged,
 } from "../../lib/terminalRenderingSettings";
-import { extractTextLinkMatches, navigateLinkTarget } from "../../lib/fileLinkNavigation";
+import {
+  extractTextLinkMatches,
+  getWorkspacePaneLeafIdFromEventTarget,
+  navigateLinkTarget,
+} from "../../lib/fileLinkNavigation";
 import {
   collectDetachedTerminalEvictionKeys,
   markPaneTerminalDetached,
@@ -2092,7 +2096,10 @@ function createCachedTerminal(
     fontSize: 12,
     linkHandler: {
       activate(event, text) {
-        void navigateLinkTarget(text, { shiftKey: Boolean(event?.shiftKey) });
+        void navigateLinkTarget(text, {
+          shiftKey: Boolean(event?.shiftKey),
+          sourceLeafId: getWorkspacePaneLeafIdFromEventTarget(event?.target ?? null),
+        });
       },
     },
     lineHeight: 1.3,
@@ -2355,7 +2362,10 @@ function createTerminalTextLinkProvider(terminal: Terminal): ILinkProvider {
           underline: false,
         },
         activate(event, text) {
-          void navigateLinkTarget(text, { shiftKey: Boolean(event?.shiftKey) });
+          void navigateLinkTarget(text, {
+            shiftKey: Boolean(event?.shiftKey),
+            sourceLeafId: getWorkspacePaneLeafIdFromEventTarget(event?.target ?? null),
+          });
         },
         hover() {
           terminal.element?.classList.add("xterm-cursor-pointer");

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -116,6 +116,10 @@ interface FrontendTerminalRuntimeSnapshot {
   flushInFlightMs: number | null;
   outputQueueChunks: number;
   outputQueueChars: number;
+  outputDrainInFlight: boolean;
+  outputDrainTimerActive: boolean;
+  outputDrainRequestedSeq: number;
+  outputDrainRetryAttempts: number;
   flushTimerActive: boolean;
   fitTimerActive: boolean;
   lastResizeSent: TerminalSize | null;
@@ -172,6 +176,10 @@ interface SessionTerminal {
   outputQueue: string[];
   outputQueueChars: number;
   lastAppliedSeq: number;
+  outputDrainInFlight: boolean;
+  outputDrainTimer?: number;
+  outputDrainRequestedSeq: number;
+  outputDrainRetryAttempts: number;
   resumeInFlight: boolean;
   resumeRetryAttempts: number;
   resumeRetryTimer?: number;
@@ -234,6 +242,10 @@ const INPUT_DROP_WARN_COOLDOWN_MS = 5000;
 const OUTPUT_FLUSH_DELAY_MS = 4;
 const OUTPUT_FLUSH_STALL_TIMEOUT_MS = 2500;
 const OUTPUT_BATCH_CHAR_LIMIT = 65536;
+const OUTPUT_PULL_MAX_BYTES = 256 * 1024;
+const OUTPUT_DRAIN_RETRY_BASE_MS = 250;
+const OUTPUT_DRAIN_RETRY_MAX_MS = 2000;
+const OUTPUT_DRAIN_RETRY_MAX_ATTEMPTS = 5;
 const OUTPUT_QUEUE_MAX_CHARS_ATTACHED = 8 * 1024 * 1024;
 const OUTPUT_QUEUE_MAX_CHARS_DETACHED = 512 * 1024;
 const PENDING_OUTPUT_MAX_CHARS = 256 * 1024;
@@ -505,6 +517,10 @@ function snapshotFrontendRuntime(
       : null,
     outputQueueChunks: session.outputQueue.length,
     outputQueueChars: session.outputQueueChars,
+    outputDrainInFlight: session.outputDrainInFlight,
+    outputDrainTimerActive: session.outputDrainTimer !== undefined,
+    outputDrainRequestedSeq: session.outputDrainRequestedSeq,
+    outputDrainRetryAttempts: session.outputDrainRetryAttempts,
     flushTimerActive: session.flushTimer !== undefined,
     fitTimerActive: session.fitTimer !== undefined,
     lastResizeSent: session.lastResizeSent ? { ...session.lastResizeSent } : null,
@@ -860,6 +876,10 @@ function clearSessionTimers(session: SessionTerminal) {
   if (session.resumeRetryTimer !== undefined) {
     window.clearTimeout(session.resumeRetryTimer);
     session.resumeRetryTimer = undefined;
+  }
+  if (session.outputDrainTimer !== undefined) {
+    window.clearTimeout(session.outputDrainTimer);
+    session.outputDrainTimer = undefined;
   }
   if (session.flushWatchdogTimer !== undefined) {
     window.clearTimeout(session.flushWatchdogTimer);
@@ -1438,6 +1458,8 @@ function flushOutputQueue(cacheKey: string) {
     });
     if (latest.outputQueue.length > 0) {
       scheduleOutputFlush(cacheKey, latest, 0);
+    } else {
+      scheduleOutputDrainIfNeeded(cacheKey, latest, 0);
     }
   }, OUTPUT_FLUSH_STALL_TIMEOUT_MS);
   try {
@@ -1454,6 +1476,8 @@ function flushOutputQueue(cacheKey: string) {
       latest.flushStartedAt = undefined;
       if (latest.outputQueue.length > 0) {
         scheduleOutputFlush(cacheKey, latest, 0);
+      } else {
+        scheduleOutputDrainIfNeeded(cacheKey, latest, 0);
       }
     });
   } catch (error) {
@@ -1633,33 +1657,195 @@ async function resumeSessionOutput(
     if (latest.isAttached && latest.outputQueue.length > 0) {
       scheduleOutputFlush(cacheKey, latest, 0);
     }
+    scheduleOutputDrainIfNeeded(cacheKey, latest, 0);
   }
 }
 
-function queueOutput(workspaceId: string, sessionId: string, chunk: SequencedOutputChunk) {
+function scheduleOutputDrainIfNeeded(
+  cacheKey: string,
+  session: SessionTerminal,
+  delayMs: number = 0,
+) {
+  if (session.outputDrainRequestedSeq <= session.lastAppliedSeq) {
+    return;
+  }
+  const parsed = parseTerminalCacheKey(cacheKey);
+  if (!parsed) {
+    return;
+  }
+  scheduleTerminalOutputDrain(
+    parsed.workspaceId,
+    parsed.sessionId,
+    session.outputDrainRequestedSeq,
+    delayMs,
+  );
+}
+
+function scheduleTerminalOutputDrain(
+  workspaceId: string,
+  sessionId: string,
+  latestSeq: number,
+  delayMs: number = 0,
+) {
   const cacheKey = terminalCacheKey(workspaceId, sessionId);
   const session = cachedTerminals.get(cacheKey);
-  if (!session || session.resumeInFlight) {
-    addPendingOutputChunk(cacheKey, chunk);
+  if (!session) {
     return;
   }
 
+  session.outputDrainRequestedSeq = Math.max(
+    session.outputDrainRequestedSeq,
+    latestSeq,
+  );
   scheduleBackendRendererDiagnosticsRefresh(workspaceId, sessionId);
 
-  const result = enqueueOutputChunk(cacheKey, session, chunk);
-  if (result === "duplicate") {
+  if (!session.isAttached) {
+    session.needsResumeOnAttach = true;
     return;
   }
-  if (result === "gap") {
-    addPendingOutputChunk(cacheKey, chunk);
-    if (session.resumeRetryTimer === undefined) {
-      void resumeSessionOutput(workspaceId, sessionId, "live-gap");
-    }
+  if (session.resumeInFlight || session.outputDrainInFlight) {
+    return;
+  }
+  if (session.outputDrainTimer !== undefined) {
+    return;
+  }
+  if (
+    session.outputQueueChars >
+    OUTPUT_QUEUE_MAX_CHARS_ATTACHED - OUTPUT_PULL_MAX_BYTES
+  ) {
     return;
   }
 
-  if (session.isAttached) {
-    scheduleOutputFlush(cacheKey, session);
+  session.outputDrainTimer = window.setTimeout(() => {
+    const latest = cachedTerminals.get(cacheKey);
+    if (!latest) {
+      return;
+    }
+    latest.outputDrainTimer = undefined;
+    void drainTerminalOutput(workspaceId, sessionId);
+  }, delayMs);
+}
+
+async function drainTerminalOutput(workspaceId: string, sessionId: string) {
+  const cacheKey = terminalCacheKey(workspaceId, sessionId);
+  const session = cachedTerminals.get(cacheKey);
+  if (!session || session.outputDrainInFlight) {
+    return;
+  }
+  if (!session.isAttached) {
+    session.needsResumeOnAttach = true;
+    return;
+  }
+  if (session.resumeInFlight) {
+    return;
+  }
+  if (
+    session.outputQueueChars >
+    OUTPUT_QUEUE_MAX_CHARS_ATTACHED - OUTPUT_PULL_MAX_BYTES
+  ) {
+    return;
+  }
+
+  const sessionRef = session;
+  sessionRef.outputDrainInFlight = true;
+  let drainSucceeded = false;
+  let retryDelayMs: number | null = null;
+  try {
+    const fromSeq = sessionRef.lastAppliedSeq > 0 ? sessionRef.lastAppliedSeq : null;
+    const resume = await ipc.terminalDrainOutput(
+      workspaceId,
+      sessionId,
+      fromSeq,
+      OUTPUT_PULL_MAX_BYTES,
+    );
+    const latest = cachedTerminals.get(cacheKey);
+    if (!latest || latest !== sessionRef) {
+      return;
+    }
+    drainSucceeded = true;
+    latest.outputDrainRetryAttempts = 0;
+
+    latest.outputDrainRequestedSeq = Math.max(
+      latest.outputDrainRequestedSeq,
+      resume.latestSeq,
+    );
+
+    if (resume.gap && latest.lastAppliedSeq > 0) {
+      logTerminalWarning("terminal-output-drain-gap", {
+        cacheKey,
+        fromSeq: fromSeq ?? undefined,
+        oldestAvailableSeq: resume.oldestAvailableSeq ?? undefined,
+      });
+      void resumeSessionOutput(workspaceId, sessionId, "live-gap");
+      return;
+    }
+
+    for (const chunk of resume.chunks) {
+      const current = cachedTerminals.get(cacheKey);
+      if (!current || current !== sessionRef) {
+        return;
+      }
+      const result = enqueueOutputChunk(cacheKey, current, chunk);
+      if (result === "duplicate") {
+        continue;
+      }
+      if (result === "gap") {
+        addPendingOutputChunk(cacheKey, chunk);
+        logTerminalWarning("terminal-output-drain-gap-during-apply", {
+          cacheKey,
+          chunkSeq: chunk.seq,
+          lastAppliedSeq: current.lastAppliedSeq,
+        });
+        void resumeSessionOutput(workspaceId, sessionId, "live-gap");
+        break;
+      }
+    }
+
+    if (latest.isAttached && latest.outputQueue.length > 0) {
+      scheduleOutputFlush(cacheKey, latest, 0);
+    }
+  } catch (error) {
+    if (sessionRef.outputDrainRetryAttempts < OUTPUT_DRAIN_RETRY_MAX_ATTEMPTS) {
+      const exponent = Math.min(sessionRef.outputDrainRetryAttempts, 3);
+      retryDelayMs = Math.min(
+        OUTPUT_DRAIN_RETRY_BASE_MS * (2 ** exponent),
+        OUTPUT_DRAIN_RETRY_MAX_MS,
+      );
+      sessionRef.outputDrainRetryAttempts += 1;
+    } else {
+      sessionRef.outputDrainRequestedSeq = sessionRef.lastAppliedSeq;
+      sessionRef.needsResumeOnAttach = true;
+    }
+    logTerminalWarning("terminal-output-drain-failed", {
+      cacheKey,
+      details: errorToMessage(error),
+      retryDelayMs: retryDelayMs ?? undefined,
+      attempt: sessionRef.outputDrainRetryAttempts,
+    });
+  } finally {
+    const latest = cachedTerminals.get(cacheKey);
+    if (!latest || latest !== sessionRef) {
+      return;
+    }
+    latest.outputDrainInFlight = false;
+    if (latest.isAttached && latest.outputQueue.length > 0) {
+      scheduleOutputFlush(cacheKey, latest, 0);
+    }
+    if (
+      drainSucceeded &&
+      latest.outputDrainRequestedSeq > latest.lastAppliedSeq &&
+      latest.outputQueueChars <= OUTPUT_QUEUE_MAX_CHARS_ATTACHED - OUTPUT_PULL_MAX_BYTES
+    ) {
+      scheduleTerminalOutputDrain(workspaceId, sessionId, latest.outputDrainRequestedSeq, 0);
+    }
+    if (!drainSucceeded && retryDelayMs !== null) {
+      scheduleTerminalOutputDrain(
+        workspaceId,
+        sessionId,
+        latest.outputDrainRequestedSeq,
+        retryDelayMs,
+      );
+    }
   }
 }
 
@@ -1814,6 +2000,10 @@ function markWorkspaceTerminalsDetached(workspaceId: string) {
       window.clearTimeout(session.flushTimer);
       session.flushTimer = undefined;
     }
+    if (session.outputDrainTimer !== undefined) {
+      window.clearTimeout(session.outputDrainTimer);
+      session.outputDrainTimer = undefined;
+    }
     capSessionOutputQueue(cacheKey, session);
     const sessionId = cacheKey.slice(workspacePrefix.length);
     scheduleDetachedTerminalEviction(workspaceId, sessionId, session);
@@ -1830,6 +2020,10 @@ function markCachedTerminalDetached(cacheKey: string, session: SessionTerminal) 
   if (session.flushTimer !== undefined) {
     window.clearTimeout(session.flushTimer);
     session.flushTimer = undefined;
+  }
+  if (session.outputDrainTimer !== undefined) {
+    window.clearTimeout(session.outputDrainTimer);
+    session.outputDrainTimer = undefined;
   }
   capSessionOutputQueue(cacheKey, session);
   const parsed = parseTerminalCacheKey(cacheKey);
@@ -2076,6 +2270,10 @@ function createCachedTerminal(
     outputQueue: [],
     outputQueueChars: 0,
     lastAppliedSeq: 0,
+    outputDrainInFlight: false,
+    outputDrainTimer: undefined,
+    outputDrainRequestedSeq: 0,
+    outputDrainRetryAttempts: 0,
     resumeInFlight: false,
     resumeRetryAttempts: 0,
     rendererMode: "canvas",
@@ -3332,6 +3530,8 @@ export function TerminalPanel({ workspaceId, embedded = false }: TerminalPanelPr
         void resumeSessionOutput(workspaceId, sessionId, "attach");
       } else if (cached.outputQueue.length > 0) {
         scheduleOutputFlush(cacheKey, cached, 0);
+      } else {
+        scheduleOutputDrainIfNeeded(cacheKey, cached, 0);
       }
       if (SHOW_TERMINAL_DIAGNOSTICS_UI) {
         void refreshBackendRendererDiagnostics(workspaceId, sessionId);
@@ -3433,11 +3633,7 @@ export function TerminalPanel({ workspaceId, embedded = false }: TerminalPanelPr
       try {
         const [outputUn, exitUn, notificationUn, notificationClearedUn] = await Promise.all([
           listenTerminalOutput(workspaceId, (event) => {
-            queueOutput(workspaceId, event.sessionId, {
-              seq: event.seq,
-              ts: event.ts,
-              data: event.data,
-            });
+            scheduleTerminalOutputDrain(workspaceId, event.sessionId, event.latestSeq);
           }),
           listenTerminalExit(workspaceId, (event) => {
             destroyCachedTerminal(workspaceId, event.sessionId);

--- a/src/components/terminal/TerminalPanel.tsx
+++ b/src/components/terminal/TerminalPanel.tsx
@@ -55,6 +55,7 @@ import type {
 
 interface TerminalPanelProps {
   workspaceId: string;
+  embedded?: boolean;
 }
 
 interface TerminalSize {
@@ -2718,7 +2719,7 @@ function NewTabDropdown({
 
 // ── Main component ──────────────────────────────────────────────────
 
-export function TerminalPanel({ workspaceId }: TerminalPanelProps) {
+export function TerminalPanel({ workspaceId, embedded = false }: TerminalPanelProps) {
   const { t } = useTranslation("app");
   const workspaceState = useTerminalStore((state) => state.workspaces[workspaceId]);
   const focusMode = useUiStore((state) => state.focusMode);
@@ -2736,9 +2737,10 @@ export function TerminalPanel({ workspaceId }: TerminalPanelProps) {
   const focusedSessionId = workspaceState?.focusedSessionId ?? null;
   const pendingStartupPreset = workspaceState?.pendingStartupPreset ?? null;
   const isMac = isMacDesktop();
-  const useTitlebarSafeInset = isMac && focusMode && !showSidebar && layoutMode === "terminal";
+  const useTitlebarSafeInset =
+    !embedded && isMac && focusMode && !showSidebar && layoutMode === "terminal";
   const gitPanelDocked = showGitPanel && gitPanelPinned;
-  const useFocusModeHeaderHeight = focusMode && gitPanelDocked;
+  const useFocusModeHeaderHeight = !embedded && focusMode && gitPanelDocked;
   const linuxDesktop = isLinuxDesktop();
   const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
 

--- a/src/components/workspace/WorkspacePaneShell.tsx
+++ b/src/components/workspace/WorkspacePaneShell.tsx
@@ -1,0 +1,879 @@
+import {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from "react";
+import {
+  FilePen,
+  MessageSquare,
+  SquareTerminal,
+  X,
+} from "lucide-react";
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+import { useShallow } from "zustand/react/shallow";
+import { useWorkspaceStore } from "../../stores/workspaceStore";
+import { useTerminalStore, type LayoutMode } from "../../stores/terminalStore";
+import { useThreadStore } from "../../stores/threadStore";
+import { useGitStore } from "../../stores/gitStore";
+import { useUiStore } from "../../stores/uiStore";
+import {
+  SURFACE_ORDER,
+  collectWorkspacePaneLeaves,
+  getWorkspacePaneActiveTab,
+  useWorkspacePaneStore,
+  type WorkspacePaneLeaf,
+  type WorkspacePaneNode,
+  type WorkspacePaneSplit,
+  type WorkspacePaneSplitDirection,
+  type WorkspacePaneSurfaceKind,
+} from "../../stores/workspacePaneStore";
+import { handleDragDoubleClick, handleDragMouseDown } from "../../lib/windowDrag";
+import { isMacDesktop, usesCustomWindowFrame } from "../../lib/windowActions";
+
+const LazyChatPanel = lazy(() =>
+  import("../chat/ChatPanel").then((module) => ({
+    default: module.ChatPanel,
+  })),
+);
+
+const LazyTerminalPanel = lazy(() =>
+  import("../terminal/TerminalPanel").then((module) => ({
+    default: module.TerminalPanel,
+  })),
+);
+
+const LazyEditorWithExplorer = lazy(() =>
+  import("../editor/EditorWithExplorer").then((module) => ({
+    default: module.EditorWithExplorer,
+  })),
+);
+
+function SurfaceIcon({ kind, size = 13 }: { kind: WorkspacePaneSurfaceKind; size?: number }) {
+  if (kind === "terminal") {
+    return <SquareTerminal size={size} />;
+  }
+  if (kind === "editor") {
+    return <FilePen size={size} />;
+  }
+  return <MessageSquare size={size} />;
+}
+
+function surfaceLabel(t: TFunction<"app">, kind: WorkspacePaneSurfaceKind): string {
+  return t(`workspacePanes.surfaces.${kind}`);
+}
+
+function countPaneLeaves(node: WorkspacePaneNode): number {
+  return collectWorkspacePaneLeaves(node).length;
+}
+
+function focusedSurfaceKind(layoutRoot: WorkspacePaneNode, focusedLeafId: string): WorkspacePaneSurfaceKind {
+  const leaves = collectWorkspacePaneLeaves(layoutRoot);
+  const focusedLeaf = leaves.find((leaf) => leaf.id === focusedLeafId) ?? leaves[0] ?? null;
+  return focusedLeaf ? getWorkspacePaneActiveTab(focusedLeaf)?.kind ?? "chat" : "chat";
+}
+
+type DropPlacement = "left" | "right" | "top" | "bottom";
+const PANE_LEAF_SELECTOR = "[data-workspace-pane-leaf-id]";
+const SURFACE_DRAG_THRESHOLD_PX = 5;
+
+function directionForDropPlacement(placement: DropPlacement): WorkspacePaneSplitDirection {
+  return placement === "left" || placement === "right" ? "vertical" : "horizontal";
+}
+
+function positionForDropPlacement(placement: DropPlacement): "before" | "after" {
+  return placement === "left" || placement === "top" ? "before" : "after";
+}
+
+function isSurfaceKind(value: string | null | undefined): value is WorkspacePaneSurfaceKind {
+  return value === "chat" || value === "terminal" || value === "editor";
+}
+
+function resolveDropPlacementFromRect(rect: DOMRect, clientX: number, clientY: number): DropPlacement {
+  const x = clientX - rect.left;
+  const y = clientY - rect.top;
+  const distances: Array<[DropPlacement, number]> = [
+    ["left", x],
+    ["right", rect.width - x],
+    ["top", y],
+    ["bottom", rect.height - y],
+  ];
+  distances.sort((a, b) => a[1] - b[1]);
+  return distances[0]?.[0] ?? "right";
+}
+
+function resolvePointerDropTarget(clientX: number, clientY: number): {
+  leafId: string;
+  placement: DropPlacement;
+} | null {
+  const element = document.elementFromPoint(clientX, clientY);
+  const leafElement = element instanceof Element
+    ? element.closest<HTMLElement>(PANE_LEAF_SELECTOR)
+    : null;
+  const leafId = leafElement?.dataset.workspacePaneLeafId;
+  if (!leafElement || !leafId) {
+    return null;
+  }
+  return {
+    leafId,
+    placement: resolveDropPlacementFromRect(leafElement.getBoundingClientRect(), clientX, clientY),
+  };
+}
+
+interface SurfaceDragState {
+  kind: WorkspacePaneSurfaceKind;
+  pointerX: number;
+  pointerY: number;
+  targetLeafId: string | null;
+  placement: DropPlacement | null;
+}
+
+interface WorkspacePaneShellProps {
+  workspaceId: string;
+}
+
+export function WorkspacePaneShell({ workspaceId }: WorkspacePaneShellProps) {
+  const { t } = useTranslation("app");
+  const terminalLayoutMode = useTerminalStore((state) =>
+    state.workspaces[workspaceId]?.layoutMode ?? "chat",
+  );
+  const setTerminalLayoutMode = useTerminalStore((state) => state.setLayoutMode);
+  const ensureWorkspace = useWorkspacePaneStore((state) => state.ensureWorkspace);
+  const activateFocusedSurface = useWorkspacePaneStore((state) => state.activateFocusedSurface);
+  const splitFocusedLeaf = useWorkspacePaneStore((state) => state.splitFocusedLeaf);
+  const layout = useWorkspacePaneStore((state) => state.workspaces[workspaceId]);
+  const suppressSurfaceClickRef = useRef(false);
+  const suppressSurfaceClickTimerRef = useRef<number | null>(null);
+  const surfaceDragCleanupRef = useRef<(() => void) | null>(null);
+  const [surfaceDrag, setSurfaceDrag] = useState<SurfaceDragState | null>(null);
+  const [editingThreadTitle, setEditingThreadTitle] = useState(false);
+  const [threadTitleDraft, setThreadTitleDraft] = useState("");
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const { activeWorkspace, activeThread, renameThread, gitStatus, focusMode, showSidebar } =
+    useWorkspacePaneHeaderState(workspaceId);
+  const customWindowFrame = usesCustomWindowFrame();
+  const useTitlebarSafeInset = isMacDesktop() && focusMode && !showSidebar;
+
+  useEffect(() => {
+    ensureWorkspace(workspaceId, terminalLayoutMode);
+  }, [ensureWorkspace, terminalLayoutMode, workspaceId]);
+
+  useEffect(() => {
+    if (!layout || layout.legacyMode === terminalLayoutMode) {
+      return;
+    }
+    void setTerminalLayoutMode(workspaceId, layout.legacyMode);
+  }, [layout, setTerminalLayoutMode, terminalLayoutMode, workspaceId]);
+
+  const activeSurface = useMemo(() => {
+    if (!layout) {
+      return "chat";
+    }
+    return focusedSurfaceKind(layout.root, layout.focusedLeafId);
+  }, [layout]);
+
+  useEffect(() => {
+    if (editingThreadTitle) {
+      return;
+    }
+    setThreadTitleDraft(activeThread?.title ?? "");
+  }, [activeThread?.id, activeThread?.title, editingThreadTitle]);
+
+  useEffect(() => {
+    if (editingThreadTitle) {
+      titleInputRef.current?.focus();
+      titleInputRef.current?.select();
+    }
+  }, [editingThreadTitle]);
+
+  useEffect(() => (
+    () => {
+      if (suppressSurfaceClickTimerRef.current !== null) {
+        window.clearTimeout(suppressSurfaceClickTimerRef.current);
+      }
+      surfaceDragCleanupRef.current?.();
+    }
+  ), []);
+
+  const handlePrimarySurfaceClick = useCallback(
+    (kind: WorkspacePaneSurfaceKind) => {
+      if (suppressSurfaceClickRef.current) {
+        suppressSurfaceClickRef.current = false;
+        return;
+      }
+      activateFocusedSurface(workspaceId, kind);
+    },
+    [activateFocusedSurface, workspaceId],
+  );
+
+  const clearSurfaceDragSuppression = useCallback((delay = 0) => {
+    if (suppressSurfaceClickTimerRef.current !== null) {
+      window.clearTimeout(suppressSurfaceClickTimerRef.current);
+    }
+    suppressSurfaceClickTimerRef.current = window.setTimeout(() => {
+      suppressSurfaceClickRef.current = false;
+      suppressSurfaceClickTimerRef.current = null;
+    }, delay);
+  }, []);
+
+  const commitSurfaceDrag = useCallback(
+    (kind: WorkspacePaneSurfaceKind, target: { leafId: string; placement: DropPlacement } | null) => {
+      if (!target) {
+        return;
+      }
+      const currentLayout = useWorkspacePaneStore.getState().workspaces[workspaceId];
+      const targetLeaf = currentLayout
+        ? collectWorkspacePaneLeaves(currentLayout.root).find((leaf) => leaf.id === target.leafId) ?? null
+        : null;
+      const activeKind = targetLeaf ? getWorkspacePaneActiveTab(targetLeaf)?.kind ?? null : null;
+      if (!targetLeaf || activeKind === kind) {
+        return;
+      }
+      useWorkspacePaneStore.getState().splitLeaf(
+        workspaceId,
+        target.leafId,
+        directionForDropPlacement(target.placement),
+        kind,
+        positionForDropPlacement(target.placement),
+      );
+    },
+    [workspaceId],
+  );
+
+  const handleSurfacePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>, kind: WorkspacePaneSurfaceKind) => {
+      if (event.button !== 0 || !isSurfaceKind(kind)) {
+        return;
+      }
+
+      surfaceDragCleanupRef.current?.();
+      const pointerId = event.pointerId;
+      const sourceButton = event.currentTarget;
+      const startX = event.clientX;
+      const startY = event.clientY;
+      let dragging = false;
+      let latestTarget: { leafId: string; placement: DropPlacement } | null = null;
+      try {
+        sourceButton.setPointerCapture(pointerId);
+      } catch {
+        // Pointer capture is best-effort; window-level listeners still drive the drag.
+      }
+
+      const publishDrag = (clientX: number, clientY: number) => {
+        latestTarget = resolvePointerDropTarget(clientX, clientY);
+        setSurfaceDrag({
+          kind,
+          pointerX: clientX,
+          pointerY: clientY,
+          targetLeafId: latestTarget?.leafId ?? null,
+          placement: latestTarget?.placement ?? null,
+        });
+      };
+
+      const stopDrag = (commit: boolean) => {
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerup", handlePointerUp);
+        window.removeEventListener("pointercancel", handlePointerCancel);
+        window.removeEventListener("blur", handleWindowBlur);
+        sourceButton.removeEventListener("lostpointercapture", handleLostPointerCapture);
+        surfaceDragCleanupRef.current = null;
+        document.body.classList.remove("workspace-pane-surface-dragging");
+        try {
+          if (sourceButton.hasPointerCapture(pointerId)) {
+            sourceButton.releasePointerCapture(pointerId);
+          }
+        } catch {
+          // Ignore stale pointer capture state after cancellation.
+        }
+        setSurfaceDrag(null);
+        if (dragging && commit) {
+          commitSurfaceDrag(kind, latestTarget);
+          clearSurfaceDragSuppression(250);
+          return;
+        }
+        suppressSurfaceClickRef.current = false;
+      };
+
+      const handleWindowBlur = () => {
+        stopDrag(false);
+      };
+
+      const handleLostPointerCapture = (captureEvent: PointerEvent) => {
+        if (captureEvent.pointerId !== pointerId) {
+          return;
+        }
+        stopDrag(false);
+      };
+
+      const handlePointerMove = (moveEvent: PointerEvent) => {
+        if (moveEvent.pointerId !== pointerId) {
+          return;
+        }
+        const distance = Math.hypot(moveEvent.clientX - startX, moveEvent.clientY - startY);
+        if (!dragging && distance < SURFACE_DRAG_THRESHOLD_PX) {
+          return;
+        }
+        if (!dragging) {
+          dragging = true;
+          suppressSurfaceClickRef.current = true;
+          document.body.classList.add("workspace-pane-surface-dragging");
+        }
+        moveEvent.preventDefault();
+        publishDrag(moveEvent.clientX, moveEvent.clientY);
+      };
+
+      const handlePointerUp = (upEvent: PointerEvent) => {
+        if (upEvent.pointerId !== pointerId) {
+          return;
+        }
+        upEvent.preventDefault();
+        if (dragging) {
+          latestTarget = resolvePointerDropTarget(upEvent.clientX, upEvent.clientY);
+        }
+        stopDrag(true);
+      };
+
+      const handlePointerCancel = (cancelEvent: PointerEvent) => {
+        if (cancelEvent.pointerId !== pointerId) {
+          return;
+        }
+        stopDrag(false);
+      };
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+      window.addEventListener("pointercancel", handlePointerCancel);
+      window.addEventListener("blur", handleWindowBlur);
+      sourceButton.addEventListener("lostpointercapture", handleLostPointerCapture);
+      surfaceDragCleanupRef.current = () => stopDrag(false);
+    },
+    [clearSurfaceDragSuppression, commitSurfaceDrag],
+  );
+
+  const handleSurfaceKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLButtonElement>, kind: WorkspacePaneSurfaceKind) => {
+      if (!event.shiftKey) {
+        return;
+      }
+      const splitByKey: Partial<Record<string, [WorkspacePaneSplitDirection, "before" | "after"]>> = {
+        ArrowLeft: ["vertical", "before"],
+        ArrowRight: ["vertical", "after"],
+        ArrowUp: ["horizontal", "before"],
+        ArrowDown: ["horizontal", "after"],
+      };
+      const split = splitByKey[event.key];
+      if (!split) {
+        return;
+      }
+      event.preventDefault();
+      splitFocusedLeaf(workspaceId, split[0], kind, split[1]);
+    },
+    [splitFocusedLeaf, workspaceId],
+  );
+
+  const startThreadTitleEdit = useCallback(() => {
+    if (!activeThread) {
+      return;
+    }
+    setThreadTitleDraft(activeThread.title ?? "");
+    setEditingThreadTitle(true);
+  }, [activeThread]);
+
+  const cancelThreadTitleEdit = useCallback(() => {
+    setThreadTitleDraft(activeThread?.title ?? "");
+    setEditingThreadTitle(false);
+  }, [activeThread?.title]);
+
+  const saveThreadTitleEdit = useCallback(async () => {
+    if (!activeThread) {
+      setEditingThreadTitle(false);
+      return;
+    }
+    const normalized = threadTitleDraft.trim();
+    if (!normalized) {
+      cancelThreadTitleEdit();
+      return;
+    }
+    if (normalized !== (activeThread.title ?? "")) {
+      await renameThread(activeThread.id, normalized);
+    }
+    setEditingThreadTitle(false);
+  }, [activeThread, cancelThreadTitleEdit, renameThread, threadTitleDraft]);
+
+  if (!layout) {
+    return (
+      <div className="workspace-pane-shell workspace-pane-shell-empty">
+        <span>{t("workspacePanes.loading")}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="workspace-pane-shell">
+      <div
+        className="workspace-pane-header"
+        onMouseDown={handleDragMouseDown}
+        onDoubleClick={handleDragDoubleClick}
+        style={{
+          paddingLeft: showSidebar ? 16 : customWindowFrame ? 16 : useTitlebarSafeInset ? 80 : 80,
+        }}
+      >
+        <div className="workspace-pane-header-content no-drag">
+          <WorkspacePaneBreadcrumb
+            activeSurface={activeSurface}
+            activeThreadTitle={activeThread?.title ?? null}
+            canRenameThread={activeThread !== null}
+            changedFileCount={gitStatus?.files.length ?? 0}
+            editingThreadTitle={editingThreadTitle}
+            titleInputRef={titleInputRef}
+            threadTitleDraft={threadTitleDraft}
+            workspaceName={activeWorkspace?.name || activeWorkspace?.rootPath?.split("/").pop() || ""}
+            workspacePath={activeWorkspace?.rootPath ?? ""}
+            onCancelThreadTitleEdit={cancelThreadTitleEdit}
+            onSaveThreadTitleEdit={saveThreadTitleEdit}
+            onStartThreadTitleEdit={startThreadTitleEdit}
+            onThreadTitleDraftChange={setThreadTitleDraft}
+          />
+        </div>
+
+        <div className="workspace-pane-header-actions no-drag">
+          <div
+            className="layout-mode-switcher"
+            role="tablist"
+            aria-label={t("workspacePanes.primarySwitcher")}
+          >
+            {SURFACE_ORDER.map((kind) => {
+              const active = activeSurface === kind;
+              const buttonLabel = t("workspacePanes.primarySurfaceTitle", {
+                surface: surfaceLabel(t, kind),
+              });
+              return (
+                <button
+                  key={kind}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  aria-keyshortcuts="Shift+ArrowLeft Shift+ArrowRight Shift+ArrowUp Shift+ArrowDown"
+                  className={`layout-mode-btn${active ? " active" : ""}`}
+                  title={buttonLabel}
+                  aria-label={buttonLabel}
+                  onClick={() => handlePrimarySurfaceClick(kind)}
+                  onKeyDown={(event) => handleSurfaceKeyDown(event, kind)}
+                  onPointerDown={(event) => handleSurfacePointerDown(event, kind)}
+                >
+                  <SurfaceIcon kind={kind} size={12} />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="workspace-pane-canvas">
+        <PaneNodeView
+          node={layout.root}
+          workspaceId={workspaceId}
+          focusedLeafId={layout.focusedLeafId}
+          leafCount={countPaneLeaves(layout.root)}
+          surfaceDrag={surfaceDrag}
+        />
+      </div>
+
+      {surfaceDrag && (
+        <div
+          className="workspace-pane-drag-chip"
+          style={{
+            transform: `translate3d(${surfaceDrag.pointerX + 12}px, ${surfaceDrag.pointerY + 12}px, 0)`,
+          }}
+        >
+          <SurfaceIcon kind={surfaceDrag.kind} size={13} />
+          <span>{surfaceLabel(t, surfaceDrag.kind)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function useWorkspacePaneHeaderState(workspaceId: string) {
+  const { activeWorkspace } = useWorkspaceStore(
+    useShallow((state) => ({
+      activeWorkspace:
+        state.workspaces.find((workspace) => workspace.id === workspaceId) ?? null,
+    })),
+  );
+  const { activeThread, renameThread } = useThreadStore(
+    useShallow((state) => ({
+      activeThread:
+        state.threads.find(
+          (thread) => thread.id === state.activeThreadId && thread.workspaceId === workspaceId,
+        ) ?? null,
+      renameThread: state.renameThread,
+    })),
+  );
+  const gitStatus = useGitStore((state) => state.status);
+  const focusMode = useUiStore((state) => state.focusMode);
+  const showSidebar = useUiStore((state) => state.showSidebar);
+
+  return {
+    activeWorkspace,
+    activeThread,
+    renameThread,
+    gitStatus,
+    focusMode,
+    showSidebar,
+  };
+}
+
+function WorkspacePaneBreadcrumb({
+  activeSurface,
+  activeThreadTitle,
+  canRenameThread,
+  changedFileCount,
+  editingThreadTitle,
+  titleInputRef,
+  threadTitleDraft,
+  workspaceName,
+  workspacePath,
+  onCancelThreadTitleEdit,
+  onSaveThreadTitleEdit,
+  onStartThreadTitleEdit,
+  onThreadTitleDraftChange,
+}: {
+  activeSurface: WorkspacePaneSurfaceKind;
+  activeThreadTitle: string | null;
+  canRenameThread: boolean;
+  changedFileCount: number;
+  editingThreadTitle: boolean;
+  titleInputRef: RefObject<HTMLInputElement | null>;
+  threadTitleDraft: string;
+  workspaceName: string;
+  workspacePath: string;
+  onCancelThreadTitleEdit: () => void;
+  onSaveThreadTitleEdit: () => Promise<void>;
+  onStartThreadTitleEdit: () => void;
+  onThreadTitleDraftChange: (value: string) => void;
+}) {
+  const { t: tChat } = useTranslation("chat");
+  const title =
+    activeThreadTitle ||
+    (activeSurface === "terminal"
+      ? tChat("panel.threadTitle.terminal")
+      : activeSurface === "editor"
+        ? tChat("panel.threadTitle.fileEditor")
+        : tChat("panel.threadTitle.newChat"));
+
+  return (
+    <>
+      {workspaceName && (
+        <>
+          <span className="workspace-pane-header-folder" title={workspacePath}>
+            {workspaceName}
+          </span>
+          <span className="workspace-pane-header-separator">/</span>
+        </>
+      )}
+      {editingThreadTitle ? (
+        <input
+          ref={titleInputRef}
+          value={threadTitleDraft}
+          onChange={(event) => onThreadTitleDraftChange(event.target.value)}
+          onBlur={onCancelThreadTitleEdit}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              void onSaveThreadTitleEdit();
+              return;
+            }
+            if (event.key === "Escape") {
+              event.preventDefault();
+              onCancelThreadTitleEdit();
+            }
+          }}
+          className="workspace-pane-title-input"
+        />
+      ) : (
+        <button
+          type="button"
+          className="workspace-pane-title-btn"
+          title={canRenameThread ? tChat("panel.renameThread") : title}
+          disabled={!canRenameThread}
+          onClick={onStartThreadTitleEdit}
+        >
+          {title}
+        </button>
+      )}
+      {changedFileCount > 0 && (
+        <>
+          <span className="workspace-pane-header-separator">/</span>
+          <span className="workspace-pane-header-changes">
+            {tChat("panel.changedFiles", { count: changedFileCount })}
+          </span>
+        </>
+      )}
+    </>
+  );
+}
+
+export function ActiveWorkspacePaneShell() {
+  const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
+  const { t } = useTranslation("app");
+
+  if (!activeWorkspaceId) {
+    return (
+      <div className="workspace-pane-shell workspace-pane-shell-empty">
+        <span>{t("workspacePanes.noWorkspace")}</span>
+      </div>
+    );
+  }
+
+  return <WorkspacePaneShell workspaceId={activeWorkspaceId} />;
+}
+
+interface PaneNodeViewProps {
+  node: WorkspacePaneNode;
+  workspaceId: string;
+  focusedLeafId: string;
+  leafCount: number;
+  surfaceDrag: SurfaceDragState | null;
+}
+
+function PaneNodeView({
+  node,
+  workspaceId,
+  focusedLeafId,
+  leafCount,
+  surfaceDrag,
+}: PaneNodeViewProps) {
+  if (node.type === "leaf") {
+    return (
+      <PaneLeafView
+        leaf={node}
+        workspaceId={workspaceId}
+        focused={node.id === focusedLeafId}
+        leafCount={leafCount}
+        surfaceDrag={surfaceDrag}
+      />
+    );
+  }
+
+  return (
+    <PaneSplitView
+      split={node}
+      workspaceId={workspaceId}
+      focusedLeafId={focusedLeafId}
+      leafCount={leafCount}
+      surfaceDrag={surfaceDrag}
+    />
+  );
+}
+
+interface PaneSplitViewProps {
+  split: WorkspacePaneSplit;
+  workspaceId: string;
+  focusedLeafId: string;
+  leafCount: number;
+  surfaceDrag: SurfaceDragState | null;
+}
+
+function PaneSplitView({
+  split,
+  workspaceId,
+  focusedLeafId,
+  leafCount,
+  surfaceDrag,
+}: PaneSplitViewProps) {
+  const updateRatio = useWorkspacePaneStore((state) => state.updateRatio);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  const vertical = split.direction === "vertical";
+  const firstSize = `${split.ratio * 100}%`;
+  const secondSize = `${(1 - split.ratio) * 100}%`;
+
+  useEffect(() => () => dragCleanupRef.current?.(), []);
+
+  const handleMouseDown = useCallback(
+    (event: ReactMouseEvent) => {
+      event.preventDefault();
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+      const rect = container.getBoundingClientRect();
+      const dimension = vertical ? rect.width : rect.height;
+      const start = vertical ? rect.left : rect.top;
+
+      document.body.style.userSelect = "none";
+
+      const onMove = (moveEvent: MouseEvent) => {
+        const position = vertical ? moveEvent.clientX : moveEvent.clientY;
+        updateRatio(workspaceId, split.id, (position - start) / dimension);
+      };
+      const cleanup = () => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", cleanup);
+        document.body.style.userSelect = "";
+        dragCleanupRef.current = null;
+      };
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", cleanup);
+      dragCleanupRef.current = cleanup;
+    },
+    [split.id, updateRatio, vertical, workspaceId],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className="workspace-pane-split"
+      style={{ flexDirection: vertical ? "row" : "column" }}
+    >
+      <div
+        className="workspace-pane-split-child"
+        style={{ flexBasis: `calc(${firstSize} - 2px)` }}
+      >
+        <PaneNodeView
+          node={split.children[0]}
+          workspaceId={workspaceId}
+          focusedLeafId={focusedLeafId}
+          leafCount={leafCount}
+          surfaceDrag={surfaceDrag}
+        />
+      </div>
+      <div
+        className={vertical ? "workspace-pane-resize-handle-v" : "workspace-pane-resize-handle-h"}
+        onMouseDown={handleMouseDown}
+        role="separator"
+        aria-orientation={vertical ? "vertical" : "horizontal"}
+      />
+      <div
+        className="workspace-pane-split-child"
+        style={{ flexBasis: `calc(${secondSize} - 2px)` }}
+      >
+        <PaneNodeView
+          node={split.children[1]}
+          workspaceId={workspaceId}
+          focusedLeafId={focusedLeafId}
+          leafCount={leafCount}
+          surfaceDrag={surfaceDrag}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface PaneLeafViewProps {
+  leaf: WorkspacePaneLeaf;
+  workspaceId: string;
+  focused: boolean;
+  leafCount: number;
+  surfaceDrag: SurfaceDragState | null;
+}
+
+function PaneLeafView({
+  leaf,
+  workspaceId,
+  focused,
+  leafCount,
+  surfaceDrag,
+}: PaneLeafViewProps) {
+  const { t } = useTranslation("app");
+  const focusLeaf = useWorkspacePaneStore((state) => state.focusLeaf);
+  const closeLeaf = useWorkspacePaneStore((state) => state.closeLeaf);
+  const activeTab = getWorkspacePaneActiveTab(leaf);
+  const activeSurfaceKind = activeTab?.kind ?? null;
+  const showSnapPreview =
+    surfaceDrag !== null &&
+    surfaceDrag.targetLeafId === leaf.id &&
+    surfaceDrag.placement !== null &&
+    surfaceDrag.kind !== activeSurfaceKind;
+
+  return (
+    <section
+      className={`workspace-pane-leaf${focused ? " workspace-pane-leaf-focused" : ""}${
+        leafCount > 1 ? " workspace-pane-leaf-has-close" : ""
+      }`}
+      data-workspace-pane-leaf-id={leaf.id}
+      onMouseDownCapture={() => focusLeaf(workspaceId, leaf.id)}
+    >
+      {leafCount > 1 && (
+        <button
+          type="button"
+          className="workspace-pane-close-btn"
+          title={t("workspacePanes.closePane")}
+          aria-label={t("workspacePanes.closePane")}
+          onClick={() => closeLeaf(workspaceId, leaf.id)}
+        >
+          <X size={12} />
+        </button>
+      )}
+
+      {showSnapPreview && (
+        <div className="workspace-pane-snap-overlay" aria-hidden="true">
+          <div
+            className={`workspace-pane-snap-preview workspace-pane-snap-preview-${surfaceDrag.placement}`}
+          >
+            <div className="workspace-pane-snap-label">
+              <SurfaceIcon kind={surfaceDrag.kind} size={14} />
+              <span>
+                {t(`workspacePanes.dropZones.${surfaceDrag.placement}`, {
+                  surface: surfaceLabel(t, surfaceDrag.kind),
+                })}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="workspace-pane-body">
+        {activeTab ? (
+          <SurfaceView kind={activeTab.kind} workspaceId={workspaceId} />
+        ) : (
+          <EmptyPane />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function EmptyPane() {
+  const { t } = useTranslation("app");
+
+  return (
+    <div className="workspace-pane-empty">
+      {t("workspacePanes.emptyPane")}
+    </div>
+  );
+}
+
+function SurfaceView({
+  kind,
+  workspaceId,
+}: {
+  kind: WorkspacePaneSurfaceKind;
+  workspaceId: string;
+}) {
+  const { t } = useTranslation("app");
+
+  return (
+    <Suspense
+      fallback={
+        <div className="workspace-pane-loading">
+          {t("workspacePanes.loading")}
+        </div>
+      }
+    >
+      {kind === "chat" && <LazyChatPanel embedded />}
+      {kind === "terminal" && <LazyTerminalPanel workspaceId={workspaceId} embedded />}
+      {kind === "editor" && <LazyEditorWithExplorer embedded />}
+    </Suspense>
+  );
+}

--- a/src/globals.css
+++ b/src/globals.css
@@ -847,6 +847,15 @@ button, input, textarea, select {
   background: var(--block-error-bg);
 }
 
+.chat-plain-link {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.chat-plain-link:hover {
+  text-decoration: underline;
+}
+
 /* ── Timestamp hover-reveal ── */
 .msg-row-timestamp {
   font-size: 10px; color: var(--text-3);
@@ -2160,15 +2169,18 @@ button, input, textarea, select {
   cursor: pointer;
   opacity: 0;
   pointer-events: none;
+  transform: translateX(4px);
   transition: background var(--duration-fast) var(--ease-out),
               color var(--duration-fast) var(--ease-out),
-              opacity var(--duration-fast) var(--ease-out);
+              opacity var(--duration-fast) var(--ease-out),
+              transform var(--duration-fast) var(--ease-out);
 }
 
-.workspace-pane-leaf:hover .workspace-pane-close-btn,
+.workspace-pane-leaf-focused:hover .workspace-pane-close-btn,
 .workspace-pane-close-btn:focus-visible {
   opacity: 1;
   pointer-events: auto;
+  transform: translateX(0);
 }
 
 .workspace-pane-close-btn:hover {
@@ -2178,6 +2190,11 @@ button, input, textarea, select {
 
 .workspace-pane-leaf-has-close .terminal-tabs-bar,
 .workspace-pane-leaf-has-close .editor-tabs-bar {
+  transition: padding-right var(--duration-fast) var(--ease-out);
+}
+
+.workspace-pane-leaf-focused.workspace-pane-leaf-has-close:hover .terminal-tabs-bar,
+.workspace-pane-leaf-focused.workspace-pane-leaf-has-close:hover .editor-tabs-bar {
   padding-right: 38px;
 }
 
@@ -6234,7 +6251,7 @@ button, input, textarea, select {
 .editor-tab.active {
   background: var(--bg-1);
   color: var(--text-1);
-  box-shadow: inset 0 1px 0 var(--accent);
+  box-shadow: inset 0 -2px 0 var(--accent);
 }
 
 .editor-tab-name {

--- a/src/globals.css
+++ b/src/globals.css
@@ -1935,6 +1935,369 @@ button, input, textarea, select {
   overflow: hidden;
 }
 
+/* Workspace pane shell */
+.workspace-pane-shell {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--content-bg);
+}
+
+.workspace-pane-shell-empty {
+  align-items: center;
+  justify-content: center;
+  color: var(--text-3);
+  font-size: 12px;
+}
+
+.workspace-pane-header {
+  height: var(--panel-header-height);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--content-bg);
+}
+
+.workspace-pane-header-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.workspace-pane-header-folder {
+  flex-shrink: 0;
+  max-width: min(220px, 34vw);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-3);
+  font-size: 12px;
+}
+
+.workspace-pane-header-separator {
+  flex-shrink: 0;
+  margin: 0 6px;
+  color: var(--border);
+  font-size: 12px;
+}
+
+.workspace-pane-title-btn {
+  min-width: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 2px 6px;
+  font-size: 13.5px;
+  font-weight: 600;
+  text-align: left;
+  cursor: text;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.workspace-pane-title-btn:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.workspace-pane-title-btn:disabled {
+  cursor: default;
+}
+
+.workspace-pane-title-input {
+  min-width: 120px;
+  width: 100%;
+  max-width: 520px;
+  padding: 4px 8px;
+  border: 1px solid var(--border-active);
+  border-radius: var(--radius-sm);
+  background: var(--bg-3);
+  color: var(--text-1);
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.workspace-pane-header-changes {
+  flex-shrink: 0;
+  color: var(--warning);
+  font-size: 11px;
+  font-family: "JetBrains Mono", monospace;
+  white-space: nowrap;
+}
+
+.workspace-pane-header-actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.workspace-pane-drag-chip {
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 10000;
+  pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  max-width: 180px;
+  padding: 7px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-sm);
+  background: rgba(10, 10, 10, 0.82);
+  color: var(--text-1);
+  font-size: 12px;
+  font-weight: 600;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.32);
+}
+
+.workspace-pane-surface-dragging,
+.workspace-pane-surface-dragging * {
+  cursor: grabbing !important;
+  user-select: none !important;
+}
+
+.workspace-pane-canvas {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+
+.workspace-pane-split {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+
+.workspace-pane-split-child {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+
+.workspace-pane-resize-handle-v,
+.workspace-pane-resize-handle-h {
+  flex-shrink: 0;
+  background: var(--border);
+  position: relative;
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.workspace-pane-resize-handle-v {
+  width: 4px;
+  cursor: col-resize;
+}
+
+.workspace-pane-resize-handle-h {
+  height: 4px;
+  cursor: row-resize;
+}
+
+.workspace-pane-resize-handle-v::after {
+  content: "";
+  position: absolute;
+  inset: 0 -3px;
+}
+
+.workspace-pane-resize-handle-h::after {
+  content: "";
+  position: absolute;
+  inset: -3px 0;
+}
+
+.workspace-pane-resize-handle-v:hover,
+.workspace-pane-resize-handle-v:active,
+.workspace-pane-resize-handle-h:hover,
+.workspace-pane-resize-handle-h:active {
+  background: var(--accent);
+}
+
+.workspace-pane-leaf {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--content-bg);
+}
+
+.workspace-pane-leaf-focused {
+  background: var(--content-bg);
+}
+
+.workspace-pane-close-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 9;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.48);
+  color: var(--text-3);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out),
+              opacity var(--duration-fast) var(--ease-out);
+}
+
+.workspace-pane-leaf:hover .workspace-pane-close-btn,
+.workspace-pane-close-btn:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.workspace-pane-close-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-1);
+}
+
+.workspace-pane-leaf-has-close .terminal-tabs-bar,
+.workspace-pane-leaf-has-close .editor-tabs-bar {
+  padding-right: 38px;
+}
+
+.workspace-pane-leaf-has-close .terminal-tabs-actions {
+  margin-right: 0;
+}
+
+.workspace-pane-body {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.workspace-pane-snap-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 8;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.workspace-pane-snap-preview {
+  position: absolute;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: rgba(248, 113, 113, 0.11);
+  box-shadow:
+    inset 0 0 0 1px rgba(248, 113, 113, 0.14),
+    0 0 0 1px rgba(0, 0, 0, 0.34);
+  animation: workspace-snap-preview-in var(--duration-fast) var(--ease-out);
+}
+
+.workspace-pane-snap-preview::before {
+  content: "";
+  position: absolute;
+  inset: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: calc(var(--radius-sm) - 1px);
+}
+
+.workspace-pane-snap-preview-left {
+  left: 8px;
+  top: 8px;
+  bottom: 8px;
+  width: calc(50% - 12px);
+}
+
+.workspace-pane-snap-preview-right {
+  right: 8px;
+  top: 8px;
+  bottom: 8px;
+  width: calc(50% - 12px);
+}
+
+.workspace-pane-snap-preview-top {
+  left: 8px;
+  right: 8px;
+  top: 8px;
+  height: calc(50% - 12px);
+}
+
+.workspace-pane-snap-preview-bottom {
+  left: 8px;
+  right: 8px;
+  bottom: 8px;
+  height: calc(50% - 12px);
+}
+
+.workspace-pane-snap-label {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: calc(100% - 24px);
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  background: rgba(10, 10, 10, 0.72);
+  color: var(--text-1);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@keyframes workspace-snap-preview-in {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-pane-snap-preview {
+    animation: none;
+  }
+}
+
+.workspace-pane-loading,
+.workspace-pane-empty {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-3);
+  font-size: 12px;
+}
+
 .chat-focus-header {
   height: var(--panel-header-height);
   flex-shrink: 0;
@@ -1969,6 +2332,8 @@ button, input, textarea, select {
   background: transparent;
   color: var(--text-3);
   cursor: pointer;
+  touch-action: none;
+  user-select: none;
   transition: background var(--duration-fast) var(--ease-out),
               color var(--duration-fast) var(--ease-out);
 }

--- a/src/i18n/resources/en/app.json
+++ b/src/i18n/resources/en/app.json
@@ -291,6 +291,25 @@
       "codexReviewStarted": "Started an inline Codex review."
     }
   },
+  "workspacePanes": {
+    "loading": "Loading pane...",
+    "noWorkspace": "Open a workspace to start.",
+    "primarySwitcher": "Primary workspace view",
+    "primarySurfaceTitle": "Switch to {{surface}}",
+    "emptyPane": "Drag Chat, Terminal, or Editor here.",
+    "closePane": "Close pane",
+    "dropZones": {
+      "left": "Split left with {{surface}}",
+      "right": "Split right with {{surface}}",
+      "top": "Split above with {{surface}}",
+      "bottom": "Split below with {{surface}}"
+    },
+    "surfaces": {
+      "chat": "Chat",
+      "terminal": "Terminal",
+      "editor": "Editor"
+    }
+  },
   "terminal": {
     "newTerminal": "New terminal",
     "terminal": "Terminal",

--- a/src/i18n/resources/pt-BR/app.json
+++ b/src/i18n/resources/pt-BR/app.json
@@ -291,6 +291,25 @@
       "codexReviewStarted": "Revisão inline do Codex iniciada."
     }
   },
+  "workspacePanes": {
+    "loading": "Carregando painel...",
+    "noWorkspace": "Abra um workspace para começar.",
+    "primarySwitcher": "Visualização principal do workspace",
+    "primarySurfaceTitle": "Ir para {{surface}}",
+    "emptyPane": "Arraste Chat, Terminal ou Editor para cá.",
+    "closePane": "Fechar painel",
+    "dropZones": {
+      "left": "Dividir à esquerda com {{surface}}",
+      "right": "Dividir à direita com {{surface}}",
+      "top": "Dividir acima com {{surface}}",
+      "bottom": "Dividir abaixo com {{surface}}"
+    },
+    "surfaces": {
+      "chat": "Chat",
+      "terminal": "Terminal",
+      "editor": "Editor"
+    }
+  },
   "terminal": {
     "newTerminal": "Novo terminal",
     "terminal": "Terminal",

--- a/src/lib/editorFileTypes.ts
+++ b/src/lib/editorFileTypes.ts
@@ -1,0 +1,6 @@
+const MARKDOWN_PREVIEW_EXTENSIONS = new Set(["md", "mdx", "markdown"]);
+
+export function isMarkdownPreviewFile(filePath: string): boolean {
+  const extension = filePath.split(".").pop()?.toLowerCase();
+  return extension ? MARKDOWN_PREVIEW_EXTENSIONS.has(extension) : false;
+}

--- a/src/lib/fileLinkNavigation.test.ts
+++ b/src/lib/fileLinkNavigation.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockOpenExternal = vi.hoisted(() => vi.fn());
 const mockOpenFileAtLocation = vi.hoisted(() => vi.fn());
 const mockSetLayoutMode = vi.hoisted(() => vi.fn());
+const mockEnsureWorkspace = vi.hoisted(() => vi.fn());
 const mockShowSurface = vi.hoisted(() => vi.fn());
 const mockSetActiveView = vi.hoisted(() => vi.fn());
 const mockWorkspaceState = vi.hoisted(() => ({
@@ -66,6 +67,7 @@ vi.mock("../stores/workspacePaneStore", () => ({
   getWorkspacePaneActiveTab: vi.fn(() => null),
   useWorkspacePaneStore: {
     getState: () => ({
+      ensureWorkspace: mockEnsureWorkspace,
       showSurface: mockShowSurface,
       workspaces: {},
     }),

--- a/src/lib/fileLinkNavigation.test.ts
+++ b/src/lib/fileLinkNavigation.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockOpenExternal = vi.hoisted(() => vi.fn());
 const mockOpenFileAtLocation = vi.hoisted(() => vi.fn());
 const mockSetLayoutMode = vi.hoisted(() => vi.fn());
+const mockShowSurface = vi.hoisted(() => vi.fn());
+const mockSetActiveView = vi.hoisted(() => vi.fn());
 const mockWorkspaceState = vi.hoisted(() => ({
   activeWorkspaceId: "ws-1",
   activeRepoId: "repo-1",
@@ -54,6 +56,26 @@ vi.mock("../stores/terminalStore", () => ({
   useTerminalStore: {
     getState: () => ({
       setLayoutMode: mockSetLayoutMode,
+      workspaces: {},
+    }),
+  },
+}));
+
+vi.mock("../stores/workspacePaneStore", () => ({
+  collectWorkspacePaneLeaves: vi.fn(() => []),
+  getWorkspacePaneActiveTab: vi.fn(() => null),
+  useWorkspacePaneStore: {
+    getState: () => ({
+      showSurface: mockShowSurface,
+      workspaces: {},
+    }),
+  },
+}));
+
+vi.mock("../stores/uiStore", () => ({
+  useUiStore: {
+    getState: () => ({
+      setActiveView: mockSetActiveView,
     }),
   },
 }));
@@ -331,6 +353,8 @@ describe("fileLinkNavigation", () => {
 
     expect(mockOpenFileAtLocation).not.toHaveBeenCalled();
     expect(mockSetLayoutMode).not.toHaveBeenCalled();
+    expect(mockShowSurface).not.toHaveBeenCalled();
+    expect(mockSetActiveView).not.toHaveBeenCalled();
 
     await expect(
       navigateLinkTarget("/workspace/apps/app/src/main.ts#L12C4", { shiftKey: true }),
@@ -341,7 +365,9 @@ describe("fileLinkNavigation", () => {
       "src/main.ts",
       { line: 12, column: 4 },
     );
-    expect(mockSetLayoutMode).toHaveBeenCalledWith("ws-1", "editor");
+    expect(mockShowSurface).toHaveBeenCalledWith("ws-1", "editor");
+    expect(mockSetActiveView).toHaveBeenCalledWith("chat");
+    expect(mockSetLayoutMode).not.toHaveBeenCalled();
   });
 
   it("opens repo-relative local links against the active repo on shift-click", async () => {
@@ -354,7 +380,8 @@ describe("fileLinkNavigation", () => {
       "src/main.ts",
       { line: 12, column: 4 },
     );
-    expect(mockSetLayoutMode).toHaveBeenCalledWith("ws-1", "editor");
+    expect(mockShowSurface).toHaveBeenCalledWith("ws-1", "editor");
+    expect(mockSetLayoutMode).not.toHaveBeenCalled();
   });
 
   it("opens external links through the shell only on shift-click", async () => {

--- a/src/lib/fileLinkNavigation.test.ts
+++ b/src/lib/fileLinkNavigation.test.ts
@@ -223,6 +223,50 @@ describe("fileLinkNavigation", () => {
     });
   });
 
+  it("resolves repo-relative file references against the active repo first", () => {
+    expect(
+      resolveLocalFileLinkTarget("src/main.ts:44:7", {
+        workspaceRoot: "/workspace",
+        repos: [
+          { id: "repo-1", path: "/workspace/apps/app", isActive: true },
+          { id: "repo-2", path: "/workspace/apps/app/packages/web", isActive: true },
+        ],
+        activeRepoId: "repo-1",
+      }),
+    ).toMatchObject({
+      rootPath: "/workspace/apps/app",
+      filePath: "src/main.ts",
+      absolutePath: "/workspace/apps/app/src/main.ts",
+      line: 44,
+      column: 7,
+    });
+
+    expect(
+      resolveLocalFileLinkTarget("./README.md#L12", {
+        workspaceRoot: "/workspace",
+        repos: [{ id: "repo-1", path: "/workspace/apps/app", isActive: true }],
+        activeRepoId: "repo-1",
+      }),
+    ).toMatchObject({
+      rootPath: "/workspace/apps/app",
+      filePath: "README.md",
+      absolutePath: "/workspace/apps/app/README.md",
+      line: 12,
+    });
+
+    expect(
+      resolveLocalFileLinkTarget(".gitignore", {
+        workspaceRoot: "/workspace",
+        repos: [{ id: "repo-1", path: "/workspace/apps/app", isActive: true }],
+        activeRepoId: "repo-1",
+      }),
+    ).toMatchObject({
+      rootPath: "/workspace/apps/app",
+      filePath: ".gitignore",
+      absolutePath: "/workspace/apps/app/.gitignore",
+    });
+  });
+
   it("rejects paths outside the active workspace and classifies external URLs", () => {
     expect(
       resolveLocalFileLinkTarget("/other/place/file.ts#L1", {
@@ -233,10 +277,11 @@ describe("fileLinkNavigation", () => {
 
     expect(classifyLinkTarget("https://example.com")).toBe("external");
     expect(classifyLinkTarget("/workspace/apps/app/src/main.ts#L1")).toBe("local");
+    expect(classifyLinkTarget("src/main.ts#L1")).toBe("local");
     expect(classifyLinkTarget("#heading")).toBe("other");
   });
 
-  it("extracts plain-text terminal links for absolute paths, hashes and URLs", () => {
+  it("extracts plain-text terminal links for absolute paths, relative paths, hashes and URLs", () => {
     expect(
       extractTextLinkMatches("- /workspace/apps/app/src/main.ts:44:7"),
     ).toEqual([
@@ -265,7 +310,18 @@ describe("fileLinkNavigation", () => {
       },
     ]);
 
-    expect(extractTextLinkMatches("relative src/App.tsx should stay plain")).toEqual([]);
+    expect(
+      extractTextLinkMatches("relative src/App.tsx should now link"),
+    ).toEqual([
+      {
+        text: "src/App.tsx",
+        startIndex: 9,
+        endIndex: 20,
+        kind: "local",
+      },
+    ]);
+
+    expect(extractTextLinkMatches("ignore example.com and version 1.2.3")).toEqual([]);
   });
 
   it("opens local links internally only on shift-click", async () => {
@@ -278,6 +334,19 @@ describe("fileLinkNavigation", () => {
 
     await expect(
       navigateLinkTarget("/workspace/apps/app/src/main.ts#L12C4", { shiftKey: true }),
+    ).resolves.toBe("internal");
+
+    expect(mockOpenFileAtLocation).toHaveBeenCalledWith(
+      "/workspace/apps/app",
+      "src/main.ts",
+      { line: 12, column: 4 },
+    );
+    expect(mockSetLayoutMode).toHaveBeenCalledWith("ws-1", "editor");
+  });
+
+  it("opens repo-relative local links against the active repo on shift-click", async () => {
+    await expect(
+      navigateLinkTarget("src/main.ts:12:4", { shiftKey: true }),
     ).resolves.toBe("internal");
 
     expect(mockOpenFileAtLocation).toHaveBeenCalledWith(

--- a/src/lib/fileLinkNavigation.ts
+++ b/src/lib/fileLinkNavigation.ts
@@ -16,7 +16,7 @@ import {
 } from "./localFileLinkPatterns";
 import { useFileStore } from "../stores/fileStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
-import { showWorkspaceSurface } from "./workspacePaneNavigation";
+import { showWorkspaceEditorForFileLink } from "./workspacePaneNavigation";
 import type { Repo } from "../types";
 
 const EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
@@ -175,9 +175,24 @@ export function resolveLocalFileLinkTarget(
   return null;
 }
 
+export interface LinkNavigationOptions {
+  shiftKey: boolean;
+  sourceLeafId?: string | null;
+}
+
+export function getWorkspacePaneLeafIdFromEventTarget(target: EventTarget | null): string | null {
+  const element = target instanceof Element
+    ? target
+    : target instanceof Node
+      ? target.parentElement
+      : null;
+  const leaf = element?.closest("[data-workspace-pane-leaf-id]");
+  return leaf instanceof HTMLElement ? leaf.dataset.workspacePaneLeafId ?? null : null;
+}
+
 export async function navigateLinkTarget(
   rawTarget: string,
-  options: { shiftKey: boolean },
+  options: LinkNavigationOptions,
 ): Promise<LinkNavigationResult> {
   if (!options.shiftKey) {
     return "ignored";
@@ -211,7 +226,7 @@ export async function navigateLinkTarget(
       .openFileAtLocation(localTarget.rootPath, localTarget.filePath, reveal);
 
     if (activeWorkspaceId) {
-      showWorkspaceSurface(activeWorkspaceId, "editor");
+      showWorkspaceEditorForFileLink(activeWorkspaceId, options.sourceLeafId ?? null);
     }
 
     return "internal";

--- a/src/lib/fileLinkNavigation.ts
+++ b/src/lib/fileLinkNavigation.ts
@@ -4,16 +4,27 @@ import {
   isWithinRoot,
   normalizeAbsolutePath,
 } from "./fileRootUtils";
+import {
+  DISALLOWED_LOCAL_PREFIX_CHAR_RE,
+  TEXT_LINK_PATTERN,
+  isLocalFileLinkSyntax,
+  parseLocalAbsolutePathTarget,
+  parseLocalRelativePathTarget,
+  parseLocalUrlTarget,
+  trimLinkText,
+  tryParseUrl,
+} from "./localFileLinkPatterns";
 import { useFileStore } from "../stores/fileStore";
 import { useTerminalStore } from "../stores/terminalStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
-import type { EditorRevealLocation, Repo } from "../types";
+import type { Repo } from "../types";
 
 const EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+type LinkRepoRoot = Pick<Repo, "id" | "path"> & Partial<Pick<Repo, "isActive">>;
 
 export interface LinkResolutionContext {
   workspaceRoot: string | null;
-  repos: Pick<Repo, "id" | "path">[];
+  repos: LinkRepoRoot[];
   activeRepoId?: string | null;
 }
 
@@ -35,133 +46,8 @@ export interface TextLinkMatch {
 export type LinkTargetKind = "local" | "external" | "other";
 export type LinkNavigationResult = "internal" | "external" | "ignored";
 
-const TEXT_LINK_PATTERN = /file:\/\/\/[^\s<>"'`]+|(?:https?:\/\/|mailto:|tel:)[^\s<>"'`]+|(?:\/(?!\/)|[A-Za-z]:[\\/]|\\\\)[^\s<>"'`]+/g;
-const TRAILING_LINK_PUNCTUATION_RE = /[),.;!?]+$/;
-const DISALLOWED_LOCAL_PREFIX_CHAR_RE = /[A-Za-z0-9._~/-]/;
-
-function hasUrlScheme(value: string): boolean {
-  return /^[A-Za-z][A-Za-z\d+.-]*:/.test(value);
-}
-
-function tryParseUrl(value: string): URL | null {
-  if (!hasUrlScheme(value)) {
-    return null;
-  }
-
-  try {
-    return new URL(value);
-  } catch {
-    return null;
-  }
-}
-
-function isWindowsDrivePath(path: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(path);
-}
-
-function isLocalAbsolutePath(path: string): boolean {
-  return (path.startsWith("/") && !path.startsWith("//")) || isWindowsDrivePath(path) || /^\\\\/.test(path);
-}
-
-function stripLocationSuffix(path: string): {
-  path: string;
-  reveal: EditorRevealLocation | null;
-} {
-  const lastSegmentMatch = /:(\d+)$/.exec(path);
-  if (!lastSegmentMatch) {
-    return { path, reveal: null };
-  }
-
-  const withoutLastSegment = path.slice(0, -lastSegmentMatch[0].length);
-  const lineAndColumnMatch = /:(\d+)$/.exec(withoutLastSegment);
-  if (lineAndColumnMatch) {
-    const candidatePath = withoutLastSegment.slice(0, -lineAndColumnMatch[0].length);
-    if (isLocalAbsolutePath(candidatePath)) {
-      return {
-        path: candidatePath,
-        reveal: {
-          line: Number(lineAndColumnMatch[1]),
-          column: Number(lastSegmentMatch[1]),
-        },
-      };
-    }
-  }
-
-  if (!isLocalAbsolutePath(withoutLastSegment)) {
-    return { path, reveal: null };
-  }
-
-  return {
-    path: withoutLastSegment,
-    reveal: {
-      line: Number(lastSegmentMatch[1]),
-      column: undefined,
-    },
-  };
-}
-
-function parseHashReveal(hash: string): EditorRevealLocation | null {
-  const normalized = hash.replace(/^#/, "");
-  const match = /^L(\d+)(?:C(\d+))?(?:[-:].*)?$/i.exec(normalized);
-  if (!match) {
-    return null;
-  }
-  return {
-    line: Number(match[1]),
-    column: match[2] ? Number(match[2]) : undefined,
-  };
-}
-
-function parseLocalAbsolutePathTarget(rawTarget: string): {
-  absolutePath: string;
-  reveal: EditorRevealLocation | null;
-} | null {
-  if (!isLocalAbsolutePath(rawTarget)) {
-    return null;
-  }
-
-  const hashIndex = rawTarget.indexOf("#");
-  const basePath = hashIndex >= 0 ? rawTarget.slice(0, hashIndex) : rawTarget;
-  const hash = hashIndex >= 0 ? rawTarget.slice(hashIndex) : "";
-  const { path, reveal } = stripLocationSuffix(basePath);
-
-  return {
-    absolutePath: normalizeAbsolutePath(path),
-    reveal: parseHashReveal(hash) ?? reveal,
-  };
-}
-
-function parseLocalUrlTarget(rawTarget: string): {
-  absolutePath: string;
-  reveal: EditorRevealLocation | null;
-} | null {
-  const url = tryParseUrl(rawTarget);
-  if (!url) {
-    return null;
-  }
-
-  if (url.protocol === "file:" || url.hostname === "file") {
-    let decodedPath: string;
-    try {
-      decodedPath = decodeURIComponent(url.pathname);
-    } catch {
-      return null;
-    }
-    const { path, reveal } = stripLocationSuffix(decodedPath);
-    if (!isLocalAbsolutePath(path) && !/^\/[A-Za-z]:\//.test(path)) {
-      return null;
-    }
-    return {
-      absolutePath: normalizeAbsolutePath(path),
-      reveal: parseHashReveal(url.hash) ?? reveal,
-    };
-  }
-
-  return null;
-}
-
 export function classifyLinkTarget(rawTarget: string): LinkTargetKind {
-  if (parseLocalAbsolutePathTarget(rawTarget) || parseLocalUrlTarget(rawTarget)) {
+  if (isLocalFileLinkSyntax(rawTarget)) {
     return "local";
   }
 
@@ -178,7 +64,7 @@ export function extractTextLinkMatches(text: string): TextLinkMatch[] {
   for (const match of text.matchAll(TEXT_LINK_PATTERN)) {
     const rawText = match[0];
     const startIndex = match.index ?? 0;
-    const trimmedText = rawText.replace(TRAILING_LINK_PUNCTUATION_RE, "");
+    const trimmedText = trimLinkText(rawText);
     if (!trimmedText) {
       continue;
     }
@@ -205,42 +91,88 @@ export function extractTextLinkMatches(text: string): TextLinkMatch[] {
   return matches;
 }
 
+function getOrderedRelativeRoots(context: LinkResolutionContext): string[] {
+  const repos = context.repos.slice();
+  const activeRepo = context.activeRepoId
+    ? repos.find((repo) => repo.id === context.activeRepoId) ?? null
+    : null;
+  const activeRepos = repos
+    .filter((repo) => repo.id !== activeRepo?.id && repo.isActive)
+    .sort((left, right) => compareRepoRoots(left, right, null));
+  const remainingRepos = repos
+    .filter((repo) => repo.id !== activeRepo?.id && !repo.isActive)
+    .sort((left, right) => compareRepoRoots(left, right, null));
+  const roots = [
+    ...(activeRepo ? [activeRepo] : []),
+    ...activeRepos,
+    ...remainingRepos,
+  ].map((repo) => normalizeAbsolutePath(repo.path));
+
+  if (context.workspaceRoot) {
+    roots.push(normalizeAbsolutePath(context.workspaceRoot));
+  }
+
+  return [...new Set(roots)];
+}
+
 export function resolveLocalFileLinkTarget(
   rawTarget: string,
   context: LinkResolutionContext,
 ): ResolvedLocalFileLink | null {
-  const localTarget = parseLocalAbsolutePathTarget(rawTarget) ?? parseLocalUrlTarget(rawTarget);
-  if (!localTarget) {
-    return null;
-  }
+  const absoluteTarget = parseLocalAbsolutePathTarget(rawTarget) ?? parseLocalUrlTarget(rawTarget);
 
   const workspaceRoot = context.workspaceRoot ? normalizeAbsolutePath(context.workspaceRoot) : null;
-  const candidateRoots = context.repos
-    .slice()
-    .sort((left, right) => compareRepoRoots(left, right, context.activeRepoId))
-    .map((repo) => normalizeAbsolutePath(repo.path));
+  if (absoluteTarget) {
+    const candidateRoots = context.repos
+      .slice()
+      .sort((left, right) => compareRepoRoots(left, right, context.activeRepoId))
+      .map((repo) => normalizeAbsolutePath(repo.path));
 
-  if (workspaceRoot) {
-    candidateRoots.push(workspaceRoot);
+    if (workspaceRoot) {
+      candidateRoots.push(workspaceRoot);
+    }
+
+    const absolutePath = normalizeAbsolutePath(absoluteTarget.path);
+    const matchedRoot = candidateRoots.find((root) => isWithinRoot(absolutePath, root));
+    if (!matchedRoot) {
+      return null;
+    }
+
+    const relativePath = absolutePath.slice(matchedRoot.length).replace(/^\/+/, "");
+    if (!relativePath) {
+      return null;
+    }
+
+    return {
+      rootPath: matchedRoot,
+      filePath: relativePath,
+      absolutePath,
+      line: absoluteTarget.reveal?.line,
+      column: absoluteTarget.reveal?.column ?? undefined,
+    };
   }
 
-  const matchedRoot = candidateRoots.find((root) => isWithinRoot(localTarget.absolutePath, root));
-  if (!matchedRoot) {
+  const relativeTarget = parseLocalRelativePathTarget(rawTarget);
+  if (!relativeTarget) {
     return null;
   }
 
-  const relativePath = localTarget.absolutePath.slice(matchedRoot.length).replace(/^\/+/, "");
-  if (!relativePath) {
-    return null;
+  for (const root of getOrderedRelativeRoots(context)) {
+    const absolutePath = normalizeAbsolutePath(`${root}/${relativeTarget.path}`);
+    if (!isWithinRoot(absolutePath, root)) {
+      continue;
+    }
+
+    return {
+      rootPath: root,
+      filePath: relativeTarget.path,
+      absolutePath,
+      line: relativeTarget.reveal?.line,
+      column: relativeTarget.reveal?.column ?? undefined,
+    };
   }
 
-  return {
-    rootPath: matchedRoot,
-    filePath: relativePath,
-    absolutePath: localTarget.absolutePath,
-    line: localTarget.reveal?.line,
-    column: localTarget.reveal?.column ?? undefined,
-  };
+  return null;
 }
 
 export async function navigateLinkTarget(

--- a/src/lib/fileLinkNavigation.ts
+++ b/src/lib/fileLinkNavigation.ts
@@ -15,8 +15,8 @@ import {
   tryParseUrl,
 } from "./localFileLinkPatterns";
 import { useFileStore } from "../stores/fileStore";
-import { useTerminalStore } from "../stores/terminalStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
+import { showWorkspaceSurface } from "./workspacePaneNavigation";
 import type { Repo } from "../types";
 
 const EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
@@ -211,7 +211,7 @@ export async function navigateLinkTarget(
       .openFileAtLocation(localTarget.rootPath, localTarget.filePath, reveal);
 
     if (activeWorkspaceId) {
-      await useTerminalStore.getState().setLayoutMode(activeWorkspaceId, "editor");
+      showWorkspaceSurface(activeWorkspaceId, "editor");
     }
 
     return "internal";

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -51,7 +51,7 @@ import type {
   TerminalForegroundChangedEvent,
   TerminalNotificationIntegrationId,
   TerminalNotificationSettings,
-  TerminalOutputEvent,
+  TerminalOutputReadyEvent,
   TerminalRendererDiagnostics,
   TerminalResumeSession,
   TerminalSession,
@@ -497,6 +497,18 @@ export const ipc = {
       sessionId,
       fromSeq: fromSeq ?? null,
     }),
+  terminalDrainOutput: (
+    workspaceId: string,
+    sessionId: string,
+    fromSeq: number | null,
+    targetBytes: number,
+  ) =>
+    invoke<TerminalResumeSession>("terminal_drain_output", {
+      workspaceId,
+      sessionId,
+      fromSeq,
+      targetBytes,
+    }),
   terminalListNotifications: (workspaceId: string) =>
     invoke<TerminalNotification[]>("terminal_list_notifications", { workspaceId }),
   terminalClearNotification: (workspaceId: string, sessionId?: string | null) =>
@@ -585,9 +597,9 @@ export async function listenMenuAction(
 
 export async function listenTerminalOutput(
   workspaceId: string,
-  onEvent: (event: TerminalOutputEvent) => void
+  onEvent: (event: TerminalOutputReadyEvent) => void
 ): Promise<UnlistenFn> {
-  return listen<TerminalOutputEvent>(
+  return listen<TerminalOutputReadyEvent>(
     `terminal-output-${workspaceId}`,
     ({ payload }) => onEvent(payload)
   );
@@ -671,7 +683,7 @@ export async function writeCommandToNewSession(
 
     const fallbackTimer = setTimeout(doWrite, FALLBACK_TIMEOUT_MS);
 
-    listen<TerminalOutputEvent>(
+    listen<TerminalOutputReadyEvent>(
       `terminal-output-${workspaceId}`,
       ({ payload }) => {
         if (settled || payload.sessionId !== sessionId) return;

--- a/src/lib/localFileLinkPatterns.ts
+++ b/src/lib/localFileLinkPatterns.ts
@@ -1,0 +1,296 @@
+import type { EditorRevealLocation } from "../types";
+
+export interface ParsedLocalPathTarget {
+  path: string;
+  reveal: EditorRevealLocation | null;
+}
+
+const KNOWN_ROOT_FILE_EXTENSIONS = new Set([
+  "astro",
+  "bash",
+  "c",
+  "cfg",
+  "conf",
+  "cpp",
+  "cs",
+  "css",
+  "csv",
+  "cts",
+  "cxx",
+  "dockerfile",
+  "env",
+  "fish",
+  "go",
+  "h",
+  "hpp",
+  "htm",
+  "html",
+  "ini",
+  "java",
+  "js",
+  "json",
+  "jsx",
+  "kt",
+  "less",
+  "lock",
+  "lua",
+  "m",
+  "md",
+  "mdx",
+  "mjs",
+  "mm",
+  "mts",
+  "php",
+  "plist",
+  "prisma",
+  "properties",
+  "py",
+  "rb",
+  "rs",
+  "sass",
+  "scss",
+  "sh",
+  "sql",
+  "svelte",
+  "swift",
+  "toml",
+  "ts",
+  "tsx",
+  "txt",
+  "vue",
+  "xml",
+  "yaml",
+  "yml",
+  "zsh",
+]);
+
+const KNOWN_EXTENSIONLESS_FILENAMES = new Set([
+  ".dockerignore",
+  ".editorconfig",
+  ".eslintignore",
+  ".eslintrc",
+  ".gitattributes",
+  ".gitignore",
+  ".node-version",
+  ".npmrc",
+  ".nvmrc",
+  ".prettierignore",
+  ".prettierrc",
+  ".python-version",
+  ".ruby-version",
+  "AGENTS",
+  "CHANGELOG",
+  "Dockerfile",
+  "LICENSE",
+  "Makefile",
+  "NOTICE",
+  "README",
+]);
+
+export const TEXT_LINK_PATTERN = /file:\/\/\/[^\s<>"'`]+|(?:https?:\/\/|mailto:|tel:)[^\s<>"'`]+|(?:\/(?!\/)|[A-Za-z]:[\\/]|\\\\)[^\s<>"'`]+|(?:\.\/)?[A-Za-z0-9._~@%+=-][A-Za-z0-9._~@%+=/\\-]*(?::\d+(?::\d+)?)?(?:#L\d+(?:C\d+)?)?/gi;
+export const TRAILING_LINK_PUNCTUATION_RE = /[\]),.;!?]+$/;
+export const DISALLOWED_LOCAL_PREFIX_CHAR_RE = /[A-Za-z0-9._~@/-]/;
+
+export function hasUrlScheme(value: string): boolean {
+  return /^[A-Za-z][A-Za-z\d+.-]*:/.test(value);
+}
+
+export function tryParseUrl(value: string): URL | null {
+  if (!hasUrlScheme(value)) {
+    return null;
+  }
+
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+export function isWindowsDrivePath(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path);
+}
+
+export function isLocalAbsolutePath(path: string): boolean {
+  return (path.startsWith("/") && !path.startsWith("//")) || isWindowsDrivePath(path) || /^\\\\/.test(path);
+}
+
+export function trimLinkText(value: string): string {
+  return value.replace(TRAILING_LINK_PUNCTUATION_RE, "");
+}
+
+export function parseHashReveal(hash: string): EditorRevealLocation | null {
+  const normalized = hash.replace(/^#/, "");
+  const match = /^L(\d+)(?:C(\d+))?(?:[-:].*)?$/i.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  return {
+    line: Number(match[1]),
+    column: match[2] ? Number(match[2]) : undefined,
+  };
+}
+
+function stripLocationSuffix(
+  path: string,
+  isPathCandidate: (candidate: string) => boolean,
+): ParsedLocalPathTarget {
+  const lastSegmentMatch = /:(\d+)$/.exec(path);
+  if (!lastSegmentMatch) {
+    return { path, reveal: null };
+  }
+
+  const withoutLastSegment = path.slice(0, -lastSegmentMatch[0].length);
+  const lineAndColumnMatch = /:(\d+)$/.exec(withoutLastSegment);
+  if (lineAndColumnMatch) {
+    const candidatePath = withoutLastSegment.slice(0, -lineAndColumnMatch[0].length);
+    if (isPathCandidate(candidatePath)) {
+      return {
+        path: candidatePath,
+        reveal: {
+          line: Number(lineAndColumnMatch[1]),
+          column: Number(lastSegmentMatch[1]),
+        },
+      };
+    }
+  }
+
+  if (!isPathCandidate(withoutLastSegment)) {
+    return { path, reveal: null };
+  }
+
+  return {
+    path: withoutLastSegment,
+    reveal: {
+      line: Number(lastSegmentMatch[1]),
+      column: undefined,
+    },
+  };
+}
+
+export function parseLocalAbsolutePathTarget(rawTarget: string): ParsedLocalPathTarget | null {
+  if (!isLocalAbsolutePath(rawTarget)) {
+    return null;
+  }
+
+  const hashIndex = rawTarget.indexOf("#");
+  const basePath = hashIndex >= 0 ? rawTarget.slice(0, hashIndex) : rawTarget;
+  const hash = hashIndex >= 0 ? rawTarget.slice(hashIndex) : "";
+  const parsed = stripLocationSuffix(basePath, isLocalAbsolutePath);
+
+  return {
+    path: parsed.path,
+    reveal: parseHashReveal(hash) ?? parsed.reveal,
+  };
+}
+
+export function parseLocalUrlTarget(rawTarget: string): ParsedLocalPathTarget | null {
+  const url = tryParseUrl(rawTarget);
+  if (!url) {
+    return null;
+  }
+
+  if (url.protocol === "file:" || url.hostname === "file") {
+    let decodedPath: string;
+    try {
+      decodedPath = decodeURIComponent(url.pathname);
+    } catch {
+      return null;
+    }
+    const parsed = stripLocationSuffix(decodedPath, (path) =>
+      isLocalAbsolutePath(path) || /^\/[A-Za-z]:\//.test(path),
+    );
+    if (!isLocalAbsolutePath(parsed.path) && !/^\/[A-Za-z]:\//.test(parsed.path)) {
+      return null;
+    }
+    return {
+      path: parsed.path,
+      reveal: parseHashReveal(url.hash) ?? parsed.reveal,
+    };
+  }
+
+  return null;
+}
+
+function basenameForPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized.split("/").pop() ?? normalized;
+}
+
+function hasDirectorySegment(path: string): boolean {
+  return path.replace(/\\/g, "/").includes("/");
+}
+
+function isLikelyFileName(fileName: string, hasDirectory: boolean): boolean {
+  if (!fileName || fileName === "." || fileName === "..") {
+    return false;
+  }
+  if (KNOWN_EXTENSIONLESS_FILENAMES.has(fileName) || /^\.env(?:\.|$)/.test(fileName)) {
+    return true;
+  }
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex <= 0 || dotIndex === fileName.length - 1) {
+    return false;
+  }
+  const extension = fileName.slice(dotIndex + 1).toLowerCase();
+  return hasDirectory || KNOWN_ROOT_FILE_EXTENSIONS.has(extension);
+}
+
+function normalizeRelativePath(path: string): string | null {
+  if (!path || hasUrlScheme(path) || isLocalAbsolutePath(path) || path.startsWith("#")) {
+    return null;
+  }
+
+  let normalized = path.replace(/\\/g, "/").replace(/^\.\/+/, "");
+  if (!normalized || normalized.startsWith("../") || normalized === "..") {
+    return null;
+  }
+
+  normalized = normalized.replace(/\/+/g, "/").replace(/\/+$/, "");
+  const segments = normalized.split("/");
+  if (
+    segments.some((segment) => (
+      segment.length === 0 ||
+      segment === "." ||
+      segment === ".." ||
+      segment.includes(":")
+    ))
+  ) {
+    return null;
+  }
+
+  const fileName = basenameForPath(normalized);
+  if (!isLikelyFileName(fileName, hasDirectorySegment(normalized))) {
+    return null;
+  }
+
+  return normalized;
+}
+
+export function parseLocalRelativePathTarget(rawTarget: string): ParsedLocalPathTarget | null {
+  if (!rawTarget || rawTarget.startsWith("//")) {
+    return null;
+  }
+
+  const hashIndex = rawTarget.indexOf("#");
+  const basePath = hashIndex >= 0 ? rawTarget.slice(0, hashIndex) : rawTarget;
+  const hash = hashIndex >= 0 ? rawTarget.slice(hashIndex) : "";
+  const parsed = stripLocationSuffix(basePath, (path) => normalizeRelativePath(path) !== null);
+  const normalizedPath = normalizeRelativePath(parsed.path);
+  if (!normalizedPath) {
+    return null;
+  }
+
+  return {
+    path: normalizedPath,
+    reveal: parseHashReveal(hash) ?? parsed.reveal,
+  };
+}
+
+export function isLocalFileLinkSyntax(rawTarget: string): boolean {
+  return Boolean(
+    parseLocalAbsolutePathTarget(rawTarget) ||
+      parseLocalUrlTarget(rawTarget) ||
+      parseLocalRelativePathTarget(rawTarget),
+  );
+}

--- a/src/lib/newThreadActions.ts
+++ b/src/lib/newThreadActions.ts
@@ -5,6 +5,10 @@ import { useThreadStore } from "../stores/threadStore";
 import { useUiStore } from "../stores/uiStore";
 import { useWorkspaceStore } from "../stores/workspaceStore";
 import { resolveNewThreadTargetLayoutMode } from "./newThreadLayout";
+import {
+  applyWorkspaceLayoutMode,
+  getWorkspacePaneLayoutMode,
+} from "./workspacePaneNavigation";
 
 export async function createAndActivateWorkspaceThread(
   workspaceId: string | null | undefined,
@@ -17,6 +21,7 @@ export async function createAndActivateWorkspaceThread(
   const activeWorkspaceId = workspaceStore.activeWorkspaceId;
   const terminalStore = useTerminalStore.getState();
   const currentLayoutMode =
+    (activeWorkspaceId ? getWorkspacePaneLayoutMode(activeWorkspaceId) : null) ??
     (activeWorkspaceId
       ? terminalStore.workspaces[activeWorkspaceId]?.layoutMode
       : terminalStore.workspaces[workspaceId]?.layoutMode) ?? null;
@@ -28,7 +33,7 @@ export async function createAndActivateWorkspaceThread(
     await workspaceStore.setActiveWorkspace(workspaceId);
   }
 
-  await terminalStore.setLayoutMode(workspaceId, targetLayoutMode);
+  applyWorkspaceLayoutMode(workspaceId, targetLayoutMode);
   useWorkspaceStore.getState().setActiveRepo(null, { remember: false });
 
   const threadId = await useThreadStore.getState().createThread({

--- a/src/lib/workspacePaneNavigation.test.ts
+++ b/src/lib/workspacePaneNavigation.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockSetLayoutMode = vi.hoisted(() => vi.fn());
+const terminalWorkspaces = vi.hoisted(() => (
+  {} as Record<string, { layoutMode: string }>
+));
+
+vi.mock("../stores/terminalStore", () => ({
+  useTerminalStore: {
+    getState: () => ({
+      workspaces: terminalWorkspaces,
+      setLayoutMode: mockSetLayoutMode,
+    }),
+  },
+}));
+
+import {
+  collectWorkspacePaneLeaves,
+  getWorkspacePaneActiveTab,
+  useWorkspacePaneStore,
+} from "../stores/workspacePaneStore";
+import { useUiStore } from "../stores/uiStore";
+import { showWorkspaceEditorForFileLink } from "./workspacePaneNavigation";
+
+describe("showWorkspaceEditorForFileLink", () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => storage.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        storage.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        storage.delete(key);
+      }),
+      clear: vi.fn(() => {
+        storage.clear();
+      }),
+      key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+      get length() {
+        return storage.size;
+      },
+    });
+    useWorkspacePaneStore.setState({ workspaces: {} });
+    useUiStore.setState({ activeView: "harnesses" });
+    mockSetLayoutMode.mockClear();
+    for (const key of Object.keys(terminalWorkspaces)) {
+      delete terminalWorkspaces[key];
+    }
+  });
+
+  it("opens an editor split next to a chat-only focused pane", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "chat");
+    const sourceLeaf = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0];
+
+    showWorkspaceEditorForFileLink("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(layout.root.type).toBe("split");
+    expect(layout.root.type === "split" ? layout.root.direction : null).toBe("vertical");
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "chat",
+      "editor",
+    ]);
+    expect(leaves[0].id).toBe(sourceLeaf.id);
+    expect(layout.focusedLeafId).toBe(leaves[1].id);
+    expect(useUiStore.getState().activeView).toBe("chat");
+    expect(mockSetLayoutMode).toHaveBeenCalledWith("ws-1", "editor");
+  });
+
+  it("opens an editor split next to a terminal-only focused pane", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "terminal");
+
+    showWorkspaceEditorForFileLink("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(layout.root.type).toBe("split");
+    expect(layout.root.type === "split" ? layout.root.direction : null).toBe("vertical");
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "terminal",
+      "editor",
+    ]);
+    expect(mockSetLayoutMode).toHaveBeenCalledWith("ws-1", "split");
+  });
+
+  it("opens an editor split from the source pane when focus is elsewhere", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "split");
+    const leaves = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    );
+    const chatLeaf = leaves.find((leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "chat");
+    const terminalLeaf = leaves.find((leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "terminal");
+    if (!chatLeaf || !terminalLeaf) {
+      throw new Error("expected chat and terminal leaves");
+    }
+    useWorkspacePaneStore.getState().focusLeaf("ws-1", chatLeaf.id);
+
+    showWorkspaceEditorForFileLink("ws-1", terminalLeaf.id);
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const nextLeaves = collectWorkspacePaneLeaves(layout.root);
+    expect(nextLeaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "chat",
+      "terminal",
+      "editor",
+    ]);
+    expect(nextLeaves[1].id).toBe(terminalLeaf.id);
+    expect(layout.focusedLeafId).toBe(nextLeaves[2].id);
+  });
+
+  it("materializes a missing terminal layout before opening the editor split", () => {
+    terminalWorkspaces["ws-1"] = { layoutMode: "terminal" };
+
+    showWorkspaceEditorForFileLink("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "terminal",
+      "editor",
+    ]);
+  });
+
+  it("moves a hidden editor tab into a split instead of flipping the terminal pane", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "terminal");
+    const sourceLeaf = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0];
+    useWorkspacePaneStore.getState().showSurface("ws-1", "editor", sourceLeaf.id);
+    const terminalTab = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0].tabs.find((tab) => tab.kind === "terminal");
+    if (!terminalTab) {
+      throw new Error("expected terminal tab");
+    }
+    useWorkspacePaneStore.getState().setActiveTab("ws-1", sourceLeaf.id, terminalTab.id);
+
+    showWorkspaceEditorForFileLink("ws-1", sourceLeaf.id);
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "terminal",
+      "editor",
+    ]);
+    expect(leaves[0].id).toBe(sourceLeaf.id);
+  });
+
+  it("uses an already visible editor instead of moving the source pane", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "chat");
+    const sourceLeaf = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0];
+    useWorkspacePaneStore.getState().splitLeaf("ws-1", sourceLeaf.id, "vertical", "editor");
+    const splitLeaves = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    );
+    const chatLeaf = splitLeaves.find((leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "chat");
+    const editorLeaf = splitLeaves.find((leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "editor");
+    if (!chatLeaf || !editorLeaf) {
+      throw new Error("expected chat and editor leaves");
+    }
+    useWorkspacePaneStore.getState().focusLeaf("ws-1", chatLeaf.id);
+
+    showWorkspaceEditorForFileLink("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "chat",
+      "editor",
+    ]);
+    expect(layout.focusedLeafId).toBe(editorLeaf.id);
+  });
+});

--- a/src/lib/workspacePaneNavigation.ts
+++ b/src/lib/workspacePaneNavigation.ts
@@ -35,6 +35,56 @@ export function showWorkspaceSurface(
   syncTerminalLayoutMode(workspaceId);
 }
 
+export function showWorkspaceEditorForFileLink(
+  workspaceId: string,
+  sourceLeafId?: string | null,
+): void {
+  useUiStore.getState().setActiveView("chat");
+
+  let paneStore = useWorkspacePaneStore.getState();
+  let layout = paneStore.workspaces[workspaceId];
+  if (!layout) {
+    const terminalMode = useTerminalStore.getState().workspaces[workspaceId]?.layoutMode ?? "chat";
+    paneStore.ensureWorkspace(workspaceId, terminalMode);
+    paneStore = useWorkspacePaneStore.getState();
+    layout = paneStore.workspaces[workspaceId];
+    if (!layout) {
+      paneStore.showSurface(workspaceId, "editor");
+      syncTerminalLayoutMode(workspaceId);
+      return;
+    }
+  }
+
+  const leaves = collectWorkspacePaneLeaves(layout.root);
+  const targetLeaf =
+    (sourceLeafId ? leaves.find((leaf) => leaf.id === sourceLeafId) : null) ??
+    leaves.find((leaf) => leaf.id === layout.focusedLeafId) ??
+    leaves[0] ??
+    null;
+  const visibleEditorLeaf = leaves.find(
+    (leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "editor",
+  );
+
+  if (visibleEditorLeaf) {
+    paneStore.focusLeaf(workspaceId, visibleEditorLeaf.id);
+    syncTerminalLayoutMode(workspaceId);
+    return;
+  }
+
+  const targetKind = targetLeaf ? getWorkspacePaneActiveTab(targetLeaf)?.kind ?? null : null;
+  const shouldSplitBesideCurrent =
+    targetLeaf !== null &&
+    (targetKind === "chat" || targetKind === "terminal");
+
+  if (shouldSplitBesideCurrent) {
+    paneStore.splitLeaf(workspaceId, targetLeaf.id, "vertical", "editor", "after");
+  } else {
+    paneStore.showSurface(workspaceId, "editor", targetLeaf?.id ?? null);
+  }
+
+  syncTerminalLayoutMode(workspaceId);
+}
+
 export function applyWorkspaceLayoutMode(workspaceId: string, mode: LayoutMode): void {
   useUiStore.getState().setActiveView("chat");
   useWorkspacePaneStore.getState().applyLegacyLayoutMode(workspaceId, mode);

--- a/src/lib/workspacePaneNavigation.ts
+++ b/src/lib/workspacePaneNavigation.ts
@@ -1,0 +1,78 @@
+import { useTerminalStore, type LayoutMode } from "../stores/terminalStore";
+import { useUiStore } from "../stores/uiStore";
+import {
+  collectWorkspacePaneLeaves,
+  getWorkspacePaneActiveTab,
+  useWorkspacePaneStore,
+  type WorkspacePaneSurfaceKind,
+} from "../stores/workspacePaneStore";
+
+const TERMINAL_CYCLE: LayoutMode[] = ["chat", "split", "terminal"];
+
+function syncTerminalLayoutMode(workspaceId: string): void {
+  const mode = useWorkspacePaneStore.getState().workspaces[workspaceId]?.legacyMode;
+  if (!mode) {
+    return;
+  }
+  const terminalStore = useTerminalStore.getState();
+  if (terminalStore.workspaces[workspaceId]?.layoutMode === mode) {
+    return;
+  }
+  void terminalStore.setLayoutMode(workspaceId, mode);
+}
+
+export function showWorkspaceSurface(
+  workspaceId: string,
+  kind: WorkspacePaneSurfaceKind,
+  leafId?: string | null,
+): void {
+  useUiStore.getState().setActiveView("chat");
+  if (leafId == null) {
+    useWorkspacePaneStore.getState().showSurface(workspaceId, kind);
+  } else {
+    useWorkspacePaneStore.getState().showSurface(workspaceId, kind, leafId);
+  }
+  syncTerminalLayoutMode(workspaceId);
+}
+
+export function applyWorkspaceLayoutMode(workspaceId: string, mode: LayoutMode): void {
+  useUiStore.getState().setActiveView("chat");
+  useWorkspacePaneStore.getState().applyLegacyLayoutMode(workspaceId, mode);
+  syncTerminalLayoutMode(workspaceId);
+}
+
+export function getWorkspacePaneLayoutMode(workspaceId: string): LayoutMode | null {
+  return useWorkspacePaneStore.getState().workspaces[workspaceId]?.legacyMode ?? null;
+}
+
+export function isWorkspaceSurfaceVisible(
+  workspaceId: string,
+  kind: WorkspacePaneSurfaceKind,
+): boolean {
+  const layout = useWorkspacePaneStore.getState().workspaces[workspaceId];
+  if (!layout) {
+    return false;
+  }
+  return collectWorkspacePaneLeaves(layout.root).some(
+    (leaf) => getWorkspacePaneActiveTab(leaf)?.kind === kind,
+  );
+}
+
+export function cycleWorkspaceTerminalLayout(workspaceId: string): void {
+  const paneLayout = useWorkspacePaneStore.getState().workspaces[workspaceId];
+  const terminalLayout = useTerminalStore.getState().workspaces[workspaceId]?.layoutMode ?? "chat";
+  const currentMode = paneLayout?.legacyMode ?? terminalLayout;
+  const currentIndex = TERMINAL_CYCLE.indexOf(currentMode);
+  const nextMode = TERMINAL_CYCLE[(currentIndex + 1) % TERMINAL_CYCLE.length] ?? "chat";
+  applyWorkspaceLayoutMode(workspaceId, nextMode);
+}
+
+export function toggleWorkspaceEditorLayout(workspaceId: string): void {
+  const terminalWorkspace = useTerminalStore.getState().workspaces[workspaceId];
+  const paneLayout = useWorkspacePaneStore.getState().workspaces[workspaceId];
+  const currentMode = paneLayout?.legacyMode ?? terminalWorkspace?.layoutMode ?? "chat";
+  applyWorkspaceLayoutMode(
+    workspaceId,
+    currentMode === "editor" ? terminalWorkspace?.preEditorLayoutMode ?? "chat" : "editor",
+  );
+}

--- a/src/stores/fileStore.test.ts
+++ b/src/stores/fileStore.test.ts
@@ -197,6 +197,30 @@ describe("fileStore", () => {
     });
   });
 
+  it("opens markdown files in preview mode by default", async () => {
+    mockIpc.readFile.mockResolvedValueOnce(makeReadFileResult("# Readme\n"));
+
+    await useFileStore.getState().openFile("/repo", "README.md");
+
+    const tab = useFileStore.getState().tabs[0]!;
+    expect(tab.renderMode).toBe("markdown-preview");
+    expect(tab.pendingReveal).toBeNull();
+    expect(tab.content).toBe("# Readme\n");
+  });
+
+  it("opens markdown files in plain mode when a line reveal is requested", async () => {
+    await useFileStore
+      .getState()
+      .openFileAtLocation("/repo", "README.md", { line: 12, column: 4 });
+
+    const tab = useFileStore.getState().tabs[0]!;
+    expect(tab.renderMode).toBe("plain-editor");
+    expect(tab.pendingReveal).toMatchObject({
+      line: 12,
+      column: 4,
+    });
+  });
+
   it("reuses an existing tab and updates its pending reveal without reloading the file", async () => {
     await useFileStore.getState().openFile("/repo", "src/app.ts");
     const tabId = useFileStore.getState().tabs[0]!.id;

--- a/src/stores/fileStore.ts
+++ b/src/stores/fileStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { ipc } from "../lib/ipc";
+import { isMarkdownPreviewFile } from "../lib/editorFileTypes";
 import {
   isWithinRoot,
   resolveAbsoluteFilePath,
@@ -130,6 +131,30 @@ function toPlainEditorTab(
   };
 }
 
+function defaultOpenRenderMode(
+  filePath: string,
+  pendingReveal: EditorRevealRequest | null,
+): EditorRenderMode {
+  if (!pendingReveal && isMarkdownPreviewFile(filePath)) {
+    return "markdown-preview";
+  }
+  return "plain-editor";
+}
+
+function toOpenedFileTab(
+  tab: EditorTab,
+  pendingReveal: EditorRevealRequest | null,
+  renderMode: EditorRenderMode,
+): EditorTab {
+  return {
+    ...tab,
+    renderMode,
+    gitContext: null,
+    pendingReveal: renderMode === "plain-editor" ? pendingReveal : null,
+    loadError: undefined,
+  };
+}
+
 function toMarkdownPreviewTab(tab: EditorTab): EditorTab {
   return {
     ...tab,
@@ -186,15 +211,17 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
     const resolved = resolveFileContext(rootPath, filePath);
     const existing = get().tabs.find((tab) => tab.absolutePath === resolved.absolutePath);
     const pendingReveal = createRevealRequest(reveal);
+    const renderMode = defaultOpenRenderMode(filePath, pendingReveal);
     if (existing) {
       destroyCachedEditor(`${existing.id}:git-base`);
       destroyCachedEditor(`${existing.id}:git-modified`);
+      const nextRenderMode = existing.isBinary ? "plain-editor" : renderMode;
       set((state) => ({
         activeTabId: existing.id,
         tabs: state.tabs.map((tab) =>
           tab.id === existing.id
             ? {
-                ...toPlainEditorTab(tab, pendingReveal),
+                ...toOpenedFileTab(tab, pendingReveal, nextRenderMode),
                 workspaceId,
                 rootPath,
                 filePath,
@@ -221,7 +248,11 @@ export const useFileStore = create<FileStoreState>((set, get) => ({
         tabs: state.tabs.map((t) =>
           t.id === id
             ? {
-                ...toPlainEditorTab(t, pendingReveal),
+                ...toOpenedFileTab(
+                  t,
+                  pendingReveal,
+                  result.isBinary ? "plain-editor" : renderMode,
+                ),
                 content: result.content,
                 savedContent: result.content,
                 isBinary: result.isBinary,

--- a/src/stores/workspacePaneStore.test.ts
+++ b/src/stores/workspacePaneStore.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  collectWorkspacePaneLeaves,
+  getWorkspacePaneActiveTab,
+  useWorkspacePaneStore,
+} from "./workspacePaneStore";
+
+describe("workspacePaneStore", () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => storage.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        storage.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        storage.delete(key);
+      }),
+      clear: vi.fn(() => {
+        storage.clear();
+      }),
+      key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+      get length() {
+        return storage.size;
+      },
+    });
+    useWorkspacePaneStore.setState({ workspaces: {} });
+  });
+
+  it("materializes legacy split mode as chat over terminal", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "split");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    expect(layout.legacyMode).toBe("split");
+    expect(layout.root.type).toBe("split");
+    expect(layout.root.type === "split" ? layout.root.direction : null).toBe("horizontal");
+
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "chat",
+      "terminal",
+    ]);
+  });
+
+  it("splits the focused leaf with the next useful surface", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "chat");
+    const firstLeaf = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0];
+
+    useWorkspacePaneStore.getState().splitLeaf("ws-1", firstLeaf.id, "vertical");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    expect(layout.legacyMode).toBe("split");
+    expect(layout.root.type).toBe("split");
+    expect(layout.root.type === "split" ? layout.root.direction : null).toBe("vertical");
+    expect(collectWorkspacePaneLeaves(layout.root).map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "chat",
+      "terminal",
+    ]);
+  });
+
+  it("places dropped surfaces before the target leaf when requested", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "chat");
+    const firstLeaf = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0];
+
+    useWorkspacePaneStore.getState().splitLeaf("ws-1", firstLeaf.id, "vertical", "editor", "before");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    expect(layout.root.type).toBe("split");
+    expect(collectWorkspacePaneLeaves(layout.root).map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "editor",
+      "chat",
+    ]);
+  });
+
+  it("moves a singleton surface instead of duplicating it", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "split");
+    const leaves = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root);
+
+    useWorkspacePaneStore.getState().showSurface("ws-1", "chat", leaves[1].id);
+
+    const nextLeaves = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root);
+    const chatLeafCount = nextLeaves.filter((leaf) =>
+      leaf.tabs.some((tab) => tab.kind === "chat"),
+    ).length;
+
+    expect(chatLeafCount).toBe(1);
+    expect(nextLeaves).toHaveLength(1);
+    expect(getWorkspacePaneActiveTab(nextLeaves[0])?.kind).toBe("chat");
+    expect(nextLeaves[0].tabs.some((tab) => tab.kind === "terminal")).toBe(true);
+  });
+
+  it("does not leave an empty pane when splitting with an existing surface", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "split");
+    const leaves = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root);
+
+    useWorkspacePaneStore.getState().splitLeaf("ws-1", leaves[0].id, "vertical", "terminal", "before");
+
+    const nextLeaves = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root);
+    expect(nextLeaves).toHaveLength(2);
+    expect(nextLeaves.every((leaf) => leaf.tabs.length > 0)).toBe(true);
+    expect(nextLeaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "terminal",
+      "chat",
+    ]);
+  });
+
+  it("switches only the focused pane when activating a surface from the switcher", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "split");
+    const leaves = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root);
+    useWorkspacePaneStore.getState().focusLeaf("ws-1", leaves[0].id);
+
+    useWorkspacePaneStore.getState().activateFocusedSurface("ws-1", "editor");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const nextLeaves = collectWorkspacePaneLeaves(layout.root);
+    expect(nextLeaves).toHaveLength(2);
+    expect(nextLeaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "editor",
+      "terminal",
+    ]);
+    expect(layout.focusedLeafId).toBe(leaves[0].id);
+  });
+
+  it("swaps surfaces when the requested switcher surface is already in another pane", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "split");
+    const leaves = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root);
+    useWorkspacePaneStore.getState().focusLeaf("ws-1", leaves[0].id);
+
+    useWorkspacePaneStore.getState().activateFocusedSurface("ws-1", "terminal");
+
+    const nextLeaves = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root);
+    expect(nextLeaves).toHaveLength(2);
+    expect(nextLeaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "terminal",
+      "chat",
+    ]);
+  });
+
+  it("collapses the tree when a leaf closes", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "split");
+    const leaves = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root);
+
+    useWorkspacePaneStore.getState().closeLeaf("ws-1", leaves[1].id);
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    expect(layout.root.type).toBe("leaf");
+    if (layout.root.type !== "leaf") {
+      throw new Error("expected leaf root");
+    }
+    expect(getWorkspacePaneActiveTab(layout.root)?.kind).toBe("chat");
+    expect(layout.legacyMode).toBe("chat");
+  });
+
+  it("persists layouts by workspace", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "chat");
+    const leaf = collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root)[0];
+    useWorkspacePaneStore.getState().splitLeaf("ws-1", leaf.id, "vertical", "editor");
+
+    useWorkspacePaneStore.setState({ workspaces: {} });
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "chat");
+
+    const restored = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    expect(restored.root.type).toBe("split");
+    expect(collectWorkspacePaneLeaves(restored.root).map((restoredLeaf) =>
+      getWorkspacePaneActiveTab(restoredLeaf)?.kind,
+    )).toEqual(["chat", "editor"]);
+  });
+});

--- a/src/stores/workspacePaneStore.ts
+++ b/src/stores/workspacePaneStore.ts
@@ -1,0 +1,692 @@
+import { create } from "zustand";
+import type { LayoutMode } from "./terminalStore";
+
+export type WorkspacePaneSurfaceKind = "chat" | "terminal" | "editor";
+export type WorkspacePaneSplitDirection = "horizontal" | "vertical";
+
+export interface WorkspacePaneTab {
+  id: string;
+  kind: WorkspacePaneSurfaceKind;
+}
+
+export interface WorkspacePaneLeaf {
+  type: "leaf";
+  id: string;
+  tabs: WorkspacePaneTab[];
+  activeTabId: string | null;
+}
+
+export interface WorkspacePaneSplit {
+  type: "split";
+  id: string;
+  direction: WorkspacePaneSplitDirection;
+  ratio: number;
+  children: [WorkspacePaneNode, WorkspacePaneNode];
+}
+
+export type WorkspacePaneNode = WorkspacePaneLeaf | WorkspacePaneSplit;
+
+export interface WorkspacePaneLayout {
+  root: WorkspacePaneNode;
+  focusedLeafId: string;
+  legacyMode: LayoutMode;
+}
+
+interface WorkspacePaneState {
+  workspaces: Record<string, WorkspacePaneLayout>;
+  ensureWorkspace: (workspaceId: string, legacyMode?: LayoutMode) => void;
+  applyLegacyLayoutMode: (workspaceId: string, mode: LayoutMode) => void;
+  focusLeaf: (workspaceId: string, leafId: string) => void;
+  setActiveTab: (workspaceId: string, leafId: string, tabId: string) => void;
+  activateSurfaceInLeaf: (
+    workspaceId: string,
+    leafId: string,
+    kind: WorkspacePaneSurfaceKind,
+  ) => void;
+  activateFocusedSurface: (workspaceId: string, kind: WorkspacePaneSurfaceKind) => void;
+  showSurface: (workspaceId: string, kind: WorkspacePaneSurfaceKind, leafId?: string | null) => void;
+  showSingleSurface: (workspaceId: string, kind: WorkspacePaneSurfaceKind) => void;
+  splitLeaf: (
+    workspaceId: string,
+    leafId: string,
+    direction: WorkspacePaneSplitDirection,
+    kind?: WorkspacePaneSurfaceKind | null,
+    position?: "before" | "after",
+  ) => void;
+  splitFocusedLeaf: (
+    workspaceId: string,
+    direction: WorkspacePaneSplitDirection,
+    kind?: WorkspacePaneSurfaceKind | null,
+    position?: "before" | "after",
+  ) => void;
+  closeLeaf: (workspaceId: string, leafId: string) => void;
+  closeTab: (workspaceId: string, leafId: string, tabId: string) => void;
+  updateRatio: (workspaceId: string, containerId: string, ratio: number) => void;
+}
+
+const STORAGE_KEY = (workspaceId: string) => `panes:workspacePaneLayout:${workspaceId}`;
+const DEFAULT_SPLIT_RATIO = 0.66;
+const SURFACE_ORDER: WorkspacePaneSurfaceKind[] = ["chat", "terminal", "editor"];
+
+function makeId(prefix: string): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Math.random().toString(36).slice(2)}`;
+}
+
+function makeTab(kind: WorkspacePaneSurfaceKind): WorkspacePaneTab {
+  return { id: makeId(kind), kind };
+}
+
+function makeLeaf(kind?: WorkspacePaneSurfaceKind | null): WorkspacePaneLeaf {
+  const tab = kind ? makeTab(kind) : null;
+  return {
+    type: "leaf",
+    id: makeId("pane"),
+    tabs: tab ? [tab] : [],
+    activeTabId: tab?.id ?? null,
+  };
+}
+
+function makeSplit(
+  direction: WorkspacePaneSplitDirection,
+  children: [WorkspacePaneNode, WorkspacePaneNode],
+  ratio = DEFAULT_SPLIT_RATIO,
+): WorkspacePaneSplit {
+  return {
+    type: "split",
+    id: makeId("split"),
+    direction,
+    ratio,
+    children,
+  };
+}
+
+export function collectWorkspacePaneLeaves(node: WorkspacePaneNode): WorkspacePaneLeaf[] {
+  if (node.type === "leaf") {
+    return [node];
+  }
+  return [
+    ...collectWorkspacePaneLeaves(node.children[0]),
+    ...collectWorkspacePaneLeaves(node.children[1]),
+  ];
+}
+
+export function getWorkspacePaneActiveTab(leaf: WorkspacePaneLeaf): WorkspacePaneTab | null {
+  return leaf.tabs.find((tab) => tab.id === leaf.activeTabId) ?? leaf.tabs[0] ?? null;
+}
+
+function findLeaf(node: WorkspacePaneNode, leafId: string): WorkspacePaneLeaf | null {
+  if (node.type === "leaf") {
+    return node.id === leafId ? node : null;
+  }
+  return findLeaf(node.children[0], leafId) ?? findLeaf(node.children[1], leafId);
+}
+
+function replaceLeaf(
+  node: WorkspacePaneNode,
+  leafId: string,
+  replacement: WorkspacePaneNode,
+): WorkspacePaneNode {
+  if (node.type === "leaf") {
+    return node.id === leafId ? replacement : node;
+  }
+  return {
+    ...node,
+    children: [
+      replaceLeaf(node.children[0], leafId, replacement),
+      replaceLeaf(node.children[1], leafId, replacement),
+    ],
+  };
+}
+
+function removeLeaf(node: WorkspacePaneNode, leafId: string): WorkspacePaneNode | null {
+  if (node.type === "leaf") {
+    return node.id === leafId ? null : node;
+  }
+
+  const left = removeLeaf(node.children[0], leafId);
+  const right = removeLeaf(node.children[1], leafId);
+  if (!left && !right) {
+    return null;
+  }
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  return { ...node, children: [left, right] };
+}
+
+function pruneEmptyLeaves(node: WorkspacePaneNode): WorkspacePaneNode | null {
+  if (node.type === "leaf") {
+    return node.tabs.length > 0 ? node : null;
+  }
+
+  const left = pruneEmptyLeaves(node.children[0]);
+  const right = pruneEmptyLeaves(node.children[1]);
+  if (!left && !right) {
+    return null;
+  }
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  return { ...node, children: [left, right] };
+}
+
+function updateRatioInTree(
+  node: WorkspacePaneNode,
+  containerId: string,
+  ratio: number,
+): WorkspacePaneNode {
+  if (node.type === "leaf") {
+    return node;
+  }
+  if (node.id === containerId) {
+    return { ...node, ratio };
+  }
+  return {
+    ...node,
+    children: [
+      updateRatioInTree(node.children[0], containerId, ratio),
+      updateRatioInTree(node.children[1], containerId, ratio),
+    ],
+  };
+}
+
+function removeSurfaceKind(
+  node: WorkspacePaneNode,
+  kind: WorkspacePaneSurfaceKind,
+  preserveLeafId?: string,
+): WorkspacePaneNode {
+  if (node.type === "leaf") {
+    if (node.id === preserveLeafId) {
+      return node;
+    }
+    const tabs = node.tabs.filter((tab) => tab.kind !== kind);
+    const activeTabId = tabs.some((tab) => tab.id === node.activeTabId)
+      ? node.activeTabId
+      : tabs[0]?.id ?? null;
+    return { ...node, tabs, activeTabId };
+  }
+  return {
+    ...node,
+    children: [
+      removeSurfaceKind(node.children[0], kind, preserveLeafId),
+      removeSurfaceKind(node.children[1], kind, preserveLeafId),
+    ],
+  };
+}
+
+function addSurfaceToLeaf(
+  node: WorkspacePaneNode,
+  leafId: string,
+  kind: WorkspacePaneSurfaceKind,
+): { root: WorkspacePaneNode; tabId: string | null } {
+  let tabId: string | null = null;
+  const targetHasSurface = findLeaf(node, leafId)?.tabs.some((tab) => tab.kind === kind) ?? false;
+  const withoutExisting =
+    pruneEmptyLeaves(removeSurfaceKind(node, kind, targetHasSurface ? leafId : undefined)) ??
+    makeLeaf(kind);
+
+  function add(current: WorkspacePaneNode): WorkspacePaneNode {
+    if (current.type === "leaf") {
+      if (current.id !== leafId) {
+        return current;
+      }
+      const existing = current.tabs.find((tab) => tab.kind === kind);
+      const tab = existing ?? makeTab(kind);
+      tabId = tab.id;
+      return {
+        ...current,
+        tabs: existing ? current.tabs : [...current.tabs, tab],
+        activeTabId: tab.id,
+      };
+    }
+    return {
+      ...current,
+      children: [add(current.children[0]), add(current.children[1])],
+    };
+  }
+
+  return { root: add(withoutExisting), tabId };
+}
+
+function leafWithSurface(
+  leaf: WorkspacePaneLeaf,
+  kind: WorkspacePaneSurfaceKind,
+): WorkspacePaneLeaf {
+  const tab = makeTab(kind);
+  return {
+    ...leaf,
+    tabs: [tab],
+    activeTabId: tab.id,
+  };
+}
+
+function activateSurfaceInLeafNode(
+  node: WorkspacePaneNode,
+  leafId: string,
+  kind: WorkspacePaneSurfaceKind,
+): WorkspacePaneNode {
+  const targetLeaf = findLeaf(node, leafId);
+  if (!targetLeaf) {
+    return node;
+  }
+  const currentKind = getWorkspacePaneActiveTab(targetLeaf)?.kind ?? null;
+  if (currentKind === kind) {
+    return node;
+  }
+  const sourceLeaf = collectWorkspacePaneLeaves(node).find(
+    (leaf) => leaf.id !== leafId && leaf.tabs.some((tab) => tab.kind === kind),
+  );
+
+  function update(current: WorkspacePaneNode): WorkspacePaneNode {
+    if (current.type === "leaf") {
+      if (current.id === leafId) {
+        return leafWithSurface(current, kind);
+      }
+      if (sourceLeaf && current.id === sourceLeaf.id && currentKind) {
+        return leafWithSurface(current, currentKind);
+      }
+      return current;
+    }
+    return { ...current, children: [update(current.children[0]), update(current.children[1])] };
+  }
+
+  return update(node);
+}
+
+function sanitizeRatio(ratio: number): number {
+  if (!Number.isFinite(ratio)) {
+    return DEFAULT_SPLIT_RATIO;
+  }
+  return Math.max(0.12, Math.min(0.88, ratio));
+}
+
+function sanitizeTab(value: unknown): WorkspacePaneTab | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const tab = value as Partial<WorkspacePaneTab>;
+  if (!tab.id || typeof tab.id !== "string") {
+    return null;
+  }
+  if (tab.kind !== "chat" && tab.kind !== "terminal" && tab.kind !== "editor") {
+    return null;
+  }
+  return { id: tab.id, kind: tab.kind };
+}
+
+function sanitizeNode(value: unknown): WorkspacePaneNode | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const node = value as Partial<WorkspacePaneNode>;
+  if (node.type === "leaf") {
+    const rawLeaf = value as Partial<WorkspacePaneLeaf>;
+    if (!rawLeaf.id || typeof rawLeaf.id !== "string") {
+      return null;
+    }
+    const tabs = Array.isArray(rawLeaf.tabs)
+      ? rawLeaf.tabs.map(sanitizeTab).filter((tab): tab is WorkspacePaneTab => tab !== null)
+      : [];
+    const activeTabId =
+      typeof rawLeaf.activeTabId === "string" && tabs.some((tab) => tab.id === rawLeaf.activeTabId)
+        ? rawLeaf.activeTabId
+        : tabs[0]?.id ?? null;
+    return { type: "leaf", id: rawLeaf.id, tabs, activeTabId };
+  }
+  if (node.type === "split") {
+    const rawSplit = value as Partial<WorkspacePaneSplit>;
+    if (
+      !rawSplit.id ||
+      typeof rawSplit.id !== "string" ||
+      (rawSplit.direction !== "horizontal" && rawSplit.direction !== "vertical") ||
+      !Array.isArray(rawSplit.children) ||
+      rawSplit.children.length !== 2
+    ) {
+      return null;
+    }
+    const left = sanitizeNode(rawSplit.children[0]);
+    const right = sanitizeNode(rawSplit.children[1]);
+    if (!left || !right) {
+      return null;
+    }
+    return {
+      type: "split",
+      id: rawSplit.id,
+      direction: rawSplit.direction,
+      ratio: sanitizeRatio(typeof rawSplit.ratio === "number" ? rawSplit.ratio : DEFAULT_SPLIT_RATIO),
+      children: [left, right],
+    };
+  }
+  return null;
+}
+
+function readPersistedLayout(workspaceId: string): WorkspacePaneLayout | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY(workspaceId));
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<WorkspacePaneLayout>;
+    const root = sanitizeNode(parsed.root);
+    if (!root) {
+      return null;
+    }
+    const leaves = collectWorkspacePaneLeaves(root);
+    const focusedLeafId =
+      typeof parsed.focusedLeafId === "string" && leaves.some((leaf) => leaf.id === parsed.focusedLeafId)
+        ? parsed.focusedLeafId
+        : leaves[0]?.id ?? "";
+    const legacyMode =
+      parsed.legacyMode === "terminal" ||
+      parsed.legacyMode === "split" ||
+      parsed.legacyMode === "editor" ||
+      parsed.legacyMode === "chat"
+        ? parsed.legacyMode
+        : deriveLegacyMode(root);
+    return { root, focusedLeafId, legacyMode };
+  } catch {
+    return null;
+  }
+}
+
+function persistLayout(workspaceId: string, layout: WorkspacePaneLayout) {
+  try {
+    localStorage.setItem(STORAGE_KEY(workspaceId), JSON.stringify(layout));
+  } catch {
+    // Non-fatal in tests or restricted browser storage.
+  }
+}
+
+function defaultLayoutForLegacyMode(mode: LayoutMode): WorkspacePaneLayout {
+  if (mode === "split") {
+    const chatLeaf = makeLeaf("chat");
+    const terminalLeaf = makeLeaf("terminal");
+    return {
+      root: makeSplit("horizontal", [chatLeaf, terminalLeaf]),
+      focusedLeafId: chatLeaf.id,
+      legacyMode: "split",
+    };
+  }
+
+  const kind: WorkspacePaneSurfaceKind =
+    mode === "terminal" ? "terminal" : mode === "editor" ? "editor" : "chat";
+  const leaf = makeLeaf(kind);
+  return {
+    root: leaf,
+    focusedLeafId: leaf.id,
+    legacyMode: mode,
+  };
+}
+
+function deriveLegacyMode(root: WorkspacePaneNode): LayoutMode {
+  const activeKinds = collectWorkspacePaneLeaves(root)
+    .map(getWorkspacePaneActiveTab)
+    .filter((tab): tab is WorkspacePaneTab => tab !== null)
+    .map((tab) => tab.kind);
+  const uniqueKinds = Array.from(new Set(activeKinds));
+
+  if (uniqueKinds.length === 0) {
+    return "chat";
+  }
+  if (uniqueKinds.length === 1) {
+    const [kind] = uniqueKinds;
+    return kind === "terminal" ? "terminal" : kind === "editor" ? "editor" : "chat";
+  }
+  if (uniqueKinds.includes("terminal")) {
+    return "split";
+  }
+  if (uniqueKinds.includes("editor")) {
+    return "editor";
+  }
+  return "chat";
+}
+
+function chooseSplitSurface(layout: WorkspacePaneLayout, leafId: string): WorkspacePaneSurfaceKind {
+  const focusedLeaf = findLeaf(layout.root, leafId);
+  const activeKind = focusedLeaf ? getWorkspacePaneActiveTab(focusedLeaf)?.kind ?? null : null;
+  const presentKinds = new Set(
+    collectWorkspacePaneLeaves(layout.root)
+      .flatMap((leaf) => leaf.tabs.map((tab) => tab.kind)),
+  );
+
+  const preferred =
+    activeKind === "chat"
+      ? ["terminal", "editor"]
+      : activeKind === "terminal"
+        ? ["editor", "chat"]
+        : ["chat", "terminal"];
+
+  return (
+    preferred.find((kind): kind is WorkspacePaneSurfaceKind => !presentKinds.has(kind as WorkspacePaneSurfaceKind))
+    ?? preferred[0] as WorkspacePaneSurfaceKind
+  );
+}
+
+function updateWorkspace(
+  state: WorkspacePaneState,
+  workspaceId: string,
+  updater: (layout: WorkspacePaneLayout) => WorkspacePaneLayout,
+): Record<string, WorkspacePaneLayout> {
+  const current = state.workspaces[workspaceId] ?? readPersistedLayout(workspaceId) ?? defaultLayoutForLegacyMode("chat");
+  const next = updater(current);
+  persistLayout(workspaceId, next);
+  return { ...state.workspaces, [workspaceId]: next };
+}
+
+export const useWorkspacePaneStore = create<WorkspacePaneState>((set, get) => ({
+  workspaces: {},
+
+  ensureWorkspace: (workspaceId, legacyMode = "chat") => {
+    set((state) => {
+      if (state.workspaces[workspaceId]) {
+        return state;
+      }
+      const layout = readPersistedLayout(workspaceId) ?? defaultLayoutForLegacyMode(legacyMode);
+      persistLayout(workspaceId, layout);
+      return {
+        workspaces: { ...state.workspaces, [workspaceId]: layout },
+      };
+    });
+  },
+
+  applyLegacyLayoutMode: (workspaceId, mode) => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, () => defaultLayoutForLegacyMode(mode)),
+    }));
+  },
+
+  focusLeaf: (workspaceId, leafId) => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, (layout) => {
+        if (!findLeaf(layout.root, leafId)) {
+          return layout;
+        }
+        return { ...layout, focusedLeafId: leafId };
+      }),
+    }));
+  },
+
+  setActiveTab: (workspaceId, leafId, tabId) => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, (layout) => {
+        let found = false;
+        function update(node: WorkspacePaneNode): WorkspacePaneNode {
+          if (node.type === "leaf") {
+            if (node.id !== leafId || !node.tabs.some((tab) => tab.id === tabId)) {
+              return node;
+            }
+            found = true;
+            return { ...node, activeTabId: tabId };
+          }
+          return { ...node, children: [update(node.children[0]), update(node.children[1])] };
+        }
+        const root = update(layout.root);
+        return found
+          ? { root, focusedLeafId: leafId, legacyMode: deriveLegacyMode(root) }
+          : layout;
+      }),
+    }));
+  },
+
+  activateSurfaceInLeaf: (workspaceId, leafId, kind) => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, (layout) => {
+        if (!findLeaf(layout.root, leafId)) {
+          return layout;
+        }
+        const root = activateSurfaceInLeafNode(layout.root, leafId, kind);
+        return {
+          root,
+          focusedLeafId: leafId,
+          legacyMode: deriveLegacyMode(root),
+        };
+      }),
+    }));
+  },
+
+  activateFocusedSurface: (workspaceId, kind) => {
+    const layout = get().workspaces[workspaceId] ?? readPersistedLayout(workspaceId);
+    if (!layout) {
+      get().ensureWorkspace(workspaceId);
+      return;
+    }
+    get().activateSurfaceInLeaf(workspaceId, layout.focusedLeafId, kind);
+  },
+
+  showSurface: (workspaceId, kind, leafId) => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, (layout) => {
+        const targetLeafId = leafId && findLeaf(layout.root, leafId)
+          ? leafId
+          : layout.focusedLeafId;
+        const targetLeaf = findLeaf(layout.root, targetLeafId);
+        if (!targetLeaf) {
+          return layout;
+        }
+        const { root } = addSurfaceToLeaf(layout.root, targetLeafId, kind);
+        return {
+          root,
+          focusedLeafId: targetLeafId,
+          legacyMode: deriveLegacyMode(root),
+        };
+      }),
+    }));
+  },
+
+  showSingleSurface: (workspaceId, kind) => {
+    const mode: LayoutMode =
+      kind === "terminal" ? "terminal" : kind === "editor" ? "editor" : "chat";
+    get().applyLegacyLayoutMode(workspaceId, mode);
+  },
+
+  splitLeaf: (workspaceId, leafId, direction, kind, position = "after") => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, (layout) => {
+        const targetLeaf = findLeaf(layout.root, leafId);
+        if (!targetLeaf) {
+          return layout;
+        }
+        const surfaceKind = kind ?? chooseSplitSurface(layout, leafId);
+        if (getWorkspacePaneActiveTab(targetLeaf)?.kind === surfaceKind) {
+          return layout;
+        }
+        const rootWithoutExisting =
+          pruneEmptyLeaves(removeSurfaceKind(layout.root, surfaceKind)) ?? layout.root;
+        const targetAfterRemoval = findLeaf(rootWithoutExisting, leafId);
+        if (!targetAfterRemoval) {
+          return layout;
+        }
+        const newLeaf = makeLeaf(surfaceKind);
+        const children: [WorkspacePaneNode, WorkspacePaneNode] =
+          position === "before"
+            ? [newLeaf, targetAfterRemoval]
+            : [targetAfterRemoval, newLeaf];
+        const split = makeSplit(direction, children, 0.5);
+        const root = replaceLeaf(rootWithoutExisting, leafId, split);
+        return {
+          root,
+          focusedLeafId: newLeaf.id,
+          legacyMode: deriveLegacyMode(root),
+        };
+      }),
+    }));
+  },
+
+  splitFocusedLeaf: (workspaceId, direction, kind, position = "after") => {
+    const layout = get().workspaces[workspaceId] ?? readPersistedLayout(workspaceId);
+    if (!layout) {
+      get().ensureWorkspace(workspaceId);
+      return;
+    }
+    get().splitLeaf(workspaceId, layout.focusedLeafId, direction, kind, position);
+  },
+
+  closeLeaf: (workspaceId, leafId) => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, (layout) => {
+        const root = removeLeaf(layout.root, leafId);
+        if (!root) {
+          return defaultLayoutForLegacyMode("chat");
+        }
+        const leaves = collectWorkspacePaneLeaves(root);
+        const focusedLeafId = leaves.some((leaf) => leaf.id === layout.focusedLeafId)
+          ? layout.focusedLeafId
+          : leaves[0]?.id ?? "";
+        return {
+          root,
+          focusedLeafId,
+          legacyMode: deriveLegacyMode(root),
+        };
+      }),
+    }));
+  },
+
+  closeTab: (workspaceId, leafId, tabId) => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, (layout) => {
+        let changed = false;
+        function update(node: WorkspacePaneNode): WorkspacePaneNode {
+          if (node.type === "leaf") {
+            if (node.id !== leafId || !node.tabs.some((tab) => tab.id === tabId)) {
+              return node;
+            }
+            changed = true;
+            const tabs = node.tabs.filter((tab) => tab.id !== tabId);
+            return {
+              ...node,
+              tabs,
+              activeTabId: tabs.some((tab) => tab.id === node.activeTabId)
+                ? node.activeTabId
+                : tabs[0]?.id ?? null,
+            };
+          }
+          return { ...node, children: [update(node.children[0]), update(node.children[1])] };
+        }
+        const root = update(layout.root);
+        return changed
+          ? { root, focusedLeafId: leafId, legacyMode: deriveLegacyMode(root) }
+          : layout;
+      }),
+    }));
+  },
+
+  updateRatio: (workspaceId, containerId, ratio) => {
+    set((state) => ({
+      workspaces: updateWorkspace(state, workspaceId, (layout) => ({
+        ...layout,
+        root: updateRatioInTree(layout.root, containerId, sanitizeRatio(ratio)),
+      })),
+    }));
+  },
+}));
+
+export { SURFACE_ORDER };

--- a/src/types.ts
+++ b/src/types.ts
@@ -846,11 +846,11 @@ export interface TerminalNotificationClearedEvent {
   sessionId: string | null;
 }
 
-export interface TerminalOutputEvent {
+export interface TerminalOutputReadyEvent {
   sessionId: string;
-  seq: number;
+  latestSeq: number;
   ts: string;
-  data: string;
+  bytes: number;
 }
 
 export interface TerminalReplayChunk {

--- a/src/workers/markdownParserCore.ts
+++ b/src/workers/markdownParserCore.ts
@@ -146,7 +146,7 @@ function linkifyLocalFileReferencesInText(text: string): string {
 
 function linkifyLocalFileReferencesInHtml(html: string): string {
   const tagPattern = /<\/?([a-z][a-z0-9-]*)\b[^>]*>/gi;
-  const skipTags = new Set(["a", "code", "pre"]);
+  const skipTags = new Set(["a", "pre"]);
   let result = "";
   let lastIndex = 0;
   let skipDepth = 0;

--- a/src/workers/markdownParserCore.ts
+++ b/src/workers/markdownParserCore.ts
@@ -1,6 +1,12 @@
 import hljs from "highlight.js/lib/common";
 import { micromark } from "micromark";
 import { gfm, gfmHtml } from "micromark-extension-gfm";
+import {
+  DISALLOWED_LOCAL_PREFIX_CHAR_RE,
+  TEXT_LINK_PATTERN,
+  isLocalFileLinkSyntax,
+  trimLinkText,
+} from "../lib/localFileLinkPatterns";
 
 interface FenceToken {
   placeholder: string;
@@ -52,10 +58,14 @@ function escapeNonFenceHtml(input: string): string {
   return escaped;
 }
 
-function sanitizeUrl(url: string): string {
+function sanitizeUrl(url: string, attrName: string): string {
   const trimmed = url.trim();
   if (!trimmed) {
     return "#";
+  }
+
+  if (attrName.toLowerCase() === "href" && isLocalFileLinkSyntax(trimmed)) {
+    return trimmed;
   }
 
   if (
@@ -97,7 +107,7 @@ function sanitizeRenderedHtml(html: string): string {
     /\s(href|src)\s*=\s*("([^"]*)"|'([^']*)')/gi,
     (_full, attrName: string, _quoted: string, doubleValue: string, singleValue: string) => {
       const rawValue = typeof doubleValue === "string" ? doubleValue : singleValue;
-      const safe = sanitizeUrl(rawValue);
+      const safe = sanitizeUrl(rawValue, attrName);
       return ` ${attrName}="${safe}"`;
     },
   );
@@ -106,6 +116,65 @@ function sanitizeRenderedHtml(html: string): string {
     /<a\b(?![^>]*\brel=)([^>]*)>/gi,
     "<a$1 rel=\"noreferrer noopener\">",
   );
+}
+
+function escapeHtmlAttribute(input: string): string {
+  return input
+    .replaceAll("&", "&amp;")
+    .replaceAll("\"", "&quot;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+function linkifyLocalFileReferencesInText(text: string): string {
+  return text.replace(TEXT_LINK_PATTERN, (raw, offset: number) => {
+    const trimmed = trimLinkText(raw);
+    if (
+      !trimmed ||
+      !isLocalFileLinkSyntax(trimmed) ||
+      text.slice(Math.max(0, offset - 4), offset) === "&lt;" ||
+      (offset > 0 && DISALLOWED_LOCAL_PREFIX_CHAR_RE.test(text[offset - 1] ?? ""))
+    ) {
+      return raw;
+    }
+
+    const trailing = raw.slice(trimmed.length);
+    const safeHref = escapeHtmlAttribute(trimmed);
+    return `<a href="${safeHref}" rel="noreferrer noopener">${trimmed}</a>${trailing}`;
+  });
+}
+
+function linkifyLocalFileReferencesInHtml(html: string): string {
+  const tagPattern = /<\/?([a-z][a-z0-9-]*)\b[^>]*>/gi;
+  const skipTags = new Set(["a", "code", "pre"]);
+  let result = "";
+  let lastIndex = 0;
+  let skipDepth = 0;
+
+  for (const match of html.matchAll(tagPattern)) {
+    const tag = match[0];
+    const tagName = (match[1] ?? "").toLowerCase();
+    const index = match.index ?? 0;
+    const text = html.slice(lastIndex, index);
+    result += skipDepth > 0 ? text : linkifyLocalFileReferencesInText(text);
+    result += tag;
+
+    if (skipTags.has(tagName)) {
+      const isClosing = tag.startsWith("</");
+      const isSelfClosing = tag.endsWith("/>");
+      if (isClosing) {
+        skipDepth = Math.max(0, skipDepth - 1);
+      } else if (!isSelfClosing) {
+        skipDepth += 1;
+      }
+    }
+
+    lastIndex = index + tag.length;
+  }
+
+  const remaining = html.slice(lastIndex);
+  result += skipDepth > 0 ? remaining : linkifyLocalFileReferencesInText(remaining);
+  return result;
 }
 
 function normalizeFenceLanguage(raw: string): string {
@@ -284,6 +353,7 @@ export function renderMarkdownToHtml(markdown: string): string {
     extensions: [gfm()],
     htmlExtensions: [gfmHtml()],
     allowDangerousHtml: true,
+    allowDangerousProtocol: true,
   });
 
   let finalHtml = html;
@@ -291,7 +361,7 @@ export function renderMarkdownToHtml(markdown: string): string {
     finalHtml = finalHtml.replace(fence.placeholder, fence.html);
   }
 
-  return sanitizeRenderedHtml(finalHtml);
+  return linkifyLocalFileReferencesInHtml(sanitizeRenderedHtml(finalHtml));
 }
 
 export const markdownParserCoreInternals = {

--- a/tests/markdownParserCore.test.ts
+++ b/tests/markdownParserCore.test.ts
@@ -56,16 +56,18 @@ describe("renderMarkdownToHtml", () => {
     expect(autolink).toContain(">https://example.com</a>");
   });
 
-  it("linkifies bare local file references outside code spans", () => {
+  it("linkifies bare local file references outside fenced code blocks", () => {
     const html = renderMarkdownToHtml(
-      "See src/lib/fileLinkNavigation.ts:12 and README.md.\n\n`src/ignored.ts`",
+      "See src/lib/fileLinkNavigation.ts:12 and README.md.\n\n`src/inline.ts:3`\n\n```ts\nsrc/ignored.ts\n```",
     );
 
     expect(html).toContain('href="src/lib/fileLinkNavigation.ts:12"');
     expect(html).toContain(">src/lib/fileLinkNavigation.ts:12</a>");
     expect(html).toContain('href="README.md"');
     expect(html).toContain(">README.md</a>.");
-    expect(html).toContain("<code>src/ignored.ts</code>");
+    expect(html).toContain('<code><a href="src/inline.ts:3"');
+    expect(html).toContain("<code");
+    expect(html).toContain("hljs language-ts");
     expect(html).not.toContain('href="src/ignored.ts"');
   });
 

--- a/tests/markdownParserCore.test.ts
+++ b/tests/markdownParserCore.test.ts
@@ -56,6 +56,33 @@ describe("renderMarkdownToHtml", () => {
     expect(autolink).toContain(">https://example.com</a>");
   });
 
+  it("linkifies bare local file references outside code spans", () => {
+    const html = renderMarkdownToHtml(
+      "See src/lib/fileLinkNavigation.ts:12 and README.md.\n\n`src/ignored.ts`",
+    );
+
+    expect(html).toContain('href="src/lib/fileLinkNavigation.ts:12"');
+    expect(html).toContain(">src/lib/fileLinkNavigation.ts:12</a>");
+    expect(html).toContain('href="README.md"');
+    expect(html).toContain(">README.md</a>.");
+    expect(html).toContain("<code>src/ignored.ts</code>");
+    expect(html).not.toContain('href="src/ignored.ts"');
+  });
+
+  it("preserves explicit markdown links to local files", () => {
+    const html = renderMarkdownToHtml("[readme](README.md) [file](file:///repo/README.md#L4)");
+
+    expect(html).toContain('href="README.md"');
+    expect(html).toContain('href="file:///repo/README.md#L4"');
+  });
+
+  it("does not allow local file URLs in image sources", () => {
+    const html = renderMarkdownToHtml("![local](file:///repo/secret.png)");
+
+    expect(html).toContain('src="#"');
+    expect(html).not.toContain('src="file:///repo/secret.png"');
+  });
+
   it("sanitizes dangerous tags, handlers and javascript links", () => {
     const html = renderMarkdownToHtml(
       [


### PR DESCRIPTION
## Summary
This PR covers the full `feat/file-link-and-editor-improvements` branch, not just the final UI polish commit.

It improves local file-link handling across chat, terminal, markdown, and the file editor; adds the workspace pane split model; preserves chat/terminal context when Shift-opening files; and replaces terminal output push events with a pull-based backpressure path to reduce WebKit/Tauri memory pressure during long terminal streams.

## Changes
- Adds shared local file-link parsing for absolute paths, `file://` URLs, repo-relative paths, and line/column suffixes.
- Adds editor reveal support so file links open or reuse file tabs at the requested location.
- Adds workspace pane layout state, split surfaces, persistence, surface switching, and legacy layout-mode sync.
- Routes file-opening entry points through workspace pane navigation from chat, terminal, git views, command palette, explorer, and harness flows.
- Adds terminal output backpressure via ready signals, bounded drains, capped replay, and new IPC/types.
- Linkifies chat inline file paths, action output/errors, diff filenames, and code block filenames while keeping fenced code blocks unlinked.
- Preserves the source chat/terminal pane by opening the editor beside it when no visible editor exists.
- Polishes editor/terminal tab consistency and pane close-button hover behavior.
- Updates English and Portuguese workspace pane copy.
- Adds regression coverage for file-link parsing, markdown linkification, editor reveal behavior, workspace pane state, source-pane navigation, terminal output draining, and command palette interactions.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [x] `git diff --check`

## Review Notes
Please review this as a full branch. The highest-risk areas are terminal output drain/replay behavior and workspace pane split/navigation state, especially the terminal-only Codex CLI case where Shift-clicking a file path should open the editor beside the terminal instead of replacing it.