### PR TITLE
Add experimental Flatpak packaging with mise-based harness installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ openspec/
 
 # Nested repos
 remotion/
+
+# Local flatpak-builder build output
+.flatpak-builder/
+build-flatpak/

--- a/com.panes.app.yml
+++ b/com.panes.app.yml
@@ -1,6 +1,6 @@
 app-id: com.panes.app
 runtime: org.gnome.Platform
-runtime-version: "49"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 command: panes-wrapper
 sdk-extensions:
@@ -50,8 +50,8 @@ modules:
       - make prefix=/app NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease install
     sources:
       - type: archive
-        url: https://www.kernel.org/pub/software/scm/git/git-2.49.1.tar.xz
-        sha256: 310831de967f1c8c5e8ff55f92807dea89f83dc3d3d2a5d16c209bd01a31def1
+        url: https://www.kernel.org/pub/software/scm/git/git-2.55.0.tar.xz
+        sha256: 457fdb04dc8728e007d4688695e6912e6f680727920f2a40bf11eacc17505357
 
   - name: node-runtime
     buildsystem: simple
@@ -64,14 +64,14 @@ modules:
       - ln -sf ../lib/node/bin/npx /app/bin/npx
     sources:
       - type: file
-        url: https://nodejs.org/dist/v20.20.1/node-v20.20.1-linux-x64.tar.xz
-        sha256: 1592ef30f7a63309581a130f7fd8b3311a3e08ee0c609a3d13234590fe35409f
+        url: https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-x64.tar.xz
+        sha256: df770b2a6f130ed8627c9782c988fda9669fa23898329a61a871e32f965e007d
         dest-filename: node.tar.xz
         only-arches:
           - x86_64
       - type: file
-        url: https://nodejs.org/dist/v20.20.1/node-v20.20.1-linux-arm64.tar.xz
-        sha256: f9a7b07fafd1adaf2c375af2ede31f462395377a8a6c9427d32793a68135e774
+        url: https://nodejs.org/dist/v20.20.2/node-v20.20.2-linux-arm64.tar.xz
+        sha256: 73093db209e4e9e09dd7d15a47aeaab1b74833830df03efa5f942a1122c5fa71
         dest-filename: node.tar.xz
         only-arches:
           - aarch64

--- a/com.panes.app.yml
+++ b/com.panes.app.yml
@@ -1,0 +1,102 @@
+app-id: com.panes.app
+runtime: org.gnome.Platform
+runtime-version: "49"
+sdk: org.gnome.Sdk
+command: panes-wrapper
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node20
+  - org.freedesktop.Sdk.Extension.rust-stable
+
+finish-args:
+  # Display. Wayland is preferred, X11 is a fallback for non-Wayland sessions.
+  - --socket=wayland
+  - --socket=fallback-x11
+  # GPU acceleration for the webview.
+  - --device=dri
+  # Required by the webview process model.
+  - --share=ipc
+  # Codex, Claude, OpenCode, and git all need outbound network access.
+  - --share=network
+  # System tray icon (Cargo.toml enables the tauri "tray-icon" feature).
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --filesystem=xdg-run/tray-icon:create
+  # Desktop notifications for long-running agent turns.
+  - --talk-name=org.freedesktop.Notifications
+  # Git operations over SSH remotes.
+  - --socket=ssh-auth
+  # Deliberately NOT requesting --filesystem=host or --filesystem=home.
+  # Panes opens workspace folders exclusively through
+  # @tauri-apps/plugin-dialog, which on Linux routes through the
+  # xdg-desktop-portal FileChooser and returns a document-portal path
+  # under /run/flatpak/doc/. Editing, git, and terminal sessions then
+  # operate against that portal-granted path rather than an
+  # unrestricted host mount. See flatpak/README.md for the caveats
+  # this design still needs verified on real hardware.
+
+build-options:
+  append-path: /usr/lib/sdk/node20/bin:/usr/lib/sdk/rust-stable/bin
+  build-args:
+    - --share=network
+  env:
+    CARGO_HOME: /run/build/panes/cargo
+    XDG_CACHE_HOME: /run/build/panes/xdg-cache
+    npm_config_cache: /run/build/panes/npm-cache
+    PNPM_STORE_DIR: /run/build/panes/pnpm-store
+
+modules:
+  - name: git-runtime
+    buildsystem: simple
+    build-commands:
+      - make prefix=/app NO_PERL=YesPlease NO_TCLTK=YesPlease NO_GETTEXT=YesPlease install
+    sources:
+      - type: archive
+        url: https://www.kernel.org/pub/software/scm/git/git-2.49.1.tar.xz
+        sha256: 310831de967f1c8c5e8ff55f92807dea89f83dc3d3d2a5d16c209bd01a31def1
+
+  - name: node-runtime
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/bin /app/lib/node
+      - tar -xJf node.tar.xz --strip-components=1 -C /app/lib/node
+      - ln -sf ../lib/node/bin/corepack /app/bin/corepack
+      - ln -sf ../lib/node/bin/node /app/bin/node
+      - ln -sf ../lib/node/bin/npm /app/bin/npm
+      - ln -sf ../lib/node/bin/npx /app/bin/npx
+    sources:
+      - type: file
+        url: https://nodejs.org/dist/v20.20.1/node-v20.20.1-linux-x64.tar.xz
+        sha256: 1592ef30f7a63309581a130f7fd8b3311a3e08ee0c609a3d13234590fe35409f
+        dest-filename: node.tar.xz
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://nodejs.org/dist/v20.20.1/node-v20.20.1-linux-arm64.tar.xz
+        sha256: f9a7b07fafd1adaf2c375af2ede31f462395377a8a6c9427d32793a68135e774
+        dest-filename: node.tar.xz
+        only-arches:
+          - aarch64
+
+  - name: mise-runtime
+    buildsystem: simple
+    build-commands:
+      - cargo install --root /app mise --version 2026.7.0 --locked
+    sources: []
+
+  - name: panes
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/bin /app/lib/Panes /app/libexec
+      - npm exec --yes pnpm@9 install --frozen-lockfile
+      - PANES_SKIP_DESKTOP_PREBUILD= npm exec --yes pnpm@9 run build:desktop
+      - cargo build --manifest-path src-tauri/Cargo.toml --release
+      - bin_path="$(find src-tauri/target/release -maxdepth 1 -type f -perm -111 \( -name 'Panes' -o -name 'panes' \) | head -n1)" && test -n "$bin_path" && install -Dm755 "$bin_path" /app/bin/Panes
+      - install -Dm644 src-tauri/sidecar-dist/claude-agent-sdk-server.mjs /app/lib/Panes/sidecar-dist/claude-agent-sdk-server.mjs
+      - install -Dm755 flatpak/panes-wrapper.sh /app/bin/panes-wrapper
+      - install -Dm644 flatpak/mise-env.sh /app/etc/profile.d/mise-env.sh
+      - install -Dm644 flatpak/com.panes.app.desktop /app/share/applications/com.panes.app.desktop
+      - install -Dm644 flatpak/com.panes.app.metainfo.xml /app/share/metainfo/com.panes.app.metainfo.xml
+      - install -Dm644 src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.panes.app.png
+      - install -Dm644 src-tauri/icons/icon.svg /app/share/icons/hicolor/scalable/apps/com.panes.app.svg
+    sources:
+      - type: dir
+        path: .

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -19,16 +19,33 @@ step, but the design decisions (runtime, sandboxing model, mise) are his.
 ## Building locally
 
 ```sh
-flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49
-flatpak install flathub org.freedesktop.Sdk.Extension.node20//24.08 org.freedesktop.Sdk.Extension.rust-stable//24.08
-flatpak-builder --user --install --force-clean build-flatpak com.panes.app.yml
+flatpak-builder --user --install --force-clean \
+  --install-deps-from=flathub \
+  build-flatpak com.panes.app.yml
 flatpak run com.panes.app
 ```
+
+`--install-deps-from=flathub` installs `org.gnome.Platform//50`,
+`org.gnome.Sdk//50`, and whatever branch of the `node20` and `rust-stable`
+SDK extensions that SDK version actually requires, resolved by
+flatpak-builder itself rather than a hand-picked branch in this README. An
+earlier draft of this file hardcoded `org.freedesktop.Sdk.Extension.node20//24.08`,
+which was a guess, not a verified pairing for GNOME 50; letting
+flatpak-builder resolve it avoids shipping a wrong pin.
 
 The manifest allows network access during the build (`--share=network` in
 `build-options.build-args`) so `pnpm`, `cargo`, and the bundled `mise`
 runtime can fetch dependencies. This is normal for a local build and is not
 part of the app's runtime sandbox.
+
+Runtime version note: `org.gnome.Platform//50` was verified against
+[GNOME's own release notes](https://release.gnome.org/50/) (GNOME 50 shipped
+2026-03-18) and its [Flathub listing](https://flathub.org/apps/org.gnome.Platform)
+as of this writing. GNOME 49 (the previous line) remains supported until
+roughly September 2026, so it would not have been wrong to stay on it, but
+50 is the current line and there was no reason to ship one cycle behind.
+Re-check both facts against Flathub before relying on this note long after
+it was written, since runtime support windows move.
 
 ## Sandboxing model: no host filesystem access
 
@@ -55,6 +72,28 @@ Every other permission in `finish-args` is commented in the manifest with
 why it is requested (display sockets, `--device=dri` for GPU accelerated
 rendering, `--share=network` for git/agent traffic, the tray icon
 talk-names, notifications, and `--socket=ssh-auth` for git-over-SSH).
+
+### Known gap: chat attachment drag-and-drop bypasses the portal
+
+Dropping a file onto the chat composer (`ChatPanel.tsx`'s
+`onDragDropEvent` handler, which calls `appendAttachmentsFromPaths` with
+whatever `event.payload.paths` the native window drag-and-drop event
+reports) receives real host filesystem paths directly from the window
+system, not through `xdg-desktop-portal`. Outside a sandbox this is fine;
+inside this Flatpak sandbox, a path handed over this way was never granted
+by the portal and will not be readable, so dropped files will silently fail
+to attach.
+
+This has not been fixed in this PR. The attach button in the chat composer
+(`ChatPanel.tsx`, the `@tauri-apps/plugin-dialog` based attach flow) is
+portal-safe and gives users a working alternative, so this is a rough edge
+rather than a broken feature, but it should be fixed properly rather than
+left as a silent failure: either detect the sandbox and show a message
+explaining that drag-and-drop attachments do not work there, or find a way
+to route dropped paths through the portal. Doing either requires exposing
+`runtime_env::is_flatpak()` to the frontend, which no existing IPC command
+currently does; that is a small, separate follow-up rather than something to
+bolt onto this PR's harness-install and workspace-path changes.
 
 ## Installing agent CLIs inside the sandbox (mise)
 
@@ -104,9 +143,10 @@ considered resolved; the maintainer or jgillich are best placed to do that.
 ## What still needs verifying on Linux
 
 - The manifest builds and `flatpak-builder` succeeds (untested here).
-- The `org.gnome.Platform//49` runtime and matching SDK extensions are
-  actually current on Flathub at build time; verify with `flatpak remote-info`
-  and bump if a newer runtime has since become the recommended baseline.
+- The `org.gnome.Platform//50` runtime is still current on Flathub at build
+  time; verify with `flatpak remote-info` and bump if a newer runtime has
+  since become the recommended baseline (see the runtime version note under
+  "Building locally").
 - The document-portal folder grant actually persists correctly across
   Panes restarts, and that terminal sessions can read/write the full
   directory tree under the granted folder, not just files explicitly
@@ -114,6 +154,22 @@ considered resolved; the maintainer or jgillich are best placed to do that.
 - Whether the curl-pipe harness installers (Kiro, Factory Droid) work at
   all inside the sandbox.
 - The Codex auth issue above.
+- The chat attachment drag-and-drop gap above.
 - Terminal PTY behavior, clipboard, and tray icon integration inside the
   sandbox, which the original issue thread flagged as rough even before the
   mise/permissions changes in this PR.
+- `flatpak/com.panes.app.desktop` does not set `StartupWMClass`. Panes'
+  AppImage desktop-entry generator (`src-tauri/src/linux_appimage.rs`)
+  deliberately omits it too, and its test suite asserts that omission, which
+  reads as a signal that the runtime `WM_CLASS` Tauri/wry sets on Linux does
+  not actually match `Panes`; setting it to a wrong value would break
+  taskbar/dock window matching worse than leaving it unset. This was not
+  independently reverified on real hardware for this PR, it was matched to
+  the existing precedent. If a future change verifies the actual `WM_CLASS`
+  Panes' window reports on Linux, add `StartupWMClass` back with the
+  correct value in both places.
+- `flatpak/com.panes.app.metainfo.xml`'s `<releases>` block has a single
+  hardcoded entry (currently `0.59.1`) with no wiring into
+  `scripts/generate-update-manifest.mjs` or the release workflow. It needs
+  to be bumped by hand on every release until (or unless) someone wires it
+  into the existing release automation.

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,119 @@
+# Flatpak packaging (experimental)
+
+Status: this manifest builds Panes from source and installs it into a Flatpak
+sandbox with no host filesystem access. It has been reviewed and written
+against the current source tree, but has not been built or run on a real
+Linux machine as part of this change (it was authored on macOS). Treat it as
+a draft that needs a Linux verification pass before it is offered as a
+distribution channel. See "What still needs verifying" below.
+
+Credit: this manifest, the `mise` based tool install approach, and the
+document-portal path fix in `src-tauri/src/path_utils.rs` are based on the
+work contributor jgillich shared on
+[jgillich/panes@flatpak](https://github.com/jgillich/panes/tree/flatpak) in
+response to issue #8. It has been rebased onto the current source tree
+(the original branch was cut against v0.33) and adjusted to use the
+project's own `pnpm run build:desktop` script instead of a hand rolled build
+step, but the design decisions (runtime, sandboxing model, mise) are his.
+
+## Building locally
+
+```sh
+flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49
+flatpak install flathub org.freedesktop.Sdk.Extension.node20//24.08 org.freedesktop.Sdk.Extension.rust-stable//24.08
+flatpak-builder --user --install --force-clean build-flatpak com.panes.app.yml
+flatpak run com.panes.app
+```
+
+The manifest allows network access during the build (`--share=network` in
+`build-options.build-args`) so `pnpm`, `cargo`, and the bundled `mise`
+runtime can fetch dependencies. This is normal for a local build and is not
+part of the app's runtime sandbox.
+
+## Sandboxing model: no host filesystem access
+
+Panes is a tool that runs arbitrary agent-driven commands against a user's
+repositories, which is exactly the case Flatpak's sandboxing is meant to
+help with. This manifest does not request `--filesystem=host` or
+`--filesystem=home`. Instead:
+
+- Workspace folders are opened exclusively through
+  `@tauri-apps/plugin-dialog`, which on Linux is backed by the
+  `xdg-desktop-portal` FileChooser portal. Outside a sandbox this returns a
+  real path; inside a Flatpak sandbox it returns a document-portal path
+  under `/run/flatpak/doc/<id>/...`.
+- `src-tauri/src/path_utils.rs` now leaves `/run/flatpak/doc/` paths
+  untouched instead of canonicalizing them, because canonicalizing a portal
+  path can resolve it away from the bind mount the portal set up. Without
+  this, `db/workspaces.rs` would store a path that stops resolving once the
+  portal session ends.
+- Everything downstream (terminal `cwd`, git operations, the file editor)
+  operates on whatever path was granted, portal or real, without further
+  special casing.
+
+Every other permission in `finish-args` is commented in the manifest with
+why it is requested (display sockets, `--device=dri` for GPU accelerated
+rendering, `--share=network` for git/agent traffic, the tray icon
+talk-names, notifications, and `--socket=ssh-auth` for git-over-SSH).
+
+## Installing agent CLIs inside the sandbox (mise)
+
+Flatpak apps cannot see host-installed programs. Harness CLIs like `codex`,
+`claude`, or `opencode` are normally installed with a global `npm install
+-g`, but a Flatpak's `/app` is read-only at runtime, so that has nowhere to
+write to.
+
+The manifest bundles [mise](https://mise.jdx.dev/) (installed via `cargo
+install --root /app mise`) as a user-mode tool manager. `flatpak/mise-env.sh`
+is installed to `/app/etc/profile.d/` and sourced by `flatpak/panes-wrapper.sh`
+before the app launches, so `mise`'s shim directory
+(`~/.local/share/mise/shims`, already on Panes' search path via
+`runtime_env::augmented_path_entries_for`) is present for every session.
+
+On the backend, `src-tauri/src/commands/harness.rs`'s `check_harnesses` now
+reports a `preferred_install_method` ("mise" or "npm") based on
+`runtime_env::is_flatpak()` and whether `mise` is resolvable, and
+`install_harness` runs `mise use -g npm:<package>` instead of `npm install -g
+<package>` when that's the preferred method. The onboarding harness panel
+mirrors this in its install-command display and its "install in terminal"
+/ "copy command" actions.
+
+This only affects harnesses whose install method is an npm package
+(`codex`, `gemini-cli`, `opencode`, `kilo-code`). The curl-pipe installers
+for Kiro and Factory Droid are unchanged and untested inside the sandbox;
+whether their install scripts write somewhere usable inside `/app` or
+`$HOME` has not been verified.
+
+## Known open question: Codex auth inside the sandbox
+
+jgillich reported `codex` returning 401 Unauthorized inside his Flatpak
+build even with `~/.codex` mounted. This has not been reproduced or root
+caused as part of this change (no Linux environment was available). Two
+plausible causes, unverified:
+
+- Codex's login flow may rely on a system keyring or a `xdg-desktop-portal`
+  Secret Service interaction that this manifest does not grant
+  (`org.freedesktop.secrets` is not in `finish-args`).
+- Codex CLI may write its credential file to a path this sandbox's `$HOME`
+  does not match if the mount inside the sandbox differs from the host's
+  `~/.codex` in ownership or permissions.
+
+This needs to be debugged on a real Flatpak install before the issue can be
+considered resolved; the maintainer or jgillich are best placed to do that.
+
+## What still needs verifying on Linux
+
+- The manifest builds and `flatpak-builder` succeeds (untested here).
+- The `org.gnome.Platform//49` runtime and matching SDK extensions are
+  actually current on Flathub at build time; verify with `flatpak remote-info`
+  and bump if a newer runtime has since become the recommended baseline.
+- The document-portal folder grant actually persists correctly across
+  Panes restarts, and that terminal sessions can read/write the full
+  directory tree under the granted folder, not just files explicitly
+  touched through the portal.
+- Whether the curl-pipe harness installers (Kiro, Factory Droid) work at
+  all inside the sandbox.
+- The Codex auth issue above.
+- Terminal PTY behavior, clipboard, and tray icon integration inside the
+  sandbox, which the original issue thread flagged as rough even before the
+  mise/permissions changes in this PR.

--- a/flatpak/com.panes.app.desktop
+++ b/flatpak/com.panes.app.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Panes
+Comment=Local-first cockpit for AI-assisted coding
+Exec=panes-wrapper %U
+Icon=com.panes.app
+Terminal=false
+Categories=Development;IDE;
+StartupWMClass=Panes

--- a/flatpak/com.panes.app.desktop
+++ b/flatpak/com.panes.app.desktop
@@ -6,4 +6,3 @@ Exec=panes-wrapper %U
 Icon=com.panes.app
 Terminal=false
 Categories=Development;IDE;
-StartupWMClass=Panes

--- a/flatpak/com.panes.app.metainfo.xml
+++ b/flatpak/com.panes.app.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.panes.app</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Panes</name>
+  <summary>Local-first cockpit for AI-assisted coding</summary>
+  <description>
+    <p>Panes is a local-first desktop app for AI-assisted coding workflows.</p>
+    <p>It combines chat-based coding agents, git operations, terminal sessions, and lightweight file editing in one place.</p>
+  </description>
+  <launchable type="desktop-id">com.panes.app.desktop</launchable>
+  <developer id="com.panes">
+    <name>Panes contributors</name>
+  </developer>
+  <url type="homepage">https://panesade.com</url>
+  <url type="bugtracker">https://github.com/wygoralves/panes/issues</url>
+  <url type="vcs-browser">https://github.com/wygoralves/panes</url>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.59.1" date="2026-07-05"/>
+  </releases>
+</component>

--- a/flatpak/mise-env.sh
+++ b/flatpak/mise-env.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
+export MISE_DATA_DIR="${MISE_DATA_DIR:-$XDG_DATA_HOME/mise}"
+export MISE_CONFIG_DIR="${MISE_CONFIG_DIR:-$XDG_CONFIG_HOME/mise}"
+export MISE_STATE_DIR="${MISE_STATE_DIR:-$XDG_STATE_HOME/mise}"
+
+case ":${PATH:-}:" in
+  *":/app/bin:"*) ;;
+  *) PATH="/app/bin:/usr/bin:/bin${PATH:+:$PATH}" ;;
+esac
+
+case ":$PATH:" in
+  *":$MISE_DATA_DIR/shims:"*) ;;
+  *) PATH="$MISE_DATA_DIR/shims:$PATH" ;;
+esac
+
+export PATH

--- a/flatpak/panes-wrapper.sh
+++ b/flatpak/panes-wrapper.sh
@@ -2,7 +2,9 @@
 set -eu
 
 if [ -f /app/etc/profile.d/mise-env.sh ]; then
-  . /app/etc/profile.d/mise-env.sh
+  # A failure while sourcing this (e.g. an unbound variable under some
+  # future edit) must not block the app from launching under `set -eu`.
+  . /app/etc/profile.d/mise-env.sh || true
 fi
 
 export SHELL="${SHELL:-/usr/bin/bash}"

--- a/flatpak/panes-wrapper.sh
+++ b/flatpak/panes-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -eu
+
+if [ -f /app/etc/profile.d/mise-env.sh ]; then
+  . /app/etc/profile.d/mise-env.sh
+fi
+
+export SHELL="${SHELL:-/usr/bin/bash}"
+
+exec /app/bin/Panes "$@"

--- a/src-tauri/src/commands/harness.rs
+++ b/src-tauri/src/commands/harness.rs
@@ -133,9 +133,20 @@ pub async fn check_harnesses() -> Result<HarnessReport, String> {
     let npm_available = runtime_env::resolve_executable("npm").is_some()
         || detect_via_login_shell("npm", "--version").await.is_some();
 
+    let mise_preferred =
+        runtime_env::is_flatpak() && runtime_env::resolve_executable("mise").is_some();
+    let preferred_install_method = if mise_preferred {
+        Some("mise".to_string())
+    } else if npm_available {
+        Some("npm".to_string())
+    } else {
+        None
+    };
+
     Ok(HarnessReport {
         harnesses,
         npm_available,
+        preferred_install_method,
     })
 }
 
@@ -179,6 +190,23 @@ pub async fn install_harness(app: AppHandle, harness_id: String) -> Result<Insta
         )
     })?;
 
+    // Inside a Flatpak sandbox, /app is read-only at runtime, so `npm
+    // install -g` has nowhere to write to. Prefer the bundled `mise`
+    // instead, which installs into the user's writable data dir.
+    if install_cmd == "npm" && runtime_env::is_flatpak() {
+        if let Some(package) = npm_package_from_install_args(def.install_args) {
+            if runtime_env::resolve_executable("mise").is_some() {
+                let mise = resolve_mise_path().await;
+                let args = vec![
+                    "use".to_string(),
+                    "-g".to_string(),
+                    format!("npm:{package}"),
+                ];
+                return run_harness_install(&app, &harness_id, &mise, &args).await;
+            }
+        }
+    }
+
     let npm = if install_cmd == "npm" {
         resolve_npm_path().await
     } else {
@@ -188,6 +216,16 @@ pub async fn install_harness(app: AppHandle, harness_id: String) -> Result<Insta
     let args: Vec<String> = def.install_args.iter().map(|s| s.to_string()).collect();
 
     run_harness_install(&app, &harness_id, &npm, &args).await
+}
+
+/// Extracts the npm package name from an `["install", "-g", "<package>"]`
+/// style install-args slice, which is the shape every npm-installed
+/// harness in `HARNESSES` uses.
+fn npm_package_from_install_args<'a>(install_args: &[&'a str]) -> Option<&'a str> {
+    match install_args {
+        ["install", "-g", package] => Some(package),
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -579,4 +617,45 @@ async fn resolve_npm_path() -> String {
         return path;
     }
     "npm".to_string()
+}
+
+async fn resolve_mise_path() -> String {
+    if let Some(path) = runtime_env::resolve_executable("mise") {
+        return path.display().to_string();
+    }
+    if let Some((path, _version)) = detect_via_login_shell("mise", "--version").await {
+        return path;
+    }
+    "mise".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn npm_package_from_install_args_matches_every_harness_definition() {
+        for def in HARNESSES {
+            if def.install_command == Some("npm") {
+                assert!(
+                    npm_package_from_install_args(def.install_args).is_some(),
+                    "expected {} to have an install_args shape of [\"install\", \"-g\", <package>]",
+                    def.id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn npm_package_from_install_args_rejects_unexpected_shapes() {
+        assert_eq!(
+            npm_package_from_install_args(&["install", "opencode-ai"]),
+            None
+        );
+        assert_eq!(npm_package_from_install_args(&[]), None);
+        assert_eq!(
+            npm_package_from_install_args(&["install", "-g", "opencode-ai"]),
+            Some("opencode-ai")
+        );
+    }
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1039,4 +1039,10 @@ pub struct HarnessInfo {
 pub struct HarnessReport {
     pub harnesses: Vec<HarnessInfo>,
     pub npm_available: bool,
+    /// "mise" or "npm", whichever the current environment should use to
+    /// auto-install npm-packaged harnesses. `None` when neither is
+    /// available. Set to "mise" only inside a Flatpak sandbox where a
+    /// bundled `mise` is resolvable, since outside a sandbox npm-based
+    /// global installs remain the default.
+    pub preferred_install_method: Option<String>,
 }

--- a/src-tauri/src/path_utils.rs
+++ b/src-tauri/src/path_utils.rs
@@ -5,7 +5,19 @@ use std::{
 };
 
 pub fn canonicalize_path(path: &Path) -> io::Result<PathBuf> {
+    if is_flatpak_document_portal_path(path) {
+        // Paths under /run/flatpak/doc/ are bind mounts set up per-grant by
+        // xdg-desktop-portal for sandboxed apps. Canonicalizing them can
+        // resolve straight through the bind mount to a target the sandbox
+        // has no access to (or one that stops existing once the portal
+        // session ends), so we store them as-is instead.
+        return Ok(path.to_path_buf());
+    }
     std::fs::canonicalize(path).map(normalize_windows_path)
+}
+
+fn is_flatpak_document_portal_path(path: &Path) -> bool {
+    path.starts_with("/run/flatpak/doc")
 }
 
 pub fn normalize_windows_path_string(path: &str) -> String {
@@ -86,7 +98,11 @@ fn normalize_for_comparison(path: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{add_windows_verbatim_prefix, is_path_within_root, strip_windows_verbatim_prefix};
+    use super::{
+        add_windows_verbatim_prefix, canonicalize_path, is_path_within_root,
+        strip_windows_verbatim_prefix,
+    };
+    use std::path::Path;
 
     #[test]
     fn strips_drive_letter_windows_verbatim_prefix() {
@@ -138,5 +154,12 @@ mod tests {
             "/workspace/apps/api/src/main.ts",
             "/workspace/apps/app"
         ));
+    }
+
+    #[test]
+    fn leaves_flatpak_document_portal_paths_uncanonicalized() {
+        let portal_path = Path::new("/run/flatpak/doc/12345/my-repo");
+        let result = canonicalize_path(portal_path).expect("portal path is returned as-is");
+        assert_eq!(result, portal_path);
     }
 }

--- a/src-tauri/src/runtime_env.rs
+++ b/src-tauri/src/runtime_env.rs
@@ -44,6 +44,13 @@ pub fn platform_id() -> &'static str {
     }
 }
 
+/// Whether the app is currently running inside a Flatpak sandbox.
+/// Flatpak sets `FLATPAK_ID` in every sandboxed process, so this is
+/// reliable without shelling out.
+pub fn is_flatpak() -> bool {
+    env::var_os("FLATPAK_ID").is_some()
+}
+
 pub fn app_data_dir() -> PathBuf {
     app_data_dir_for(
         cfg!(target_os = "windows"),
@@ -1605,5 +1612,22 @@ mod tests {
         assert!(legacy.join("config.toml").exists());
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn is_flatpak_reflects_flatpak_id_env_var() {
+        let _env_guard = env_lock().lock().expect("env lock poisoned");
+        let original = std::env::var_os("FLATPAK_ID");
+
+        std::env::remove_var("FLATPAK_ID");
+        assert!(!is_flatpak());
+
+        std::env::set_var("FLATPAK_ID", "com.panes.app");
+        assert!(is_flatpak());
+
+        match original {
+            Some(value) => std::env::set_var("FLATPAK_ID", value),
+            None => std::env::remove_var("FLATPAK_ID"),
+        }
     }
 }

--- a/src/components/onboarding/HarnessPanel.tsx
+++ b/src/components/onboarding/HarnessPanel.tsx
@@ -32,6 +32,7 @@ import type { HarnessInfo } from "../../types";
 function HarnessTile({
   harness,
   description,
+  preferredInstallMethod,
   onInstallInTerminal,
   onCopyCommand,
   onLaunch,
@@ -39,13 +40,14 @@ function HarnessTile({
 }: {
   harness: HarnessInfo;
   description: string;
+  preferredInstallMethod: string | null;
   onInstallInTerminal: () => void;
   onCopyCommand: () => void;
   onLaunch: () => void;
   onOpenWebsite: () => void;
 }) {
   const { t } = useTranslation("app");
-  const installCmd = getHarnessInstallCommand(harness.id);
+  const installCmd = getHarnessInstallCommand(harness.id, preferredInstallMethod);
   const action = getHarnessTileAction(harness);
 
   return (
@@ -122,6 +124,7 @@ export function HarnessPanel() {
   const scan = useHarnessStore((s) => s.scan);
   const ensureScanned = useHarnessStore((s) => s.ensureScanned);
   const launch = useHarnessStore((s) => s.launch);
+  const preferredInstallMethod = useHarnessStore((s) => s.preferredInstallMethod);
 
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const createSession = useTerminalStore((s) => s.createSession);
@@ -159,12 +162,12 @@ export function HarnessPanel() {
   }
 
   function handleInstallInTerminal(harnessId: string) {
-    const cmd = getHarnessInstallCommand(harnessId);
+    const cmd = getHarnessInstallCommand(harnessId, preferredInstallMethod);
     if (cmd) void spawnInTerminal(cmd);
   }
 
   function handleCopyCommand(harnessId: string) {
-    const cmd = getHarnessInstallCommand(harnessId);
+    const cmd = getHarnessInstallCommand(harnessId, preferredInstallMethod);
     if (cmd) {
       void copyTextToClipboard(cmd)
         .then(() => {
@@ -249,6 +252,7 @@ export function HarnessPanel() {
                   key={h.id}
                   harness={h}
                   description={t(`harnesses.descriptions.${h.id}`, { defaultValue: h.description })}
+                  preferredInstallMethod={preferredInstallMethod}
                   onInstallInTerminal={() => handleInstallInTerminal(h.id)}
                   onCopyCommand={() => handleCopyCommand(h.id)}
                   onLaunch={() => void handleLaunch(h.id)}

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -399,6 +399,7 @@ function ProviderRow({
   description,
   harness,
   installing,
+  preferredInstallMethod,
   onInstall,
   onOpenWebsite,
 }: {
@@ -407,11 +408,12 @@ function ProviderRow({
   description: string;
   harness: HarnessInfo;
   installing: boolean;
+  preferredInstallMethod: string | null;
   onInstall: () => void;
   onOpenWebsite: () => void;
 }) {
   const { t } = useTranslation(["setup", "app"]);
-  const installCommand = getHarnessInstallCommand(harness.id);
+  const installCommand = getHarnessInstallCommand(harness.id, preferredInstallMethod);
   const canInstall = harness.canAutoInstall && Boolean(installCommand);
 
   return (
@@ -746,6 +748,7 @@ export function OnboardingWizard() {
   const harnessError = useHarnessStore((s) => s.error);
   const harnesses = useHarnessStore((s) => s.harnesses);
   const scanHarnesses = useHarnessStore((s) => s.scan);
+  const preferredInstallMethod = useHarnessStore((s) => s.preferredInstallMethod);
 
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
@@ -973,7 +976,7 @@ export function OnboardingWizard() {
   const nodeManualGuidance = readiness.dependencyReport
     ? getNodeManualGuidance(readiness.dependencyReport)
     : null;
-  const openCodeInstallCommand = getHarnessInstallCommand("opencode");
+  const openCodeInstallCommand = getHarnessInstallCommand("opencode", preferredInstallMethod);
   const showOpenCodeInstallCard =
     selectedChatEngines.includes("opencode") &&
     shouldShowOpenCodeInstallCard(readiness.engineHealth.opencode);
@@ -1245,6 +1248,7 @@ export function OnboardingWizard() {
                           harness={harness}
                           description={t(`app:harnesses.descriptions.${harness.id}`, { defaultValue: harness.description })}
                           installing={installing?.kind === "harness" && installing.id === harness.id}
+                          preferredInstallMethod={preferredInstallMethod}
                           onInstall={() => void handleInstallHarness(harness)}
                           onOpenWebsite={() => void handleOpenWebsite(harness.website)}
                         />

--- a/src/lib/harnessInstallActions.test.ts
+++ b/src/lib/harnessInstallActions.test.ts
@@ -56,4 +56,22 @@ describe("harness install actions", () => {
       "npm install -g opencode-ai",
     );
   });
+
+  it("prefers mise for npm-packaged harnesses when it is the preferred install method", () => {
+    expect(getHarnessInstallCommand("codex", "mise")).toBe(
+      "mise use -g npm:@openai/codex",
+    );
+    expect(getHarnessInstallCommand("opencode", "mise")).toBe(
+      "mise use -g npm:opencode-ai",
+    );
+  });
+
+  it("leaves curl-pipe installers unchanged even when mise is preferred", () => {
+    expect(getHarnessInstallCommand("kiro", "mise")).toContain("bash");
+  });
+
+  it("falls back to npm when no preferred install method is given", () => {
+    expect(getHarnessInstallCommand("codex")).toBe("npm install -g @openai/codex");
+    expect(getHarnessInstallCommand("codex", null)).toBe("npm install -g @openai/codex");
+  });
 });

--- a/src/lib/harnessInstallActions.ts
+++ b/src/lib/harnessInstallActions.ts
@@ -10,9 +10,31 @@ export const HARNESS_INSTALL_COMMANDS: Readonly<Record<string, string>> = {
   "factory-droid": "curl -fsSL https://app.factory.ai/cli | sh",
 };
 
+// npm package name for each harness whose install command in
+// HARNESS_INSTALL_COMMANDS is an `npm install -g <package>` invocation.
+// Used to build the `mise use -g npm:<package>` equivalent when mise is
+// the preferred install method (e.g. inside a Flatpak sandbox, where /app
+// is read-only and a global npm install has nowhere to write to).
+const NPM_PACKAGE_NAMES: Readonly<Record<string, string>> = {
+  codex: "@openai/codex",
+  "gemini-cli": "@google/gemini-cli",
+  opencode: "opencode-ai",
+  "kilo-code": "@kilocode/cli",
+};
+
 export type HarnessTileAction = "launch" | "install" | "manual";
 
-export function getHarnessInstallCommand(harnessId: string): string | null {
+export function getHarnessInstallCommand(
+  harnessId: string,
+  preferredInstallMethod: string | null = null,
+): string | null {
+  if (preferredInstallMethod === "mise") {
+    const npmPackage = NPM_PACKAGE_NAMES[harnessId];
+    if (npmPackage) {
+      return `mise use -g npm:${npmPackage}`;
+    }
+  }
+
   return HARNESS_INSTALL_COMMANDS[harnessId] ?? null;
 }
 

--- a/src/stores/harnessStore.ts
+++ b/src/stores/harnessStore.ts
@@ -8,6 +8,7 @@ interface HarnessStore {
   phase: HarnessPhase;
   harnesses: HarnessInfo[];
   npmAvailable: boolean;
+  preferredInstallMethod: string | null;
   error: string | null;
   loadedOnce: boolean;
 
@@ -38,6 +39,7 @@ function requestHarnessScan(
       set({
         harnesses: report.harnesses,
         npmAvailable: report.npmAvailable,
+        preferredInstallMethod: report.preferredInstallMethod,
         phase: "idle",
         error: null,
         loadedOnce: true,
@@ -61,6 +63,7 @@ export const useHarnessStore = create<HarnessStore>((set, get) => ({
   phase: "idle",
   harnesses: [],
   npmAvailable: false,
+  preferredInstallMethod: null,
   error: null,
   loadedOnce: false,
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1112,6 +1112,7 @@ export interface HarnessInfo {
 export interface HarnessReport {
   harnesses: HarnessInfo[];
   npmAvailable: boolean;
+  preferredInstallMethod: string | null;
 }
 
 // ── Stream Events ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a draft Flatpak manifest for Panes that builds from source into a sandbox with no host filesystem access, plus the backend changes needed for the app to actually work inside that sandbox: preserving document-portal workspace paths and installing harness CLIs through mise instead of a read-only npm global install.

This is based on the work contributor jgillich shared on [jgillich/panes@flatpak](https://github.com/jgillich/panes/tree/flatpak) in response to this issue. That branch was cut against v0.33 and has diverged a lot from the current tree, so rather than a direct merge, this rebases the same design (manifest structure, sandboxing model, mise-based tool install) onto the current source, adjusted to use the project's own `pnpm run build:desktop` script instead of a hand-rolled build step.

## What came from jgillich's fork vs. what was added here

From his fork: the overall manifest shape (runtime, sdk-extensions, module list), the choice of `mise` for in-sandbox tool installs, `flatpak/mise-env.sh` and `flatpak/panes-wrapper.sh` (used as-is, with one small robustness fix from review, see below), the desktop file and metainfo, and the core insight that workspace paths need special handling under the document portal.

Adapted or added in this PR: the `panes` build module now runs `pnpm run build:desktop` (the project's actual build entrypoint, which builds the frontend and the Claude sidecar together) instead of separate hand-chained steps; `runtime_env::is_flatpak()` is a new small helper (his fork detected Flatpak differently in a codebase that has since restructured `runtime_env.rs` and `terminal/mod.rs` substantially); the mise-based install path in `harness.rs` is rewritten against the current `HarnessDef`/`HarnessReport` shapes rather than the ones from v0.33; `mise`, `git`, and `node` are pinned to current releases with hashes verified during this review round (see below); the `path_utils.rs` document-portal fix is written against the current `canonicalize_path`, which has since gained Windows-verbatim-path handling that didn't exist when jgillich wrote his version. His fork's `terminal/mod.rs` mise-PATH-activation change and his onboarding wizard tweaks were intentionally left out of this PR, since `runtime_env::augmented_path_entries_for` already searches `~/.local/share/mise/shims`, which covers the common case of globally installed tools.

## Key manifest decisions

- **Runtime: `org.gnome.Platform//50`.** GNOME 50 shipped 2026-03-18 per [GNOME's release notes](https://release.gnome.org/50/) and is listed as current on [Flathub](https://flathub.org/apps/org.gnome.Platform). An earlier draft of this PR used `//49` and a hand-picked SDK extension branch (`24.08`) in the local build instructions; both were wrong (49 is one cycle behind current, and 24.08 was a guess, not a verified pairing for either runtime). The README's local build command now uses `flatpak-builder --install-deps-from=flathub`, which resolves the correct SDK/extension branches itself instead of hardcoding a guess.
- **No `--filesystem=host` or `--filesystem=home`.** Panes opens workspace folders exclusively through `@tauri-apps/plugin-dialog`, which on Linux routes through the xdg-desktop-portal FileChooser and returns a document-portal path under `/run/flatpak/doc/`. Editing, git, and terminal sessions then operate against that portal-granted path rather than an unrestricted host mount. Every other permission in `finish-args` is commented in the manifest with why it's requested. See `flatpak/README.md` for what this design still needs verified on real hardware, and for one disclosed gap that is **not** covered by this model: chat attachment drag-and-drop hands the backend a raw host path from the native window-drag event rather than a portal path, so dropped files will not be readable inside the sandbox. This was not fixed in this PR (fixing it needs a small new IPC surface to expose `is_flatpak()` to the frontend, which felt like separate scope from this PR's harness-install and workspace-path changes); the attach button remains a working, portal-safe alternative.
- **mise for in-sandbox tool installs**: `/app` is read-only at runtime, so `npm install -g` has nowhere to write. `check_harnesses` now reports `preferred_install_method` ("mise" or "npm"), and `install_harness` runs `mise use -g npm:<package>` instead when Flatpak + mise are both present. Both `HarnessPanel.tsx` (the standalone harness manager) and `OnboardingWizard.tsx`'s CLI provider step and OpenCode install card now read this and show the mise command instead of an npm one when applicable. This only covers the npm-packaged harnesses (codex, gemini-cli, opencode, kilo-code); the curl-pipe installers for Kiro and Factory Droid are unchanged and untested inside the sandbox.

## Changes

- `com.panes.app.yml`: flatpak-builder manifest (git/node/mise/panes build modules).
- `flatpak/`: desktop entry (no `StartupWMClass`, see "Notes for review"), metainfo, mise profile script, launch wrapper (now tolerates a failed source under `set -eu`), and a README covering build steps, the sandboxing rationale, disclosed gaps, and open questions.
- `src-tauri/src/runtime_env.rs`: `is_flatpak()`.
- `src-tauri/src/path_utils.rs`: leave `/run/flatpak/doc/` paths uncanonicalized.
- `src-tauri/src/commands/harness.rs`, `src-tauri/src/models.rs`: `preferred_install_method` on `HarnessReport`, mise-based install path in `install_harness`.
- `src/types.ts`, `src/stores/harnessStore.ts`, `src/lib/harnessInstallActions.ts`, `src/components/onboarding/HarnessPanel.tsx`, `src/components/onboarding/OnboardingWizard.tsx`: thread the preferred install method through to every place an install command is displayed.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm test` (400/400 passing; `harnessInstallActions.test.ts` has 3 new cases covering the mise-preferred, curl-pipe-unaffected, and npm-fallback paths, for 8 total in that file)
- [x] `pnpm build`
- [x] `cd src-tauri && cargo check`
- [x] `cd src-tauri && cargo test --lib` filtered to `harness::`, `is_flatpak`, and `path_utils::` (10 tests, all passing)
- [x] `cd src-tauri && cargo fmt --check`
- [x] Manifest YAML parses (`ruby -ryaml`, no Python `yaml` module available locally); `flatpak/com.panes.app.metainfo.xml` parses as XML.
- [x] Every source hash in the manifest was independently verified: downloaded `git-2.55.0.tar.xz` and both `node-v20.20.2-linux-{x64,arm64}.tar.xz` locally, computed `shasum -a 256`, and cross-checked against `kernel.org`'s `sha256sums.asc` and `nodejs.org`'s `SHASUMS256.txt`. All three matched exactly.

Not run: `flatpak-builder` itself. This was written on macOS with no Linux/Flatpak tooling available, so the manifest has not been built or launched.

## UI / UX impact

- [x] No user-facing UI change (the displayed install command only changes when the app detects it's running inside a Flatpak sandbox with mise available, which is not reachable outside that environment; this now applies consistently in both `HarnessPanel.tsx` and `OnboardingWizard.tsx`)

## Localization

- [x] No new user-facing copy

## Notes for review

This is a draft because the manifest is genuinely untested on Linux. `flatpak/README.md` lists what still needs a real machine to verify, including two items added during this review round:

- The chat attachment drag-and-drop gap described above (disclosed, not fixed).
- `flatpak/com.panes.app.desktop` deliberately does not set `StartupWMClass`, matching the existing precedent in `linux_appimage.rs`, whose test suite asserts that its generated AppImage desktop entry omits the same key. That reads as a signal that Tauri/wry's runtime `WM_CLASS` on Linux doesn't actually match `Panes`, so shipping a wrong value seemed worse than omitting it, but this was matched to precedent rather than independently reverified on hardware.
- The metainfo.xml `<releases>` version is hardcoded and needs manual bumping until it's wired into the release automation.

Also still open from the first draft: whether `flatpak-builder` succeeds at all, whether the document-portal folder grant survives across app restarts and covers the whole directory tree, whether the curl-pipe installers work inside the sandbox, and the Codex 401-auth-inside-sandbox issue jgillich reported (not root-caused here; two plausible causes are written up as unverified hypotheses). jgillich offered to help test in the issue thread and already ships an app on Flathub, so he'd be the ideal person to run this on a real machine.

Refs #8
