### PR TITLE
fix(linux): apply EGL/DMABUF webview workaround to X11 AppImage sessions

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Panes"
-version = "0.58.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/src/linux_webkit.rs
+++ b/src-tauri/src/linux_webkit.rs
@@ -97,6 +97,11 @@ fn plan_webkit_workarounds<'a>(
     }
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn plan_has_work(plan: &WebkitWorkaroundPlan) -> bool {
+    plan.clear_forced_x11_backend || plan.disable_dmabuf_renderer || plan.disable_compositing_mode
+}
+
 #[cfg(target_os = "linux")]
 pub fn apply_webkit_display_workarounds() {
     use std::{env, os::unix::process::CommandExt, path::Path, process::Command};
@@ -190,10 +195,7 @@ pub fn apply_webkit_display_workarounds() {
         }
     }
 
-    if !plan.clear_forced_x11_backend
-        && !plan.disable_dmabuf_renderer
-        && !plan.disable_compositing_mode
-    {
+    if !plan_has_work(&plan) {
         return;
     }
 
@@ -217,10 +219,7 @@ pub fn apply_webkit_display_workarounds() {
         env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
     }
 
-    if plan.clear_forced_x11_backend
-        || plan.disable_dmabuf_renderer
-        || plan.disable_compositing_mode
-    {
+    if plan_has_work(&plan) {
         log::info!(
             "applied linux webkit display workarounds: wayland={}, cosmic={}, clear_forced_x11_backend={}, relaunch_with_wayland_client_preload={}, disable_dmabuf_renderer={}, disable_compositing_mode={}",
             plan.is_wayland_session,
@@ -239,8 +238,8 @@ pub fn apply_webkit_display_workarounds() {}
 #[cfg(test)]
 mod tests {
     use super::{
-        plan_webkit_workarounds, WebkitDisplayEnv, WebkitWorkaroundPlan, ORIGINAL_LD_PRELOAD_ENV,
-        WAYLAND_CLIENT_PRELOAD_ENV,
+        plan_has_work, plan_webkit_workarounds, WebkitDisplayEnv, WebkitWorkaroundPlan,
+        ORIGINAL_LD_PRELOAD_ENV, WAYLAND_CLIENT_PRELOAD_ENV,
     };
 
     fn base_env<'a>() -> WebkitDisplayEnv<'a> {
@@ -528,5 +527,27 @@ mod tests {
     fn helper_env_var_names_are_stable() {
         assert_eq!(WAYLAND_CLIENT_PRELOAD_ENV, "PANES_WAYLAND_CLIENT_PRELOAD");
         assert_eq!(ORIGINAL_LD_PRELOAD_ENV, "PANES_ORIGINAL_LD_PRELOAD");
+    }
+
+    #[test]
+    fn plan_has_work_for_x11_appimage_bundle() {
+        let mut env = base_env();
+        env.xdg_session_type = Some("x11");
+        env.appimage_present = true;
+
+        let plan = plan_webkit_workarounds(&env, Some("/usr/lib64/libwayland-client.so.0"));
+
+        assert!(plan_has_work(&plan));
+    }
+
+    #[test]
+    fn plan_has_no_work_for_plain_x11_without_appimage() {
+        let mut env = base_env();
+        env.xdg_session_type = Some("x11");
+        env.gdk_backend = Some("x11");
+
+        let plan = plan_webkit_workarounds(&env, Some("/usr/lib64/libwayland-client.so.0"));
+
+        assert!(!plan_has_work(&plan));
     }
 }

--- a/src-tauri/src/linux_webkit.rs
+++ b/src-tauri/src/linux_webkit.rs
@@ -84,7 +84,13 @@ fn plan_webkit_workarounds<'a>(
             None
         },
         restore_original_ld_preload: env.internal_wayland_client_preload.is_some(),
-        disable_dmabuf_renderer: is_wayland_session && !env.dmabuf_renderer_configured,
+        // The DMA-BUF renderer crash (EGL_BAD_PARAMETER on startup, or a blank
+        // white webview) is not exclusive to Wayland: AppImage bundles carry
+        // their own Mesa/EGL stack, which can misbehave under X11 too. Apply
+        // the same conservative workaround whenever we're running as an
+        // AppImage, regardless of session type.
+        disable_dmabuf_renderer: (is_wayland_session || is_appimage_bundle)
+            && !env.dmabuf_renderer_configured,
         disable_compositing_mode: is_wayland_session
             && is_cosmic_session
             && !env.compositing_mode_configured,
@@ -184,7 +190,10 @@ pub fn apply_webkit_display_workarounds() {
         }
     }
 
-    if !plan.is_wayland_session {
+    if !plan.clear_forced_x11_backend
+        && !plan.disable_dmabuf_renderer
+        && !plan.disable_compositing_mode
+    {
         return;
     }
 
@@ -197,9 +206,10 @@ pub fn apply_webkit_display_workarounds() {
         env::remove_var("GDK_BACKEND");
     }
 
-    // WebKitGTK can fail before the frontend boots on some Wayland stacks,
-    // leaving a blank window with EGL display errors. Apply conservative
-    // defaults unless the user already configured an override.
+    // WebKitGTK can fail before the frontend boots on some Wayland or AppImage
+    // stacks, leaving a blank window with EGL display errors (for example
+    // "Could not create default EGL display: EGL_BAD_PARAMETER"). Apply
+    // conservative defaults unless the user already configured an override.
     if plan.disable_dmabuf_renderer {
         env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
     }
@@ -250,14 +260,14 @@ mod tests {
     }
 
     #[test]
-    fn skips_workarounds_outside_wayland() {
+    fn skips_workarounds_outside_wayland_without_appimage() {
         let plan = plan_webkit_workarounds(
             &WebkitDisplayEnv {
                 xdg_session_type: Some("x11"),
                 wayland_display_present: false,
                 xdg_current_desktop: Some("COSMIC"),
                 desktop_session: Some("cosmic"),
-                appimage_present: true,
+                appimage_present: false,
                 appdir_present: false,
                 gdk_backend: Some("x11"),
                 ld_preload: None,
@@ -280,6 +290,70 @@ mod tests {
                 disable_compositing_mode: false,
             }
         );
+    }
+
+    #[test]
+    fn enables_dmabuf_workaround_for_x11_appimage_bundle() {
+        // This mirrors the reported crash: an AppImage launched on a plain
+        // X11 session aborts with "Could not create default EGL display:
+        // EGL_BAD_PARAMETER" before the frontend ever boots.
+        let plan = plan_webkit_workarounds(
+            &WebkitDisplayEnv {
+                xdg_session_type: Some("x11"),
+                wayland_display_present: false,
+                xdg_current_desktop: None,
+                desktop_session: None,
+                appimage_present: true,
+                appdir_present: false,
+                gdk_backend: Some("x11"),
+                ld_preload: None,
+                internal_wayland_client_preload: None,
+                dmabuf_renderer_configured: false,
+                compositing_mode_configured: false,
+            },
+            Some("/usr/lib64/libwayland-client.so.0"),
+        );
+
+        assert_eq!(
+            plan,
+            WebkitWorkaroundPlan {
+                is_wayland_session: false,
+                is_cosmic_session: false,
+                clear_forced_x11_backend: false,
+                relaunch_with_wayland_client_preload: None,
+                restore_original_ld_preload: false,
+                disable_dmabuf_renderer: true,
+                disable_compositing_mode: false,
+            }
+        );
+    }
+
+    #[test]
+    fn enables_dmabuf_workaround_for_appimage_with_unset_session_type() {
+        // Some X11 window managers (for example qtile launched without a
+        // display manager) never populate XDG_SESSION_TYPE at all. The
+        // workaround must still trigger from APPIMAGE/APPDIR alone.
+        let mut env = base_env();
+        env.appimage_present = true;
+
+        let plan = plan_webkit_workarounds(&env, Some("/usr/lib64/libwayland-client.so.0"));
+
+        assert!(!plan.is_wayland_session);
+        assert!(plan.disable_dmabuf_renderer);
+        assert!(!plan.disable_compositing_mode);
+        assert!(!plan.clear_forced_x11_backend);
+    }
+
+    #[test]
+    fn preserves_existing_user_override_on_x11_appimage() {
+        let mut env = base_env();
+        env.xdg_session_type = Some("x11");
+        env.appimage_present = true;
+        env.dmabuf_renderer_configured = true;
+
+        let plan = plan_webkit_workarounds(&env, Some("/usr/lib64/libwayland-client.so.0"));
+
+        assert!(!plan.disable_dmabuf_renderer);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the AppImage launch crash reported on Arch Linux with a plain X11 session (qtile, no display manager): the app aborted with `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...` and left a white window. The existing WebKit display workarounds in `linux_webkit.rs` only kicked in for Wayland sessions, so a pure X11 launch got no mitigation at all.

## Root cause

This exact error string (`EGL_BAD_PARAMETER`) is a known WebKitGTK/Mesa issue class tied to the DMA-BUF compositing renderer introduced in recent WebKitGTK versions, and it shows up across several unrelated Tauri apps distributed as AppImages (not just on Wayland):

- Tauri's own docs list `WEBKIT_DISABLE_DMABUF_RENDERER=1` as the fix for "the DMABUF framebuffer error" (https://v2.tauri.app/develop/debug/linux-graphics/).
- gitbutlerapp/gitbutler#5282 and tari-project/universe#1723 hit the identical `EGL_BAD_PARAMETER` abort message from AppImage builds.
- AppImage bundles carry their own Mesa/EGL/Wayland libraries, which is why this module already special-cases AppImage/APPDIR detection for other workarounds (the linuxdeploy `GDK_BACKEND` override and the Wayland client preload relaunch).

Since AppImage's bundled graphics stack is the common thread (not the session type), the fix broadens the existing DMABUF-disable workaround to trigger for any AppImage bundle, not only Wayland ones.

**Tradeoff:** this also means X11 AppImage users who were not hitting this crash will now launch with `WEBKIT_DISABLE_DMABUF_RENDERER=1` set too, giving up the newer accelerated rendering path they were previously using without issue. This is acceptable because Tauri's own Linux graphics troubleshooting guidance recommends this env var broadly for this failure class regardless of session type, the fallback path is the one WebKitGTK used before the DMA-BUF renderer existed (well exercised, not experimental), and it is still skipped entirely for non-AppImage X11 installs (deb, native builds) and for any user who has already set the variable themselves.

## Changes

- `src-tauri/src/linux_webkit.rs`: `disable_dmabuf_renderer` now triggers when either `is_wayland_session` (unchanged) or the process is running as an AppImage bundle (`APPIMAGE`/`APPDIR` present), still gated on the user not already having set `WEBKIT_DISABLE_DMABUF_RENDERER` themselves. Reworked the "nothing to do" early return in `apply_webkit_display_workarounds` to check all three workaround flags instead of assuming Wayland is a prerequisite for everything.
- Updated the test that previously asserted "no workaround on X11 AppImage" (that was the bug) and added coverage for: X11 AppImage session, AppImage session with no `XDG_SESSION_TYPE` set at all (matches the reporter's WM setup), and that a user's existing override is still respected on X11.
- Extracted the apply function's "nothing to do" gate into a pure `plan_has_work` helper (shared by the early return and the log condition, so they cannot drift apart) and added unit tests asserting it is true for the X11 AppImage plan and false for a plain X11 install with no AppImage. Without this, a regression narrowing the gate back to the old Wayland-only check would silently defeat the fix and nothing would catch it.
- `src-tauri/Cargo.lock`: picked up the released app version bump already on master, unrelated to this change.

## Validation

- [x] `cd src-tauri && cargo check` (with a placeholder `dist/` like CI creates, since this checkout has no frontend build)
- [x] `cd src-tauri && cargo test linux_webkit` (15 passed)
- [x] `cd src-tauri && cargo fmt -- --check` (clean)
- [ ] `pnpm typecheck` / `pnpm test` / `pnpm build` skipped: no frontend files touched

I do not have Linux hardware to reproduce the original crash, so I could not verify the fix against a real X11 session end to end. The change is scoped narrowly (only affects AppImage-bundled launches) and is unit-tested against the exact environment shape from the bug report (X11, AppImage, no Wayland signals).

## UI / UX impact

- [x] No user-facing UI change

## Localization

- [x] No new user-facing copy

## Notes for review

Please double check the reasoning for extending the workaround beyond Wayland: I'm gating on AppImage/APPDIR presence rather than a stricter "definitely X11" check, since some X11 setups (like the reporter's) never populate `XDG_SESSION_TYPE` at all, and non-AppImage X11 installs are left untouched either way.

Closes #37
