### PR TITLE
docs: document local OpenAI-compatible model setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Panes is not a full IDE, but it does ship with a built-in multi-tab editor for q
 - Streaming chat with structured content blocks for text, thinking, actions, diffs, approvals, attachments, and usage updates
 - Codex chat integration via `codex app-server`
 - Claude chat integration via a Claude Agent SDK sidecar
+- OpenCode chat integration, including custom and local OpenAI-compatible providers (LM Studio, Ollama, vLLM, and others)
 - Plan mode, attachments, reasoning effort controls, per-thread approval/network overrides, and Codex-specific sandbox-mode overrides
 - Global FTS message search with keyboard navigation
 - Windowed message loading and lazy hydration for long threads/action output
@@ -166,6 +167,56 @@ This only works inside terminals launched by Panes, because the installed hook c
 Panes also listens for common desktop-notification OSC sequences emitted directly by programs running inside a Panes terminal session. These work without any Claude or Codex setup. The backend currently recognizes `OSC 9`, `OSC 777;notify;...`, and `OSC 99` notification payloads before terminal replay is recorded, so live notifications do not fire again when a terminal session is resumed.
 
 `OSC 9;4` progress reports are intentionally left alone and are not treated as notifications.
+
+### Using Local Models (LM Studio, Ollama, and Other OpenAI-Compatible Servers)
+
+Panes does not host or proxy models itself. Local model support comes from the chat engines it integrates, and there are two working paths today.
+
+**OpenCode engine**
+
+OpenCode accepts any OpenAI-compatible endpoint as a custom provider. Add a `provider` block to `opencode.json` (project-level) or `~/.config/opencode/opencode.json` (global). For LM Studio:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1"
+      },
+      "models": {
+        "qwen2.5-coder-7b-instruct": {
+          "name": "Qwen 2.5 Coder 7B"
+        }
+      }
+    }
+  }
+}
+```
+
+Replace the model id with whichever model is loaded in LM Studio, then start LM Studio's local server. With the `opencode` CLI installed, select the OpenCode engine in Panes' model picker: the provider shows up in the engine's provider list, with your configured models grouped underneath it. The same pattern works for Ollama, vLLM, or any other server that speaks the OpenAI-compatible API, just point `baseURL` at that server instead.
+
+**Codex engine**
+
+Recent Codex CLI releases ship `ollama` and `lmstudio` as reserved, built-in `model_providers` ids. Point Codex at one of them in `~/.codex/config.toml`:
+
+```toml
+model_provider = "lmstudio"
+model = "qwen2.5-coder-7b-instruct"
+```
+
+or define a custom endpoint yourself:
+
+```toml
+[model_providers.local_ollama]
+name = "Ollama (local)"
+base_url = "http://localhost:11434/v1"
+wire_api = "responses"
+```
+
+Panes' Codex engine reads whatever `codex app-server` reports from `model/list`, so once Codex CLI is configured this way, the resulting model appears in Panes' Codex model picker with no Panes-side setup. This depends on the installed Codex CLI version supporting `model_providers`; update Codex if a provider id is rejected.
 
 ### Production Build
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -43,6 +43,7 @@ O Panes não é uma IDE completa, mas inclui um editor multiaba embutido para re
 - Chat em streaming com blocos estruturados para texto, thinking, actions, diffs, approvals, attachments e atualizações de uso
 - Integração de chat com Codex via `codex app-server`
 - Integração de chat com Claude via sidecar do Claude Agent SDK
+- Integração de chat com OpenCode, incluindo providers customizados e locais compatíveis com OpenAI (LM Studio, Ollama, vLLM e outros)
 - Plan mode, attachments, controles de reasoning effort, overrides de approval/network por thread e overrides de sandbox mode específicos do Codex
 - Busca global de mensagens com FTS e navegação por teclado
 - Carregamento em janela e hidratação lazy para threads longas e outputs de action
@@ -133,6 +134,56 @@ Isso só funciona dentro de terminais abertos pelo Panes, porque o comando de ho
 O Panes também escuta sequências OSC comuns de notificação de desktop emitidas diretamente por programas rodando dentro de uma sessão de terminal do Panes. Elas funcionam sem nenhuma configuração de Claude ou Codex. Hoje o backend reconhece payloads de notificação `OSC 9`, `OSC 777;notify;...` e `OSC 99` antes de o replay do terminal ser gravado, então notificações ao vivo não disparam de novo quando a sessão do terminal é retomada.
 
 Relatórios de progresso `OSC 9;4` são deixados intactos de propósito e não são tratados como notificações.
+
+### Usando Modelos Locais (LM Studio, Ollama e Outros Servidores Compatíveis com OpenAI)
+
+O Panes não hospeda nem faz proxy de modelos por conta própria. O suporte a modelos locais vem das chat engines que ele integra, e hoje existem dois caminhos que funcionam.
+
+**Chat engine do OpenCode**
+
+O OpenCode aceita qualquer endpoint compatível com OpenAI como provider customizado. Adicione um bloco `provider` no `opencode.json` (no nível do projeto) ou em `~/.config/opencode/opencode.json` (global). Para o LM Studio:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:1234/v1"
+      },
+      "models": {
+        "qwen2.5-coder-7b-instruct": {
+          "name": "Qwen 2.5 Coder 7B"
+        }
+      }
+    }
+  }
+}
+```
+
+Troque o id do modelo pelo que estiver carregado no LM Studio e inicie o servidor local dele. Com o CLI `opencode` instalado, selecione a chat engine do OpenCode no model picker do Panes: o provider aparece na lista de providers da engine, com os modelos configurados agrupados abaixo dele. O mesmo padrão funciona para Ollama, vLLM ou qualquer outro servidor que fale a API compatível com OpenAI, bastando apontar o `baseURL` para esse servidor.
+
+**Chat engine do Codex**
+
+Versões recentes do Codex CLI trazem `ollama` e `lmstudio` como ids reservados e nativos em `model_providers`. Aponte o Codex para um deles em `~/.codex/config.toml`:
+
+```toml
+model_provider = "lmstudio"
+model = "qwen2.5-coder-7b-instruct"
+```
+
+ou defina um endpoint customizado por conta própria:
+
+```toml
+[model_providers.local_ollama]
+name = "Ollama (local)"
+base_url = "http://localhost:11434/v1"
+wire_api = "responses"
+```
+
+A chat engine do Codex no Panes lê o que o `codex app-server` reportar em `model/list`, então depois de configurar o Codex CLI dessa forma, o modelo resultante aparece no model picker do Codex no Panes sem nenhuma configuração adicional do lado do Panes. Isso depende da versão instalada do Codex CLI suportar `model_providers`; atualize o Codex se um id de provider for rejeitado.
 
 ### Build de Produção
 

--- a/src/components/chat/ModelPicker.tsx
+++ b/src/components/chat/ModelPicker.tsx
@@ -38,12 +38,14 @@ const PROVIDER_LABELS: Record<string, string> = {
   google: "Google",
   groq: "Groq",
   local: "Local",
+  lmstudio: "LM Studio",
   mistral: "Mistral",
   ollama: "Ollama",
   openai: "OpenAI",
   opencode: "OpenCode",
   openrouter: "OpenRouter",
   vertex: "Vertex",
+  vllm: "vLLM",
 };
 
 function formatModelName(name: string): string {


### PR DESCRIPTION
## Summary

Issue #28 asked how to chat with a local model (LM Studio, on macOS) in the Panes UI rather than the terminal. Panes does not host or proxy models itself, so the fix here is documentation plus a small labeling gap, not new engine code. Two paths already work end to end today:

- **OpenCode engine** (`src-tauri/src/engines/opencode.rs`): its live model discovery path is `list_models_runtime` (opencode.rs:1068), which calls `load_models_from_verbose_command` (opencode.rs:1267). That function shells out to `opencode models --verbose`, parses the output, and builds a `provider/model` slug from each record's `provider_id` and `id`, so custom providers a user defines in `opencode.json` show up the same as built-in ones. Note: `load_models_from_provider_endpoint` (opencode.rs:1324), which queries an OpenCode server's `/provider` HTTP endpoint directly, is marked `#[allow(dead_code)]` with no call sites; it is not the path Panes actually uses. Both functions key on `provider_id` the same way, so this correction does not change the shipped fix (the `PROVIDER_LABELS` entries render correctly regardless of which of the two paths produces the slug). Verified against OpenCode's own docs (https://opencode.ai/docs/providers/) that a `provider.lmstudio` block using `@ai-sdk/openai-compatible` with `baseURL: http://127.0.0.1:1234/v1` is the documented way to add LM Studio, and OpenCode's UI groups it by provider automatically once connected.
- **Codex engine** (`src-tauri/src/engines/codex.rs`): `list_models_runtime` / `fetch_models_from_server` (codex.rs:1721, 2058) call the Codex CLI's own `model/list` over `codex app-server` and pass through whatever it returns, with no Panes-side filtering. Verified against OpenAI's current Codex docs (https://developers.openai.com/codex/config-reference, https://developers.openai.com/codex/config-sample) that recent Codex CLI releases ship `ollama` and `lmstudio` as reserved built-in `model_providers` ids, selectable via `model_provider = "lmstudio"` in `~/.codex/config.toml`.

The one real gap: `src/components/chat/ModelPicker.tsx`'s `PROVIDER_LABELS` map (used to render a friendly name for each OpenCode provider) did not have entries for `lmstudio` or `vllm`, so those providers would have rendered with a capitalized raw id instead of a proper name.

## Changes

- `src/components/chat/ModelPicker.tsx`: add `lmstudio: "LM Studio"` and `vllm: "vLLM"` to `PROVIDER_LABELS`.
- `README.md`: add an OpenCode bullet to the Chat & Agents feature list, and a new "Using Local Models (LM Studio, Ollama, and Other OpenAI-Compatible Servers)" section under Getting Started with verified config examples for both the OpenCode and Codex paths.
- `README.pt-BR.md`: mirror both changes with a full Portuguese translation, per repo convention that translations ship together with the English docs.

## Validation

- [x] `pnpm typecheck` (clean)
- [x] `pnpm test` (396/397 passed; the one failure, `keepAwakeStore.test.ts`'s unsupported-runtime test, times out under full-suite load but passes in isolation and is unrelated to this change, a different store entirely)
- [x] `pnpm build` (succeeds; only pre-existing dynamic-import chunking warnings)
- [ ] `cd src-tauri && cargo check` (skipped, no Rust files touched)

## UI / UX impact

- [x] No user-facing UI change beyond the two new provider labels rendering correctly instead of falling back to a capitalized id

## Localization

- [ ] No new user-facing copy

`PROVIDER_LABELS` holds brand/product names (OpenAI, Anthropic, Ollama, OpenRouter, etc.) and is not run through the i18n layer anywhere in the existing code; the two new entries (LM Studio, vLLM) follow that same established pattern rather than introducing translated strings.

## Notes for review

Suggested reply for issue #28:

> Thanks for the detailed writeup, and glad you like the UI. Local models do work in Panes today, just not via Codex's default cloud setup. Two options:
>
> 1. Use the OpenCode engine (select it in the model/engine picker in chat). Add an OpenAI-compatible provider pointing at LM Studio in `opencode.json` (project) or `~/.config/opencode/opencode.json` (global):
>    ```json
>    {
>      "$schema": "https://opencode.ai/config.json",
>      "provider": {
>        "lmstudio": {
>          "npm": "@ai-sdk/openai-compatible",
>          "name": "LM Studio (local)",
>          "options": { "baseURL": "http://127.0.0.1:1234/v1" },
>          "models": { "<your-model-id>": { "name": "<display name>" } }
>        }
>      }
>    }
>    ```
>    Start LM Studio's local server, then pick the OpenCode engine in Panes; your LM Studio models show up grouped under "LM Studio" in the picker.
> 2. Or stay on Codex: recent Codex CLI versions ship a built-in `lmstudio` provider id. Set `model_provider = "lmstudio"` and `model = "<your-model-id>"` in `~/.codex/config.toml`, and Panes' Codex model picker will reflect it automatically since it just relays whatever `codex app-server` reports.
>
> Full writeup with both paths is now in the README. Closing this out with #43, please reopen if either path doesn't work for your Codex/OpenCode version.

Closes #28
