### PR TITLE
docs: document native OpenCode chat engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Panes is not a full IDE, but it does ship with a built-in multi-tab editor for q
 - Streaming chat with structured content blocks for text, thinking, actions, diffs, approvals, attachments, and usage updates
 - Codex chat integration via `codex app-server`
 - Claude chat integration via a Claude Agent SDK sidecar
+- OpenCode chat integration as a native engine, available once the `opencode` CLI is on your `PATH`
 - Plan mode, attachments, reasoning effort controls, per-thread approval/network overrides, and Codex-specific sandbox-mode overrides
 - Global FTS message search with keyboard navigation
 - Windowed message loading and lazy hydration for long threads/action output
@@ -233,7 +234,7 @@ User-facing frontend copy is localized with `i18next`/`react-i18next`. Treat i18
 
 Panes uses a React + Zustand frontend running inside a Tauri shell, with a Rust backend that owns persistence, engine orchestration, git operations, terminal management, and filesystem-safe file access.
 
-The app currently exposes Codex and Claude as chat engines. Codex talks to `codex app-server`; Claude is bridged through the bundled Claude runtime sidecar.
+The app currently exposes Codex, Claude, and OpenCode as chat engines. Codex talks to `codex app-server`; Claude is bridged through the bundled Claude runtime sidecar; OpenCode talks to a locally installed `opencode` CLI and becomes selectable in the engine and model picker once that CLI is detected on your `PATH`.
 
 ### Stack
 


### PR DESCRIPTION
## Summary

Native OpenCode chat engine support already ships on master (`src-tauri/src/engines/opencode.rs`, `EngineManager.opencode`, `ChatEngineId` including `opencode`, engine and model picker wiring in `ChatPanel.tsx`/`ModelPicker.tsx`), but the README only listed OpenCode under harness detection/launch, which is a separate concept from a native chat engine. This documents what already works.

## Changes

- README: list OpenCode chat integration alongside Codex and Claude in the Chat & Agents feature section, noting it requires the `opencode` CLI on `PATH`.
- README: update the architecture section to say the app exposes Codex, Claude, and OpenCode as chat engines, and briefly describe how OpenCode connects.

## Validation

- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] `cd src-tauri && cargo check`

Docs-only change to README.md; none of the above apply. Confirmed the edited sections render as plain markdown bullets/paragraphs with no broken references.

## UI / UX impact

- [x] No user-facing UI change

## Localization

- [x] No new user-facing copy

## Notes for review

Verified end-to-end reachability before writing this, since the issue predates the feature shipping:
- `is_available()` for OpenCode gates on `resolve_opencode_executable().is_some()` (`src-tauri/src/engines/opencode.rs:582-584`), the same detection pattern as the other engines.
- The frontend `ModelPicker` receives all engines from `useEngineStore` (backed by `ipc.listEngines()`), and selecting `opencode` there sets `selectedEngineId` directly (`src/components/chat/ChatPanel.tsx:5723-5728`), so a user with the `opencode` CLI installed can pick it in the same engine/model dropdown as Codex and Claude.
- `ChatPanel.tsx` has dedicated OpenCode handling for permission mode, plan mode, agent picker, and attachments, confirming this is a fully wired path rather than a stub.

Closes #30

Suggested reply for the issue (English):

Native OpenCode support has shipped. Install the `opencode` CLI so it is on your PATH (Panes can also install it for you from the Harnesses setup flow), then open the engine and model picker in chat and select OpenCode. It now works the same way Codex and Claude do, including plan mode, attachments, and approval controls.

Suggested reply for the issue (Portuguese):

O suporte nativo ao OpenCode já está disponível. Instale a CLI do `opencode` para que ela fique no seu PATH (o Panes também consegue instalar para você pelo fluxo de configuração de Harnesses) e depois abra o seletor de engine e modelo no chat e escolha OpenCode. Ele funciona do mesmo jeito que Codex e Claude, incluindo modo de plano, anexos e controles de aprovação.
