### PR TITLE
docs: clarify PR access path for non-collaborators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,25 @@ cargo fmt -- --check
 cargo check
 ```
 
+## Pull request access
+
+This repository currently has GitHub's pull request creation policy set to `collaborators_only`. That means only accounts with collaborator access can open a pull request directly against this repo, even though anyone can fork it and push a branch.
+
+If you are not a collaborator, the working path today is:
+
+1. Fork the repo and push your change to a branch on your fork.
+2. Open an issue describing the change, linking your fork and branch (a compare URL such as `https://github.com/<you>/panes/compare/master...<you>:panes:<branch>` works well).
+3. A maintainer reviews the diff from the issue, then either pulls the branch in directly or grants access so you can open the PR yourself.
+
+This is a temporary restriction while the project has one maintainer doing review, not a rejection of outside contributions. The policy may open up to all forks later; until then, route proposed changes through an issue first.
+
+### Translation contributions
+
+Localized READMEs follow the `README.<locale>.md` convention already used for `README.pt-BR.md`. A Chinese translation would live at `README.zh-CN.md` at the repo root, linked from the language line at the top of `README.md` alongside the existing English and Portuguese links. Propose translations through the same fork-and-issue path described above.
+
 ## Contribution rules
 
-- Send changes through a branch in your fork and open a pull request against `master`.
+- Send changes through a branch in your fork. If you already have collaborator access, open a pull request against `master` directly; otherwise see [Pull request access](#pull-request-access) above.
 - Keep one PR focused on one problem.
 - Update docs when behavior, setup, or workflow changes.
 - If you add or change user-facing copy, update both locale resource sets under `src/i18n/resources/en/` and `src/i18n/resources/pt-BR/`.


### PR DESCRIPTION
## Summary

The repository has GitHub's `pull_request_creation_policy` set to `collaborators_only`, confirmed via the API (`gh api repos/wygoralves/panes --jq .pull_request_creation_policy` returns `collaborators_only`). Non-collaborators can fork and branch, but cannot open a PR directly against this repo. The existing CONTRIBUTING.md did not mention this, and its "Contribution rules" section told forks to "open a pull request against master," which does not work for non-collaborator accounts today. This adds a section documenting the actual working path and a note on where translated READMEs should live.

## Changes

- Add a "Pull request access" section to CONTRIBUTING.md explaining the collaborators-only policy and the fork-plus-issue path that works today for non-collaborators.
- Add a "Translation contributions" subsection noting the existing `README.<locale>.md` convention (matches `README.pt-BR.md`) so a Chinese translation would be `README.zh-CN.md`.
- Update the first "Contribution rules" bullet so it no longer contradicts the policy above.

## Validation

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`

Docs-only change (one file, CONTRIBUTING.md). Skipped the checks above since no code changed; confirmed there are no tests that reference CONTRIBUTING.md, and confirmed the files referenced (`README.pt-BR.md`, `LICENSE`) exist in the repo.

## UI / UX impact

- [x] No user-facing UI change

## Localization

- [x] No new user-facing copy

## Notes for review

Refs #23.

Suggested reply for #23, if useful:

> Thanks for putting together the Chinese README! Right now this repo has GitHub's pull request creation restricted to collaborators, so non-collaborator PRs cannot be opened directly yet. Easiest path for now: push your translation to a branch on your fork and open an issue linking to it (a compare URL works well), and I will pull it in from there. I have documented this flow in CONTRIBUTING.md along with the `README.zh-CN.md` naming convention for translated READMEs, matching the existing `README.pt-BR.md`. I may open up direct PR creation to all forks down the line, and will update this issue if that changes.