### PR TITLE
Add a discoverable file plus chat split view

### DIFF
--- a/src/components/shared/CommandPalette.test.ts
+++ b/src/components/shared/CommandPalette.test.ts
@@ -99,9 +99,6 @@ vi.mock("../../stores/terminalStore", () => ({
 }));
 
 const mockEnsureWorkspace = vi.hoisted(() => vi.fn());
-const mockSplitLeaf = vi.hoisted(() => vi.fn());
-const mockFocusLeaf = vi.hoisted(() => vi.fn());
-const mockActivateSurfaceInLeaf = vi.hoisted(() => vi.fn());
 
 vi.mock("../../stores/workspacePaneStore", () => ({
   collectWorkspacePaneLeaves: vi.fn(() => []),
@@ -111,9 +108,6 @@ vi.mock("../../stores/workspacePaneStore", () => ({
       showSurface: mockShowSurface,
       applyLegacyLayoutMode: vi.fn(),
       ensureWorkspace: mockEnsureWorkspace,
-      splitLeaf: mockSplitLeaf,
-      focusLeaf: mockFocusLeaf,
-      activateSurfaceInLeaf: mockActivateSurfaceInLeaf,
       workspaces: {},
     }),
   },

--- a/src/components/shared/CommandPalette.test.ts
+++ b/src/components/shared/CommandPalette.test.ts
@@ -98,6 +98,11 @@ vi.mock("../../stores/terminalStore", () => ({
   },
 }));
 
+const mockEnsureWorkspace = vi.hoisted(() => vi.fn());
+const mockSplitLeaf = vi.hoisted(() => vi.fn());
+const mockFocusLeaf = vi.hoisted(() => vi.fn());
+const mockActivateSurfaceInLeaf = vi.hoisted(() => vi.fn());
+
 vi.mock("../../stores/workspacePaneStore", () => ({
   collectWorkspacePaneLeaves: vi.fn(() => []),
   getWorkspacePaneActiveTab: vi.fn(() => null),
@@ -105,6 +110,10 @@ vi.mock("../../stores/workspacePaneStore", () => ({
     getState: () => ({
       showSurface: mockShowSurface,
       applyLegacyLayoutMode: vi.fn(),
+      ensureWorkspace: mockEnsureWorkspace,
+      splitLeaf: mockSplitLeaf,
+      focusLeaf: mockFocusLeaf,
+      activateSurfaceInLeaf: mockActivateSurfaceInLeaf,
       workspaces: {},
     }),
   },
@@ -138,6 +147,27 @@ describe("CommandPalette view-files command", () => {
     expect(mockUiState.setExplorerOpen).toHaveBeenCalledWith(true);
     expect(mockShowSurface).toHaveBeenCalledWith("ws-1", "editor");
     expect(mockSetLayoutMode).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("wires the split-view-editor command to the file plus chat split helper", async () => {
+    const { getStaticCommands } = await import("./CommandPalette");
+    const close = vi.fn();
+    const command = getStaticCommands(((key: string) => key) as never).find(
+      (entry) => entry.id === "layout-split-editor",
+    );
+
+    await command?.action({
+      activeWorkspaceId: "ws-1",
+      activeRepoPath: null,
+      repos: [],
+      close,
+      openSubFlow: vi.fn(),
+    });
+
+    expect(command?.label).toBe("commandPalette.commands.layoutSplitEditor");
+    expect(mockUiState.setActiveView).toHaveBeenCalledWith("chat");
+    expect(mockEnsureWorkspace).toHaveBeenCalledWith("ws-1", "chat");
     expect(close).toHaveBeenCalled();
   });
 });

--- a/src/components/shared/CommandPalette.tsx
+++ b/src/components/shared/CommandPalette.tsx
@@ -25,6 +25,7 @@ import {
   ChevronRight,
   type LucideIcon,
   SplitSquareHorizontal,
+  SquareSplitVertical,
   GitCommitHorizontal,
   ListTree,
   History,
@@ -57,6 +58,7 @@ import {
 import { formatRelativeTime } from "../../lib/formatters";
 import { createAndActivateWorkspaceThread } from "../../lib/newThreadActions";
 import {
+  applyWorkspaceEditorChatSplit,
   applyWorkspaceLayoutMode,
   showWorkspaceEditorForDirectFileOpen,
   showWorkspaceSurface,
@@ -239,6 +241,19 @@ export function getStaticCommands(
     action: ({ activeWorkspaceId, close }) => {
       if (activeWorkspaceId) {
         applyWorkspaceLayoutMode(activeWorkspaceId, "split");
+      }
+      close();
+    },
+  },
+  {
+    id: "layout-split-editor",
+    label: t("commandPalette.commands.layoutSplitEditor"),
+    icon: SquareSplitVertical,
+    group: "layout",
+    keywords: ["split", "editor", "file", "chat", "side by side", "dividir", "arquivo"],
+    action: ({ activeWorkspaceId, close }) => {
+      if (activeWorkspaceId) {
+        applyWorkspaceEditorChatSplit(activeWorkspaceId);
       }
       close();
     },

--- a/src/components/workspace/WorkspacePaneShell.tsx
+++ b/src/components/workspace/WorkspacePaneShell.tsx
@@ -808,7 +808,7 @@ function PaneLeafView({
     <section
       className={`workspace-pane-leaf${focused ? " workspace-pane-leaf-focused" : ""}${
         leafCount > 1 ? " workspace-pane-leaf-has-close" : ""
-      }`}
+      }${splitLabel ? " workspace-pane-leaf-has-split" : ""}`}
       data-workspace-pane-leaf-id={leaf.id}
       onMouseDownCapture={() => focusLeaf(workspaceId, leaf.id)}
     >

--- a/src/components/workspace/WorkspacePaneShell.tsx
+++ b/src/components/workspace/WorkspacePaneShell.tsx
@@ -14,6 +14,7 @@ import {
 import {
   FilePen,
   MessageSquare,
+  SquareSplitVertical,
   SquareTerminal,
   X,
 } from "lucide-react";
@@ -36,6 +37,7 @@ import {
   type WorkspacePaneSplitDirection,
   type WorkspacePaneSurfaceKind,
 } from "../../stores/workspacePaneStore";
+import { applyWorkspaceEditorChatSplit } from "../../lib/workspacePaneNavigation";
 import { handleDragDoubleClick, handleDragMouseDown } from "../../lib/windowDrag";
 import { isMacDesktop, usesCustomWindowFrame } from "../../lib/windowActions";
 
@@ -795,6 +797,12 @@ function PaneLeafView({
     surfaceDrag.targetLeafId === leaf.id &&
     surfaceDrag.placement !== null &&
     surfaceDrag.kind !== activeSurfaceKind;
+  const splitLabel =
+    activeSurfaceKind === "chat"
+      ? t("workspacePanes.splitWithEditor")
+      : activeSurfaceKind === "editor"
+        ? t("workspacePanes.splitWithChat")
+        : null;
 
   return (
     <section
@@ -804,6 +812,18 @@ function PaneLeafView({
       data-workspace-pane-leaf-id={leaf.id}
       onMouseDownCapture={() => focusLeaf(workspaceId, leaf.id)}
     >
+      {splitLabel && (
+        <button
+          type="button"
+          className="workspace-pane-split-btn"
+          title={splitLabel}
+          aria-label={splitLabel}
+          onClick={() => applyWorkspaceEditorChatSplit(workspaceId)}
+        >
+          <SquareSplitVertical size={12} />
+        </button>
+      )}
+
       {leafCount > 1 && (
         <button
           type="button"

--- a/src/globals.css
+++ b/src/globals.css
@@ -2229,13 +2229,21 @@ button, input, textarea, select {
 }
 
 .workspace-pane-leaf-has-close .terminal-tabs-bar,
-.workspace-pane-leaf-has-close .editor-tabs-bar {
+.workspace-pane-leaf-has-close .editor-tabs-bar,
+.workspace-pane-leaf-has-split .editor-tabs-bar {
   transition: padding-right var(--duration-fast) var(--ease-out);
 }
 
 .workspace-pane-leaf-focused.workspace-pane-leaf-has-close:hover .terminal-tabs-bar,
-.workspace-pane-leaf-focused.workspace-pane-leaf-has-close:hover .editor-tabs-bar {
+.workspace-pane-leaf-focused.workspace-pane-leaf-has-close:hover .editor-tabs-bar,
+.workspace-pane-leaf-focused.workspace-pane-leaf-has-split:hover .editor-tabs-bar {
   padding-right: 38px;
+}
+
+/* Both the close button and the split button float over this pane at once,
+   so the tab bar needs to clear both instead of just one. */
+.workspace-pane-leaf-focused.workspace-pane-leaf-has-close.workspace-pane-leaf-has-split:hover .editor-tabs-bar {
+  padding-right: 70px;
 }
 
 .workspace-pane-leaf-has-close .terminal-tabs-actions {

--- a/src/globals.css
+++ b/src/globals.css
@@ -2200,7 +2200,7 @@ button, input, textarea, select {
   justify-content: center;
   border: 0;
   border-radius: var(--radius-sm);
-  background: rgba(0, 0, 0, 0.48);
+  background: var(--floating-chip-bg, rgba(0, 0, 0, 0.48));
   color: var(--text-3);
   cursor: pointer;
   opacity: 0;
@@ -2224,7 +2224,7 @@ button, input, textarea, select {
 }
 
 .workspace-pane-split-btn:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--wash-08, rgba(255, 255, 255, 0.08));
   color: var(--text-1);
 }
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -2188,6 +2188,46 @@ button, input, textarea, select {
   color: var(--text-1);
 }
 
+.workspace-pane-split-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 9;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.48);
+  color: var(--text-3);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(4px);
+  transition: background var(--duration-fast) var(--ease-out),
+              color var(--duration-fast) var(--ease-out),
+              opacity var(--duration-fast) var(--ease-out),
+              transform var(--duration-fast) var(--ease-out);
+}
+
+.workspace-pane-leaf-has-close .workspace-pane-split-btn {
+  right: 38px;
+}
+
+.workspace-pane-leaf-focused:hover .workspace-pane-split-btn,
+.workspace-pane-split-btn:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(0);
+}
+
+.workspace-pane-split-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-1);
+}
+
 .workspace-pane-leaf-has-close .terminal-tabs-bar,
 .workspace-pane-leaf-has-close .editor-tabs-bar {
   transition: padding-right var(--duration-fast) var(--ease-out);

--- a/src/i18n/resources/en/app.json
+++ b/src/i18n/resources/en/app.json
@@ -83,6 +83,7 @@
     "commands": {
       "layoutChat": "Switch to Chat",
       "layoutSplit": "Switch to Split View",
+      "layoutSplitEditor": "Switch to Split View: File + Chat",
       "layoutTerminal": "Switch to Terminal",
       "layoutEditor": "Switch to File Editor",
       "toggleSidebar": "Toggle Sidebar",
@@ -298,6 +299,8 @@
     "primarySurfaceTitle": "Switch to {{surface}}",
     "emptyPane": "Drag Chat, Terminal, or Editor here.",
     "closePane": "Close pane",
+    "splitWithEditor": "Open file editor beside chat",
+    "splitWithChat": "Open chat beside file editor",
     "dropZones": {
       "left": "Split left with {{surface}}",
       "right": "Split right with {{surface}}",

--- a/src/i18n/resources/pt-BR/app.json
+++ b/src/i18n/resources/pt-BR/app.json
@@ -83,6 +83,7 @@
     "commands": {
       "layoutChat": "Ir para Chat",
       "layoutSplit": "Ir para Visão dividida",
+      "layoutSplitEditor": "Ir para Visão dividida: Arquivo + Chat",
       "layoutTerminal": "Ir para Terminal",
       "layoutEditor": "Ir para Editor de arquivos",
       "toggleSidebar": "Alternar Sidebar",
@@ -298,6 +299,8 @@
     "primarySurfaceTitle": "Ir para {{surface}}",
     "emptyPane": "Arraste Chat, Terminal ou Editor para cá.",
     "closePane": "Fechar painel",
+    "splitWithEditor": "Abrir editor de arquivos ao lado do chat",
+    "splitWithChat": "Abrir chat ao lado do editor de arquivos",
     "dropZones": {
       "left": "Dividir à esquerda com {{surface}}",
       "right": "Dividir à direita com {{surface}}",

--- a/src/lib/workspacePaneNavigation.test.ts
+++ b/src/lib/workspacePaneNavigation.test.ts
@@ -299,4 +299,36 @@ describe("applyWorkspaceEditorChatSplit", () => {
       "editor",
     ]);
   });
+
+  it("focuses the existing editor pane in a genuinely nested three-leaf tree", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "split");
+    const [chatLeaf, terminalLeaf] = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    );
+    // Split the terminal leaf with the editor, producing a split-of-a-split:
+    // root(horizontal)[chat, split(vertical)[terminal, editor]].
+    useWorkspacePaneStore.getState().splitLeaf("ws-1", terminalLeaf.id, "vertical", "editor");
+    useWorkspacePaneStore.getState().focusLeaf("ws-1", terminalLeaf.id);
+    const layoutBefore = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leavesBefore = collectWorkspacePaneLeaves(layoutBefore.root);
+    expect(leavesBefore).toHaveLength(3);
+    expect(layoutBefore.root.type).toBe("split");
+    expect(
+      layoutBefore.root.type === "split" ? layoutBefore.root.children[1].type : null,
+    ).toBe("split");
+
+    applyWorkspaceEditorChatSplit("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    const editorLeaf = leaves.find((leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "editor");
+    expect(layout.root).toEqual(layoutBefore.root);
+    expect(leaves).toHaveLength(3);
+    expect(leaves.map((leaf) => leaf.id)).toEqual([
+      chatLeaf.id,
+      terminalLeaf.id,
+      editorLeaf?.id,
+    ]);
+    expect(layout.focusedLeafId).toBe(editorLeaf?.id);
+  });
 });

--- a/src/lib/workspacePaneNavigation.test.ts
+++ b/src/lib/workspacePaneNavigation.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../stores/workspacePaneStore";
 import { useUiStore } from "../stores/uiStore";
 import {
+  applyWorkspaceEditorChatSplit,
   showWorkspaceEditorForDirectFileOpen,
   showWorkspaceEditorForFileLink,
 } from "./workspacePaneNavigation";
@@ -195,5 +196,107 @@ describe("showWorkspaceEditorForFileLink", () => {
       "editor",
     ]);
     expect(layout.focusedLeafId).toBe(editorLeaf.id);
+  });
+});
+
+describe("applyWorkspaceEditorChatSplit", () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn((key: string) => storage.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        storage.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        storage.delete(key);
+      }),
+      clear: vi.fn(() => {
+        storage.clear();
+      }),
+      key: vi.fn((index: number) => Array.from(storage.keys())[index] ?? null),
+      get length() {
+        return storage.size;
+      },
+    });
+    useWorkspacePaneStore.setState({ workspaces: {} });
+    useUiStore.setState({ activeView: "harnesses", showExplorer: true });
+    mockSetLayoutMode.mockClear();
+    for (const key of Object.keys(terminalWorkspaces)) {
+      delete terminalWorkspaces[key];
+    }
+  });
+
+  it("splits a chat-only pane with the editor, side by side", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "chat");
+    const sourceLeaf = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0];
+
+    applyWorkspaceEditorChatSplit("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(layout.root.type).toBe("split");
+    expect(layout.root.type === "split" ? layout.root.direction : null).toBe("vertical");
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "chat",
+      "editor",
+    ]);
+    expect(leaves[0].id).toBe(sourceLeaf.id);
+    expect(layout.focusedLeafId).toBe(leaves[1].id);
+    expect(useUiStore.getState().activeView).toBe("chat");
+  });
+
+  it("splits an editor-only pane with chat placed before it", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "editor");
+    const sourceLeaf = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0];
+
+    applyWorkspaceEditorChatSplit("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "chat",
+      "editor",
+    ]);
+    expect(leaves[1].id).toBe(sourceLeaf.id);
+  });
+
+  it("focuses the existing editor pane instead of creating a nested split", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "chat");
+    const sourceLeaf = collectWorkspacePaneLeaves(
+      useWorkspacePaneStore.getState().workspaces["ws-1"].root,
+    )[0];
+    useWorkspacePaneStore.getState().splitLeaf("ws-1", sourceLeaf.id, "vertical", "editor");
+    useWorkspacePaneStore.getState().focusLeaf(
+      "ws-1",
+      collectWorkspacePaneLeaves(useWorkspacePaneStore.getState().workspaces["ws-1"].root)[0].id,
+    );
+    const rootBefore = useWorkspacePaneStore.getState().workspaces["ws-1"].root;
+
+    applyWorkspaceEditorChatSplit("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    const editorLeaf = leaves.find((leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "editor");
+    expect(layout.root).toEqual(rootBefore);
+    expect(layout.focusedLeafId).toBe(editorLeaf?.id);
+  });
+
+  it("converts a terminal-only pane to chat and splits it with the editor", () => {
+    useWorkspacePaneStore.getState().ensureWorkspace("ws-1", "terminal");
+
+    applyWorkspaceEditorChatSplit("ws-1");
+
+    const layout = useWorkspacePaneStore.getState().workspaces["ws-1"];
+    const leaves = collectWorkspacePaneLeaves(layout.root);
+    expect(leaves.map((leaf) => getWorkspacePaneActiveTab(leaf)?.kind)).toEqual([
+      "chat",
+      "editor",
+    ]);
   });
 });

--- a/src/lib/workspacePaneNavigation.ts
+++ b/src/lib/workspacePaneNavigation.ts
@@ -101,6 +101,47 @@ export function applyWorkspaceLayoutMode(workspaceId: string, mode: LayoutMode):
   syncTerminalLayoutMode(workspaceId);
 }
 
+export function applyWorkspaceEditorChatSplit(workspaceId: string): void {
+  useUiStore.getState().setActiveView("chat");
+
+  let paneStore = useWorkspacePaneStore.getState();
+  let layout = paneStore.workspaces[workspaceId];
+  if (!layout) {
+    const terminalMode = useTerminalStore.getState().workspaces[workspaceId]?.layoutMode ?? "chat";
+    paneStore.ensureWorkspace(workspaceId, terminalMode);
+    paneStore = useWorkspacePaneStore.getState();
+    layout = paneStore.workspaces[workspaceId];
+    if (!layout) {
+      return;
+    }
+  }
+
+  const leaves = collectWorkspacePaneLeaves(layout.root);
+  const chatLeaf = leaves.find((leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "chat");
+  const editorLeaf = leaves.find((leaf) => getWorkspacePaneActiveTab(leaf)?.kind === "editor");
+
+  if (chatLeaf && editorLeaf) {
+    paneStore.focusLeaf(workspaceId, editorLeaf.id);
+    syncTerminalLayoutMode(workspaceId);
+    return;
+  }
+
+  if (chatLeaf && !editorLeaf) {
+    paneStore.splitLeaf(workspaceId, chatLeaf.id, "vertical", "editor", "after");
+  } else if (editorLeaf && !chatLeaf) {
+    paneStore.splitLeaf(workspaceId, editorLeaf.id, "vertical", "chat", "before");
+  } else {
+    const anchor = leaves.find((leaf) => leaf.id === layout.focusedLeafId) ?? leaves[0] ?? null;
+    if (!anchor) {
+      return;
+    }
+    paneStore.activateSurfaceInLeaf(workspaceId, anchor.id, "chat");
+    paneStore.splitLeaf(workspaceId, anchor.id, "vertical", "editor", "after");
+  }
+
+  syncTerminalLayoutMode(workspaceId);
+}
+
 export function getWorkspacePaneLayoutMode(workspaceId: string): LayoutMode | null {
   return useWorkspacePaneStore.getState().workspaces[workspaceId]?.legacyMode ?? null;
 }


### PR DESCRIPTION
## Summary

Chat, terminal, and editor already coexisted in a resizable split-pane tree (dragging a surface tab onto another pane, or Shift plus Arrow keys while a surface tab is focused, both create a split), but neither gesture is discoverable. The existing "Switch to Split View" command palette entry only pairs chat with the terminal, not with the file editor, which is likely why this was reported as missing. This adds an explicit, one-click way to see a file and chat side by side, on top of the existing pane infrastructure.

## Changes

- Added `applyWorkspaceEditorChatSplit` in `src/lib/workspacePaneNavigation.ts`, which reuses the existing pane store actions (`splitLeaf`, `focusLeaf`, `activateSurfaceInLeaf`) to open chat and the editor side by side, or focus the editor pane if both are already visible (no duplicate/nested splits).
- Added a small split-view button to chat and editor panes (visible on hover, next to the existing close-pane button) that calls the helper above.
- Added a "Switch to Split View: File + Chat" command palette entry (distinct from the existing terminal split command) wired to the same helper.
- Added a `workspace-pane-leaf-has-split` marker class, mirroring the existing `workspace-pane-leaf-has-close` mechanism, so the editor tab bar reserves enough padding to clear the split button whether it is the only floating button (single pane) or shown together with the close button (multi pane, 70px instead of 38px).
- Added unit tests for the new helper (chat-only, editor-only, already-split with a flat two-leaf tree, a genuinely nested three-leaf tree, and terminal-only starting states) and for the new command palette entry.
- Added i18n keys in both `en` and `pt-BR`.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test` (54 files, 403 tests passing)
- [x] `pnpm build`
- [ ] `cd src-tauri && cargo check` (skipped intentionally, no Rust files touched)

Also visually verified the tab bar padding fix by reproducing the exact DOM structure and the real globals.css in a local browser (single pane editor, multi pane editor plus chat, multi pane terminal, and single pane chat), hovering each to trigger the real CSS, and confirming no overlap between the floating buttons and the editor tab actions in any combination.

## UI / UX impact

- [ ] No user-facing UI change
- [ ] Screenshots or screen recording attached (not attached in this PR; could not launch the desktop app from this environment, happy to add on request)

## Localization

- [ ] No new user-facing copy
- [x] Updated both `src/i18n/resources/en/` and `src/i18n/resources/pt-BR/`

## Notes for review

The underlying split-pane tree and its store actions already existed on master; this PR only adds the discoverable entry points on top of them, so the diff is intentionally small (no changes to the pane tree data model or rendering logic beyond the two new buttons).

The split button also adopts the `--floating-chip-bg` and `--wash-08` tokens introduced by the light mode work for its background and hover background, each with the current dark literal as a fallback, so it stays correct on its own and themes correctly once light mode merges.

Closes #35

