### PR TITLE
feat: unified chat components, autonomy presets, and harness launch flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,7 +424,14 @@ jobs:
 
       - name: Install dependencies for universal macOS
         if: matrix.platform == 'macos-15'
-        run: pnpm install --frozen-lockfile --config.supportedArchitectures.os=darwin --config.supportedArchitectures.cpu=x64 --config.supportedArchitectures.cpu=arm64
+        # pnpm 9 does not honor repeated --config.supportedArchitectures.* CLI
+        # flags, so the x64 Claude SDK native package never gets installed on
+        # the arm64 runner. The package.json pnpm field is the documented way
+        # to install optional dependencies for both macOS architectures.
+        run: |
+          npm pkg set 'pnpm.supportedArchitectures.os[0]=darwin' 'pnpm.supportedArchitectures.cpu[0]=x64' 'pnpm.supportedArchitectures.cpu[1]=arm64'
+          pnpm install --frozen-lockfile
+          git checkout -- package.json
 
       - name: Build platform Claude sidecar assets
         run: pnpm run build:claude-sidecar

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Panes"
-version = "0.62.1"
+version = "0.62.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Panes"
-version = "0.62.0"
+version = "0.62.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -240,6 +240,46 @@ pub async fn set_terminal_font_size(
     .map_err(err_to_string)?
 }
 
+const VALID_AUTONOMY_PRESETS: [&str; 4] = ["read-only", "ask", "auto", "full"];
+
+#[tauri::command]
+pub async fn get_default_autonomy_preset() -> Result<Option<String>, String> {
+    tokio::task::spawn_blocking(|| -> Result<Option<String>, String> {
+        let config = AppConfig::load_or_create().map_err(err_to_string)?;
+        Ok(config
+            .general
+            .default_autonomy_preset
+            .filter(|preset| VALID_AUTONOMY_PRESETS.contains(&preset.as_str())))
+    })
+    .await
+    .map_err(err_to_string)?
+}
+
+#[tauri::command]
+pub async fn set_default_autonomy_preset(
+    state: State<'_, AppState>,
+    preset: Option<String>,
+) -> Result<Option<String>, String> {
+    let normalized = match preset.as_deref() {
+        None | Some("") | Some("inherit") => None,
+        Some(value) if VALID_AUTONOMY_PRESETS.contains(&value) => Some(value.to_string()),
+        Some(value) => return Err(format!("unknown autonomy preset: {value}")),
+    };
+
+    let config_write_lock = state.config_write_lock.clone();
+    let _guard = config_write_lock.lock_owned().await;
+
+    tokio::task::spawn_blocking(move || -> Result<Option<String>, String> {
+        AppConfig::mutate(|config| {
+            config.general.default_autonomy_preset = normalized.clone();
+            Ok(normalized)
+        })
+        .map_err(err_to_string)
+    })
+    .await
+    .map_err(err_to_string)?
+}
+
 #[tauri::command]
 pub async fn get_agent_notification_settings() -> Result<AgentNotificationSettingsStatusDto, String>
 {

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -240,16 +240,11 @@ pub async fn set_terminal_font_size(
     .map_err(err_to_string)?
 }
 
-const VALID_AUTONOMY_PRESETS: [&str; 4] = ["read-only", "ask", "auto", "full"];
-
 #[tauri::command]
 pub async fn get_default_autonomy_preset() -> Result<Option<String>, String> {
     tokio::task::spawn_blocking(|| -> Result<Option<String>, String> {
         let config = AppConfig::load_or_create().map_err(err_to_string)?;
-        Ok(config
-            .general
-            .default_autonomy_preset
-            .filter(|preset| VALID_AUTONOMY_PRESETS.contains(&preset.as_str())))
+        Ok(config.default_autonomy_preset().map(ToOwned::to_owned))
     })
     .await
     .map_err(err_to_string)?
@@ -262,7 +257,9 @@ pub async fn set_default_autonomy_preset(
 ) -> Result<Option<String>, String> {
     let normalized = match preset.as_deref() {
         None | Some("") | Some("inherit") => None,
-        Some(value) if VALID_AUTONOMY_PRESETS.contains(&value) => Some(value.to_string()),
+        Some(value) if crate::config::app_config::VALID_AUTONOMY_PRESETS.contains(&value) => {
+            Some(value.to_string())
+        }
         Some(value) => return Err(format!("unknown autonomy preset: {value}")),
     };
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -191,6 +191,16 @@ struct ChatTurnFinishedEvent {
     preview: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ChatApprovalRequestedEvent {
+    thread_id: String,
+    workspace_id: String,
+    engine_id: String,
+    thread_title: String,
+    summary: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatAttachmentPayload {
@@ -2763,8 +2773,20 @@ async fn process_stream_event(
     }
 
     let _ = app.emit(stream_event_topic, &normalized_event);
-    if matches!(&normalized_event, EngineEvent::ApprovalRequested { .. }) {
+    if let EngineEvent::ApprovalRequested { summary, .. } = &normalized_event {
         let _ = app.emit(approval_event_topic, &normalized_event);
+        // Unscoped companion event so background threads can surface pending
+        // approvals without a per-thread listener.
+        let _ = app.emit(
+            "chat-approval-requested",
+            ChatApprovalRequestedEvent {
+                thread_id: thread.id.clone(),
+                workspace_id: thread.workspace_id.clone(),
+                engine_id: thread.engine_id.clone(),
+                thread_title: thread.title.clone(),
+                summary: summary.clone(),
+            },
+        );
     }
 
     if state.config.debug.persist_engine_event_logs {

--- a/src-tauri/src/commands/engines.rs
+++ b/src-tauri/src/commands/engines.rs
@@ -28,6 +28,11 @@ pub async fn get_chat_provider_usage(
 }
 
 #[tauri::command]
+pub async fn codex_uses_external_sandbox(state: State<'_, AppState>) -> Result<bool, String> {
+    Ok(state.engines.codex_uses_external_sandbox().await)
+}
+
+#[tauri::command]
 pub async fn engine_health(
     state: State<'_, AppState>,
     engine_id: String,

--- a/src-tauri/src/commands/harness.rs
+++ b/src-tauri/src/commands/harness.rs
@@ -262,32 +262,37 @@ pub async fn launch_harness(harness_id: String) -> Result<String, String> {
     // Return the command line so the frontend can write it into a terminal session
     tokio::task::spawn_blocking(move || -> Result<String, String> {
         let config = AppConfig::load_or_create().map_err(err_to_string)?;
-        Ok(compose_launch_command(
-            base_command,
-            config.harness_launch_args(&harness_id),
-        ))
+        compose_launch_command(base_command, config.harness_launch_args(&harness_id))
     })
     .await
     .map_err(err_to_string)?
 }
 
-/// Launch args are written raw into a PTY, so strip control characters (a
-/// newline would submit extra shell commands) and collapse runs of whitespace.
-fn sanitize_launch_args(args: &str) -> String {
-    args.chars()
-        .map(|c| if c.is_control() { ' ' } else { c })
-        .collect::<String>()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
+/// Launch args are submitted to the user's shell. Limit them to a portable
+/// argument grammar so the settings field cannot introduce shell operators.
+fn normalize_launch_args(args: &str) -> Result<String, String> {
+    if let Some(character) = args.chars().find(|character| {
+        !(character.is_alphanumeric()
+            || matches!(character, ' ' | '\t')
+            || matches!(character, '-' | '_' | '.' | '/' | ':' | '=' | ',' | '+'))
+    }) {
+        return Err(format!(
+            "launch arguments contain unsupported shell character: {character:?}"
+        ));
+    }
+
+    Ok(args.split_whitespace().collect::<Vec<_>>().join(" "))
 }
 
-fn compose_launch_command(base: &str, extra_args: Option<&str>) -> String {
-    let args = extra_args.map(sanitize_launch_args).unwrap_or_default();
+fn compose_launch_command(base: &str, extra_args: Option<&str>) -> Result<String, String> {
+    let args = extra_args
+        .map(normalize_launch_args)
+        .transpose()?
+        .unwrap_or_default();
     if args.is_empty() {
-        base.to_string()
+        Ok(base.to_string())
     } else {
-        format!("{base} {args}")
+        Ok(format!("{base} {args}"))
     }
 }
 
@@ -315,7 +320,7 @@ pub async fn set_harness_launch_args(
     let _guard = config_write_lock.lock_owned().await;
 
     tokio::task::spawn_blocking(move || -> Result<String, String> {
-        let sanitized = sanitize_launch_args(&args);
+        let sanitized = normalize_launch_args(&args)?;
         AppConfig::mutate(|config| {
             if sanitized.is_empty() {
                 config.harnesses.launch_args.remove(&harness_id);
@@ -751,25 +756,45 @@ mod tests {
 
     #[test]
     fn compose_launch_command_appends_configured_args() {
-        assert_eq!(compose_launch_command("codex", None), "codex");
+        assert_eq!(compose_launch_command("codex", None).unwrap(), "codex");
         assert_eq!(
-            compose_launch_command("codex", Some("--yolo")),
+            compose_launch_command("codex", Some("--yolo")).unwrap(),
             "codex --yolo"
         );
         assert_eq!(
-            compose_launch_command("claude", Some("  --dangerously-skip-permissions  ")),
+            compose_launch_command("claude", Some("  --dangerously-skip-permissions  ")).unwrap(),
             "claude --dangerously-skip-permissions"
         );
-        assert_eq!(compose_launch_command("codex", Some("   ")), "codex");
+        assert_eq!(
+            compose_launch_command("codex", Some("   ")).unwrap(),
+            "codex"
+        );
     }
 
     #[test]
-    fn sanitize_launch_args_strips_control_characters() {
+    fn normalize_launch_args_accepts_portable_argument_characters() {
         assert_eq!(
-            sanitize_launch_args("--yolo\nwhoami\r--flag"),
-            "--yolo whoami --flag"
+            normalize_launch_args("--model=gpt-5 --config /Users/me/file.toml").unwrap(),
+            "--model=gpt-5 --config /Users/me/file.toml"
         );
-        assert_eq!(sanitize_launch_args("--a\t--b"), "--a --b");
-        assert_eq!(sanitize_launch_args("\u{1b}[31m--x"), "[31m--x");
+        assert_eq!(normalize_launch_args("--a\t--b").unwrap(), "--a --b");
+    }
+
+    #[test]
+    fn normalize_launch_args_rejects_shell_syntax() {
+        for args in [
+            "--yolo; whoami",
+            "--flag | whoami",
+            "--flag $(whoami)",
+            "--flag `whoami`",
+            "--flag > output.txt",
+            "--flag\nwhoami",
+            "--name \"two words\"",
+        ] {
+            assert!(
+                normalize_launch_args(args).is_err(),
+                "accepted unsafe args: {args}"
+            );
+        }
     }
 }

--- a/src-tauri/src/commands/harness.rs
+++ b/src-tauri/src/commands/harness.rs
@@ -1,13 +1,20 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, State};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
+use crate::config::app_config::AppConfig;
 use crate::models::{HarnessInfo, HarnessReport, InstallProgressEvent, InstallResult};
 use crate::process_utils;
 use crate::runtime_env;
+use crate::state::AppState;
+
+fn err_to_string(error: impl std::fmt::Display) -> String {
+    error.to_string()
+}
 
 const LOGIN_SHELL_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -250,9 +257,80 @@ pub async fn launch_harness(harness_id: String) -> Result<String, String> {
         .iter()
         .find(|h| h.id == harness_id)
         .ok_or_else(|| format!("unknown harness: {harness_id}"))?;
+    let base_command = def.command;
 
-    // Return the command name so the frontend can write it into a terminal session
-    Ok(def.command.to_string())
+    // Return the command line so the frontend can write it into a terminal session
+    tokio::task::spawn_blocking(move || -> Result<String, String> {
+        let config = AppConfig::load_or_create().map_err(err_to_string)?;
+        Ok(compose_launch_command(
+            base_command,
+            config.harness_launch_args(&harness_id),
+        ))
+    })
+    .await
+    .map_err(err_to_string)?
+}
+
+/// Launch args are written raw into a PTY, so strip control characters (a
+/// newline would submit extra shell commands) and collapse runs of whitespace.
+fn sanitize_launch_args(args: &str) -> String {
+    args.chars()
+        .map(|c| if c.is_control() { ' ' } else { c })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn compose_launch_command(base: &str, extra_args: Option<&str>) -> String {
+    let args = extra_args.map(sanitize_launch_args).unwrap_or_default();
+    if args.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base} {args}")
+    }
+}
+
+#[tauri::command]
+pub async fn get_harness_launch_args() -> Result<BTreeMap<String, String>, String> {
+    tokio::task::spawn_blocking(|| -> Result<BTreeMap<String, String>, String> {
+        let config = AppConfig::load_or_create().map_err(err_to_string)?;
+        Ok(config.harnesses.launch_args)
+    })
+    .await
+    .map_err(err_to_string)?
+}
+
+#[tauri::command]
+pub async fn set_harness_launch_args(
+    state: State<'_, AppState>,
+    harness_id: String,
+    args: String,
+) -> Result<String, String> {
+    if !HARNESSES.iter().any(|h| h.id == harness_id) {
+        return Err(format!("unknown harness: {harness_id}"));
+    }
+
+    let config_write_lock = state.config_write_lock.clone();
+    let _guard = config_write_lock.lock_owned().await;
+
+    tokio::task::spawn_blocking(move || -> Result<String, String> {
+        let sanitized = sanitize_launch_args(&args);
+        AppConfig::mutate(|config| {
+            if sanitized.is_empty() {
+                config.harnesses.launch_args.remove(&harness_id);
+            } else {
+                config
+                    .harnesses
+                    .launch_args
+                    .insert(harness_id.clone(), sanitized.clone());
+            }
+            Ok(sanitized)
+        })
+        .map_err(err_to_string)
+    })
+    .await
+    .map_err(err_to_string)?
 }
 
 // ---------------------------------------------------------------------------
@@ -669,5 +747,29 @@ mod tests {
             npm_package_from_install_args(&["install", "-g", "opencode-ai"]),
             Some("opencode-ai")
         );
+    }
+
+    #[test]
+    fn compose_launch_command_appends_configured_args() {
+        assert_eq!(compose_launch_command("codex", None), "codex");
+        assert_eq!(
+            compose_launch_command("codex", Some("--yolo")),
+            "codex --yolo"
+        );
+        assert_eq!(
+            compose_launch_command("claude", Some("  --dangerously-skip-permissions  ")),
+            "claude --dangerously-skip-permissions"
+        );
+        assert_eq!(compose_launch_command("codex", Some("   ")), "codex");
+    }
+
+    #[test]
+    fn sanitize_launch_args_strips_control_characters() {
+        assert_eq!(
+            sanitize_launch_args("--yolo\nwhoami\r--flag"),
+            "--yolo whoami --flag"
+        );
+        assert_eq!(sanitize_launch_args("--a\t--b"), "--a --b");
+        assert_eq!(sanitize_launch_args("\u{1b}[31m--x"), "[31m--x");
     }
 }

--- a/src-tauri/src/commands/threads.rs
+++ b/src-tauri/src/commands/threads.rs
@@ -3,6 +3,7 @@ use serde_json::{json, Value};
 use tauri::State;
 
 use crate::{
+    config::app_config::AppConfig,
     db,
     engines::validate_engine_sandbox_mode,
     engines::CodexRemoteThreadSummary,
@@ -657,6 +658,85 @@ fn build_opencode_remote_session_metadata(
     metadata
 }
 
+#[derive(Debug, PartialEq)]
+struct AutonomyPresetPolicy {
+    approval_policy: Value,
+    sandbox_mode: Option<&'static str>,
+    allow_network: Option<bool>,
+}
+
+fn autonomy_policy_for_preset(
+    engine_id: &str,
+    preset: &str,
+    codex_external_sandbox: bool,
+) -> Result<AutonomyPresetPolicy, String> {
+    let policy = match engine_id {
+        "opencode" => AutonomyPresetPolicy {
+            approval_policy: json!(match preset {
+                "read-only" => "deny",
+                "ask" => "ask",
+                "auto" | "full" => "allow",
+                _ => return Err(format!("unknown autonomy preset: {preset}")),
+            }),
+            sandbox_mode: None,
+            allow_network: None,
+        },
+        "claude" => match preset {
+            "read-only" => AutonomyPresetPolicy {
+                approval_policy: json!("restricted"),
+                sandbox_mode: Some("read-only"),
+                allow_network: Some(false),
+            },
+            "ask" => AutonomyPresetPolicy {
+                approval_policy: json!("standard"),
+                sandbox_mode: Some("workspace-write"),
+                allow_network: Some(false),
+            },
+            "auto" => AutonomyPresetPolicy {
+                approval_policy: json!("trusted"),
+                sandbox_mode: Some("workspace-write"),
+                allow_network: None,
+            },
+            "full" => AutonomyPresetPolicy {
+                approval_policy: json!("trusted"),
+                sandbox_mode: Some("workspace-write"),
+                allow_network: Some(true),
+            },
+            _ => return Err(format!("unknown autonomy preset: {preset}")),
+        },
+        "codex" => match preset {
+            "read-only" => AutonomyPresetPolicy {
+                approval_policy: json!("untrusted"),
+                sandbox_mode: (!codex_external_sandbox).then_some("read-only"),
+                allow_network: Some(false),
+            },
+            "ask" => AutonomyPresetPolicy {
+                approval_policy: json!("on-request"),
+                sandbox_mode: (!codex_external_sandbox).then_some("workspace-write"),
+                allow_network: Some(false),
+            },
+            "auto" => AutonomyPresetPolicy {
+                approval_policy: json!("on-failure"),
+                sandbox_mode: (!codex_external_sandbox).then_some("workspace-write"),
+                allow_network: Some(true),
+            },
+            "full" => AutonomyPresetPolicy {
+                approval_policy: json!("never"),
+                sandbox_mode: Some("danger-full-access"),
+                allow_network: Some(true),
+            },
+            _ => return Err(format!("unknown autonomy preset: {preset}")),
+        },
+        _ => {
+            return Err(format!(
+                "autonomy presets are unsupported for engine: {engine_id}"
+            ))
+        }
+    };
+
+    Ok(policy)
+}
+
 #[tauri::command]
 pub async fn create_thread(
     state: State<'_, AppState>,
@@ -668,6 +748,14 @@ pub async fn create_thread(
     reasoning_effort: Option<String>,
     service_tier: Option<String>,
 ) -> Result<ThreadDto, String> {
+    let default_autonomy_preset = tokio::task::spawn_blocking(|| {
+        AppConfig::load_or_create()
+            .map(|config| config.default_autonomy_preset().map(ToOwned::to_owned))
+            .map_err(err_to_string)
+    })
+    .await
+    .map_err(err_to_string)??;
+
     create_thread_inner(
         state.inner(),
         workspace_id,
@@ -677,6 +765,7 @@ pub async fn create_thread(
         title,
         reasoning_effort,
         service_tier,
+        default_autonomy_preset,
     )
     .await
 }
@@ -690,6 +779,7 @@ async fn create_thread_inner(
     title: String,
     reasoning_effort: Option<String>,
     service_tier: Option<String>,
+    initial_autonomy_preset: Option<String>,
 ) -> Result<ThreadDto, String> {
     let normalized_service_tier = if engine_id == "codex" {
         normalize_thread_service_tier(service_tier)?
@@ -732,18 +822,31 @@ async fn create_thread_inner(
         } else {
             None
         };
-    let metadata = if validated_reasoning_effort.is_some() || normalized_service_tier.is_some() {
-        let mut object = serde_json::Map::new();
-        if let Some(value) = validated_reasoning_effort {
-            object.insert("reasoningEffort".to_string(), json!(value));
+    let mut metadata = serde_json::Map::new();
+    if let Some(value) = validated_reasoning_effort {
+        metadata.insert("reasoningEffort".to_string(), json!(value));
+    }
+    if let Some(value) = normalized_service_tier {
+        metadata.insert("serviceTier".to_string(), json!(value));
+    }
+
+    if let Some(preset) = initial_autonomy_preset.as_deref() {
+        let codex_external_sandbox =
+            engine_id == "codex" && state.engines.codex_uses_external_sandbox().await;
+        let policy = autonomy_policy_for_preset(&engine_id, preset, codex_external_sandbox)?;
+        metadata.insert(
+            approval_policy_metadata_key(&engine_id).to_string(),
+            policy.approval_policy,
+        );
+        if let Some(sandbox_mode) = policy.sandbox_mode {
+            metadata.insert("sandboxMode".to_string(), json!(sandbox_mode));
         }
-        if let Some(value) = normalized_service_tier {
-            object.insert("serviceTier".to_string(), json!(value));
+        if let Some(allow_network) = policy.allow_network {
+            metadata.insert("sandboxAllowNetwork".to_string(), json!(allow_network));
         }
-        Some(Value::Object(object))
-    } else {
-        None
-    };
+    }
+
+    let metadata = (!metadata.is_empty()).then_some(Value::Object(metadata));
 
     run_db(state.db.clone(), move |db| {
         let created = db::threads::create_thread(
@@ -3327,6 +3430,7 @@ mod tests {
             "Thread".to_string(),
             Some("HIGH".to_string()),
             Some("FAST".to_string()),
+            None,
         )
         .await
         .expect("expected thread creation to succeed");
@@ -3336,6 +3440,36 @@ mod tests {
             .expect("expected runtime metadata to be stored");
         assert_eq!(metadata.get("reasoningEffort"), Some(&json!("high")));
         assert_eq!(metadata.get("serviceTier"), Some(&json!("fast")));
+    }
+
+    #[tokio::test]
+    async fn create_thread_inner_persists_initial_autonomy_policy() {
+        let state = test_app_state();
+        let workspace = test_workspace(&state);
+
+        let created = create_thread_inner(
+            &state,
+            workspace.id,
+            None,
+            "claude".to_string(),
+            "claude-sonnet-4-6".to_string(),
+            "Thread".to_string(),
+            None,
+            None,
+            Some("read-only".to_string()),
+        )
+        .await
+        .expect("expected thread creation to succeed");
+
+        let metadata = created
+            .engine_metadata
+            .expect("expected autonomy metadata to be stored");
+        assert_eq!(
+            metadata.get("claudePermissionMode"),
+            Some(&json!("restricted"))
+        );
+        assert_eq!(metadata.get("sandboxMode"), Some(&json!("read-only")));
+        assert_eq!(metadata.get("sandboxAllowNetwork"), Some(&json!(false)));
     }
 
     #[tokio::test]
@@ -3351,6 +3485,7 @@ mod tests {
             "gpt-5.4".to_string(),
             "Thread".to_string(),
             Some("turbo".to_string()),
+            None,
             None,
         )
         .await
@@ -3373,11 +3508,58 @@ mod tests {
             "Thread".to_string(),
             None,
             Some("fast".to_string()),
+            None,
         )
         .await
         .expect_err("expected non-codex service tier to be rejected");
 
         assert!(error.contains("service tier is only supported for Codex threads"));
+    }
+
+    #[test]
+    fn autonomy_policy_for_preset_matches_engine_contracts() {
+        assert_eq!(
+            autonomy_policy_for_preset("codex", "read-only", false).unwrap(),
+            AutonomyPresetPolicy {
+                approval_policy: json!("untrusted"),
+                sandbox_mode: Some("read-only"),
+                allow_network: Some(false),
+            }
+        );
+        assert_eq!(
+            autonomy_policy_for_preset("claude", "full", false).unwrap(),
+            AutonomyPresetPolicy {
+                approval_policy: json!("trusted"),
+                sandbox_mode: Some("workspace-write"),
+                allow_network: Some(true),
+            }
+        );
+        assert_eq!(
+            autonomy_policy_for_preset("opencode", "auto", false).unwrap(),
+            AutonomyPresetPolicy {
+                approval_policy: json!("allow"),
+                sandbox_mode: None,
+                allow_network: None,
+            }
+        );
+    }
+
+    #[test]
+    fn external_sandbox_omits_blocked_codex_overrides() {
+        for preset in ["read-only", "ask", "auto"] {
+            assert_eq!(
+                autonomy_policy_for_preset("codex", preset, true)
+                    .unwrap()
+                    .sandbox_mode,
+                None
+            );
+        }
+        assert_eq!(
+            autonomy_policy_for_preset("codex", "full", true)
+                .unwrap()
+                .sandbox_mode,
+            Some("danger-full-access")
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/config/app_config.rs
+++ b/src-tauri/src/config/app_config.rs
@@ -13,6 +13,7 @@ use crate::runtime_env;
 pub const DEFAULT_TERMINAL_FONT_SIZE: u32 = 12;
 pub const MIN_TERMINAL_FONT_SIZE: u32 = 8;
 pub const MAX_TERMINAL_FONT_SIZE: u32 = 32;
+pub const VALID_AUTONOMY_PRESETS: [&str; 4] = ["read-only", "ask", "auto", "full"];
 
 /// Clamp a requested terminal font size into the supported range.
 pub fn clamp_terminal_font_size(font_size: u32) -> u32 {
@@ -213,6 +214,13 @@ impl AppConfig {
             .get(harness_id)
             .map(|args| args.trim())
             .filter(|args| !args.is_empty())
+    }
+
+    pub fn default_autonomy_preset(&self) -> Option<&str> {
+        self.general
+            .default_autonomy_preset
+            .as_deref()
+            .filter(|preset| VALID_AUTONOMY_PRESETS.contains(preset))
     }
 
     pub fn load_or_create() -> anyhow::Result<Self> {

--- a/src-tauri/src/config/app_config.rs
+++ b/src-tauri/src/config/app_config.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs,
     path::PathBuf,
     sync::{Mutex, MutexGuard, OnceLock},
@@ -25,6 +26,8 @@ pub struct AppConfig {
     pub ui: UiConfig,
     pub debug: DebugConfig,
     pub power: PowerConfig,
+    #[serde(skip_serializing_if = "HarnessesConfig::is_empty")]
+    pub harnesses: HarnessesConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,6 +77,21 @@ pub struct PowerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_duration_secs: Option<u64>,
     pub prevent_closed_display_sleep: bool,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HarnessesConfig {
+    /// Extra CLI flags appended to a harness command when it is launched into
+    /// a terminal, keyed by harness id (e.g. `codex = "--yolo"`).
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub launch_args: BTreeMap<String, String>,
+}
+
+impl HarnessesConfig {
+    fn is_empty(&self) -> bool {
+        self.launch_args.is_empty()
+    }
 }
 
 impl Default for GeneralConfig {
@@ -157,6 +175,7 @@ impl Default for AppConfig {
             ui: UiConfig::default(),
             debug: DebugConfig::default(),
             power: PowerConfig::default(),
+            harnesses: HarnessesConfig::default(),
         }
     }
 }
@@ -179,6 +198,16 @@ impl AppConfig {
 
     pub fn terminal_notifications_enabled(&self) -> bool {
         self.general.terminal_notifications.unwrap_or(false)
+    }
+
+    /// Extra launch flags configured for a harness, or `None` when unset or
+    /// blank.
+    pub fn harness_launch_args(&self, harness_id: &str) -> Option<&str> {
+        self.harnesses
+            .launch_args
+            .get(harness_id)
+            .map(|args| args.trim())
+            .filter(|args| !args.is_empty())
     }
 
     pub fn load_or_create() -> anyhow::Result<Self> {
@@ -374,6 +403,30 @@ max_action_output_chars = 20000
         assert!(!raw.contains("terminal_accelerated_rendering"));
         assert!(!raw.contains("terminal_notifications"));
         assert!(!raw.contains("terminal_font_size"));
+        assert!(!raw.contains("harnesses"));
+    }
+
+    #[test]
+    fn harness_launch_args_roundtrip_and_lookup() {
+        let mut config = AppConfig::default();
+        config
+            .harnesses
+            .launch_args
+            .insert("codex".to_string(), "--yolo".to_string());
+        config
+            .harnesses
+            .launch_args
+            .insert("claude-code".to_string(), "  ".to_string());
+
+        let raw = toml::to_string_pretty(&config).expect("config should serialize");
+        assert!(raw.contains("[harnesses.launch_args]"));
+        assert!(raw.contains("codex = \"--yolo\""));
+
+        let reloaded = toml::from_str::<AppConfig>(&raw).expect("config should deserialize");
+        assert_eq!(reloaded.harness_launch_args("codex"), Some("--yolo"));
+        // Blank values are treated as unset.
+        assert_eq!(reloaded.harness_launch_args("claude-code"), None);
+        assert_eq!(reloaded.harness_launch_args("gemini-cli"), None);
     }
 
     #[test]

--- a/src-tauri/src/config/app_config.rs
+++ b/src-tauri/src/config/app_config.rs
@@ -48,6 +48,10 @@ pub struct GeneralConfig {
     pub terminal_notifications: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_sound: Option<String>,
+    /// Autonomy preset applied to newly created chat threads
+    /// (`read-only` | `ask` | `auto` | `full`); `None` follows repo trust.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_autonomy_preset: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -106,6 +110,7 @@ impl Default for GeneralConfig {
             chat_notifications: None,
             terminal_notifications: None,
             notification_sound: None,
+            default_autonomy_preset: None,
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -280,6 +280,7 @@ pub fn run() {
             commands::git::watch_git_repo,
             commands::engines::list_engines,
             commands::engines::get_chat_provider_usage,
+            commands::engines::codex_uses_external_sandbox,
             commands::engines::engine_health,
             commands::engines::prewarm_engine,
             commands::engines::list_codex_skills,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -258,6 +258,8 @@ pub fn run() {
             commands::app::set_terminal_accelerated_rendering,
             commands::app::get_terminal_font_size,
             commands::app::set_terminal_font_size,
+            commands::app::get_default_autonomy_preset,
+            commands::app::set_default_autonomy_preset,
             commands::app::get_agent_notification_settings,
             commands::app::set_chat_notifications_enabled,
             commands::app::set_terminal_notifications_enabled,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -322,6 +322,8 @@ pub fn run() {
             commands::harness::check_harnesses,
             commands::harness::install_harness,
             commands::harness::launch_harness,
+            commands::harness::get_harness_launch_args,
+            commands::harness::set_harness_launch_args,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { t } from "./i18n";
 import { useUpdateStore } from "./stores/updateStore";
 import {
   ipc,
+  listenChatApprovalRequested,
   listenChatTurnFinished,
   listenEngineRuntimeUpdated,
   listenMenuAction,
@@ -229,6 +230,77 @@ export function App() {
         await ipc.showAgentNotification(title, body);
       } catch (error) {
         console.warn(`Failed to show chat notification for thread ${event.threadId}:`, error);
+      }
+    }).then((fn) => {
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      disposed = true;
+      if (unlisten) {
+        unlisten();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: (() => void) | undefined;
+    void listenChatApprovalRequested(async (event) => {
+      useThreadStore.getState().markThreadAwaitingApproval(event.threadId);
+
+      const activeWorkspaceId = useWorkspaceStore.getState().activeWorkspaceId;
+      const activeThreadId = useThreadStore.getState().activeThreadId;
+      const viewingThread =
+        document.hasFocus()
+        && activeWorkspaceId === event.workspaceId
+        && activeThreadId === event.threadId;
+      if (viewingThread) {
+        return;
+      }
+
+      const engineName = resolveAgentDisplayName(event.engineId);
+      toast.warning(event.summary, {
+        title: t("chat:autonomy.approvalToastTitle", { engine: engineName }),
+        action: {
+          label: t("chat:autonomy.openThread"),
+          onClick: () => {
+            void (async () => {
+              const uiStore = useUiStore.getState();
+              if (uiStore.activeView !== "chat") {
+                uiStore.setActiveView("chat");
+              }
+              if (useWorkspaceStore.getState().activeWorkspaceId !== event.workspaceId) {
+                await useWorkspaceStore.getState().setActiveWorkspace(event.workspaceId);
+              }
+              const thread = useThreadStore
+                .getState()
+                .threads.find((candidate) => candidate.id === event.threadId);
+              useWorkspaceStore
+                .getState()
+                .setActiveRepo(thread?.repoId ?? null, { remember: false });
+              useThreadStore.getState().setActiveThread(event.threadId);
+              await useChatStore.getState().setActiveThread(event.threadId);
+            })();
+          },
+        },
+      });
+
+      const notificationStore = useTerminalNotificationSettingsStore.getState();
+      const settings = notificationStore.settings ?? await notificationStore.load();
+      if (!settings?.chatEnabled || document.hasFocus()) {
+        return;
+      }
+
+      const title = event.threadTitle.trim() || engineName;
+      try {
+        await ipc.showAgentNotification(title, event.summary);
+      } catch (error) {
+        console.warn(`Failed to show approval notification for thread ${event.threadId}:`, error);
       }
     }).then((fn) => {
       if (disposed) {

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -71,6 +71,7 @@ import {
   isAutonomyPresetId,
 } from "../../lib/autonomyPresets";
 import type { AutonomyPresetId } from "../../lib/autonomyPresets";
+import { codexUsesExternalSandbox } from "../../lib/codexSandbox";
 import { resolvePreferredOnboardingChatSelection } from "../../lib/onboarding";
 import { recordPerfMetric } from "../../lib/perfTelemetry";
 import { isMacDesktop, usesCustomWindowFrame } from "../../lib/windowActions";
@@ -510,26 +511,6 @@ function getThreadNetworkPolicyOptions(
       description: t("policy.networkRestrictedDescription"),
     },
   ];
-}
-
-function isCodexExternalSandboxWarning(message?: string): boolean {
-  if (typeof message !== "string") {
-    return false;
-  }
-
-  const normalized = message.toLowerCase();
-  return normalized.includes("external sandbox mode");
-}
-
-function codexUsesExternalSandbox(health: Record<string, EngineHealth>): boolean {
-  const codexHealth = health.codex;
-  if (!codexHealth?.available) {
-    return false;
-  }
-
-  return (codexHealth.warnings ?? []).some((warning) =>
-    isCodexExternalSandboxWarning(warning),
-  );
 }
 
 const IMAGE_ATTACHMENT_EXTENSIONS = new Set([
@@ -2246,17 +2227,22 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
   const activeThreadAutonomyPreset = useMemo(
     () =>
       activeThreadAutonomyEngineId
-        ? detectAutonomyPreset(activeThreadAutonomyEngineId, {
-            approvalPolicy: activeThreadApprovalPolicy,
-            sandboxMode: activeThreadSandboxMode,
-            networkPolicy: readThreadStoredNetworkPolicyValue(activeThread),
-          })
+        ? detectAutonomyPreset(
+            activeThreadAutonomyEngineId,
+            {
+              approvalPolicy: activeThreadApprovalPolicy,
+              sandboxMode: activeThreadSandboxMode,
+              networkPolicy: readThreadStoredNetworkPolicyValue(activeThread),
+            },
+            { codexExternalSandbox: codexExternalSandboxActive },
+          )
         : undefined,
     [
       activeThread,
       activeThreadApprovalPolicy,
       activeThreadAutonomyEngineId,
       activeThreadSandboxMode,
+      codexExternalSandboxActive,
     ],
   );
   const fullAutonomyArmed = activeThreadAutonomyPreset === "full";
@@ -4597,7 +4583,9 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
       return;
     }
     void onThreadExecutionPolicyChange(
-      autonomyPresetPatch(preset, activeThreadAutonomyEngineId) as ThreadExecutionPolicyPatch,
+      autonomyPresetPatch(preset, activeThreadAutonomyEngineId, {
+        codexExternalSandbox: codexExternalSandboxActive,
+      }) as ThreadExecutionPolicyPatch,
     );
   }
 
@@ -4643,7 +4631,9 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
 
     if (stopAsking && activeThreadAutonomyEngineId) {
       await onThreadExecutionPolicyChange(
-        autonomyPresetPatch("full", activeThreadAutonomyEngineId) as ThreadExecutionPolicyPatch,
+        autonomyPresetPatch("full", activeThreadAutonomyEngineId, {
+          codexExternalSandbox: codexExternalSandboxActive,
+        }) as ThreadExecutionPolicyPatch,
       );
     }
   }
@@ -6173,6 +6163,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                   <PermissionPicker
                     engineId={activeThreadAutonomyEngineId}
                     presetValue={activeThreadAutonomyPreset}
+                    codexExternalSandbox={codexExternalSandboxActive}
                     onPresetChange={
                       activeThreadAutonomyEngineId ? onAutonomyPresetChange : undefined
                     }
@@ -6375,12 +6366,6 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
 
           {/* Bottom status bar with context usage */}
           <div className="chat-status-bar">
-            {fullAutonomyArmed && (
-              <span className="chat-status-armed">
-                <Zap size={10} />
-                {t("autonomy.armedStatus")}
-              </span>
-            )}
             {(isCodexEngine || selectedEngineId === "claude") && (
               usageLimits ? (
                 <div className="chat-status-usage">

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -118,6 +118,7 @@ import { ConfirmDialog } from "../shared/ConfirmDialog";
 import { handleDragMouseDown, handleDragDoubleClick } from "../../lib/windowDrag";
 import { shouldSubmitChatInput } from "./chatInputShortcuts";
 import type {
+  ActionType,
   ApprovalBlock,
   ApprovalResponse,
   ChatAttachment,
@@ -250,6 +251,21 @@ export function canUseApprovalDecisionActions(
   details?: Record<string, unknown>,
 ): boolean {
   return engineId !== "opencode" || !isOpenCodeQuestionApproval(details);
+}
+
+function approvalRowIcon(actionType: ActionType) {
+  switch (actionType) {
+    case "command":
+      return <SquareTerminal size={13} />;
+    case "file_write":
+    case "file_edit":
+    case "file_delete":
+      return <FilePen size={13} />;
+    case "git":
+      return <GitBranch size={13} />;
+    default:
+      return <Shield size={13} />;
+  }
 }
 
 export function buildPermissionApprovalResponseForEngine(
@@ -5646,19 +5662,22 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                       className="chat-approval-row"
                     >
                       <div className="approval-row-info">
-                        <div
-                          className="approval-row-summary"
-                          title={approval.summary}
-                        >
-                          {approval.summary}
-                        </div>
-                        {(command || reason) && (
+                        <div className="approval-row-head">
+                          <span className="approval-row-icon">
+                            {approvalRowIcon(approval.actionType)}
+                          </span>
                           <div
-                            className="approval-row-detail"
-                            title={command ?? reason}
+                            className="approval-row-summary"
+                            title={approval.summary}
                           >
-                            {command ?? reason}
+                            {approval.summary}
                           </div>
+                        </div>
+                        {command && (
+                          <div className="approval-row-command">{command}</div>
+                        )}
+                        {reason && (
+                          <div className="approval-row-reason">{reason}</div>
                         )}
                       </div>
 

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -65,6 +65,12 @@ import { useGitStore } from "../../stores/gitStore";
 import { useTerminalStore, type LayoutMode } from "../../stores/terminalStore";
 import { toast } from "../../stores/toastStore";
 import { ipc } from "../../lib/ipc";
+import {
+  autonomyPresetPatch,
+  detectAutonomyPreset,
+  isAutonomyPresetId,
+} from "../../lib/autonomyPresets";
+import type { AutonomyPresetId } from "../../lib/autonomyPresets";
 import { resolvePreferredOnboardingChatSelection } from "../../lib/onboarding";
 import { recordPerfMetric } from "../../lib/perfTelemetry";
 import { isMacDesktop, usesCustomWindowFrame } from "../../lib/windowActions";
@@ -2231,6 +2237,46 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
       : undefined;
   const activeThreadSandboxMode = readThreadSandboxModeValue(activeThread);
   const activeThreadNetworkPolicy = readThreadNetworkPolicyValue(activeThread);
+  const activeThreadAutonomyEngineId =
+    activeThread?.engineId === "codex" ||
+    activeThread?.engineId === "claude" ||
+    activeThread?.engineId === "opencode"
+      ? activeThread.engineId
+      : undefined;
+  const activeThreadAutonomyPreset = useMemo(
+    () =>
+      activeThreadAutonomyEngineId
+        ? detectAutonomyPreset(activeThreadAutonomyEngineId, {
+            approvalPolicy: activeThreadApprovalPolicy,
+            sandboxMode: activeThreadSandboxMode,
+            networkPolicy: readThreadStoredNetworkPolicyValue(activeThread),
+          })
+        : undefined,
+    [
+      activeThread,
+      activeThreadApprovalPolicy,
+      activeThreadAutonomyEngineId,
+      activeThreadSandboxMode,
+    ],
+  );
+  const fullAutonomyArmed = activeThreadAutonomyPreset === "full";
+  const [defaultAutonomyPreset, setDefaultAutonomyPreset] =
+    useState<AutonomyPresetId | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    void ipc
+      .getDefaultAutonomyPreset()
+      .then((preset) => {
+        if (!disposed && isAutonomyPresetId(preset)) {
+          setDefaultAutonomyPreset(preset);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      disposed = true;
+    };
+  }, []);
   const activeThreadCapabilities = useMemo(
     () => resolveEngineCapabilities(activeThread?.engineId, activeThreadEngineInfo?.capabilities),
     [activeThread?.engineId, activeThreadEngineInfo?.capabilities],
@@ -4546,6 +4592,62 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
     }
   }
 
+  function onAutonomyPresetChange(preset: AutonomyPresetId) {
+    if (!activeThreadAutonomyEngineId) {
+      return;
+    }
+    void onThreadExecutionPolicyChange(
+      autonomyPresetPatch(preset, activeThreadAutonomyEngineId) as ThreadExecutionPolicyPatch,
+    );
+  }
+
+  async function onDefaultAutonomyPresetChange(preset: AutonomyPresetId | null) {
+    const previous = defaultAutonomyPreset;
+    setDefaultAutonomyPreset(preset);
+    try {
+      await ipc.setDefaultAutonomyPreset(preset);
+    } catch (error) {
+      setDefaultAutonomyPreset(previous);
+      toast.error(t("autonomy.defaultSaveFailed", { error: String(error) }));
+    }
+  }
+
+  async function allowAllPendingApprovals(stopAsking: boolean) {
+    const engineId = activeThread?.engineId;
+    const rows = pendingApprovalBannerRows.filter((approval) => {
+      const details = approval.details ?? {};
+      if (!canUseApprovalDecisionActions(engineId, details)) {
+        return false;
+      }
+      if (isRequestUserInputApproval(details)) {
+        return false;
+      }
+      if (requiresCustomApprovalPayload(details)) {
+        return false;
+      }
+      if (shouldShowClaudeUnsupportedApproval(details, true, engineId === "claude")) {
+        return false;
+      }
+      return true;
+    });
+
+    for (const approval of rows) {
+      const details = approval.details ?? {};
+      await respondApproval(
+        approval.approvalId,
+        isPermissionsRequestApproval(details)
+          ? buildPermissionApprovalResponseForEngine(engineId, details, "accept")
+          : { decision: "accept" },
+      );
+    }
+
+    if (stopAsking && activeThreadAutonomyEngineId) {
+      await onThreadExecutionPolicyChange(
+        autonomyPresetPatch("full", activeThreadAutonomyEngineId) as ThreadExecutionPolicyPatch,
+      );
+    }
+  }
+
   function startThreadTitleEdit() {
     if (!activeThread) {
       return;
@@ -5426,6 +5528,28 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                   })}
                 </span>
                 <span className="approval-header-spacer" />
+                {pendingApprovalBannerRows.length > 1 &&
+                  activeThreadApprovalDecisionCapabilities.includes("accept") && (
+                    <>
+                      <button
+                        type="button"
+                        className="approval-batch-btn"
+                        onClick={() => void allowAllPendingApprovals(false)}
+                      >
+                        {t("autonomy.allowAll")}
+                      </button>
+                      {activeThreadAutonomyEngineId && (
+                        <button
+                          type="button"
+                          className="approval-batch-btn approval-batch-btn-warn"
+                          onClick={() => void allowAllPendingApprovals(true)}
+                          title={t("autonomy.presets.full.description")}
+                        >
+                          {t("autonomy.allowAllStopAsking")}
+                        </button>
+                      )}
+                    </>
+                  )}
                 {activeRepo && activeRepo.trustLevel !== "trusted" && (
                   <button
                     type="button"
@@ -5690,7 +5814,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
 
           {/* Input container */}
           <div
-            className={`chat-input-box ${activePlanMode && !showSpecialInputComposer ? "chat-input-box-plan" : ""} ${showSpecialInputComposer ? "chat-input-box-tool-input" : ""}`.trim()}
+            className={`chat-input-box ${activePlanMode && !showSpecialInputComposer ? "chat-input-box-plan" : ""} ${fullAutonomyArmed && !activePlanMode && !showSpecialInputComposer ? "chat-input-box-armed" : ""} ${showSpecialInputComposer ? "chat-input-box-tool-input" : ""}`.trim()}
             onPaste={handleInputPaste}
           >
             {showPendingToolInputComposer && pendingToolInputApproval ? (
@@ -6047,6 +6171,15 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                 <>
                   <div className="chat-toolbar-divider" />
                   <PermissionPicker
+                    engineId={activeThreadAutonomyEngineId}
+                    presetValue={activeThreadAutonomyPreset}
+                    onPresetChange={
+                      activeThreadAutonomyEngineId ? onAutonomyPresetChange : undefined
+                    }
+                    defaultPreset={defaultAutonomyPreset}
+                    onDefaultPresetChange={(preset) =>
+                      void onDefaultAutonomyPresetChange(preset)
+                    }
                     trustScopeLabel={
                       activeRepo
                         ? t("panel.repoAccess")
@@ -6242,6 +6375,12 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
 
           {/* Bottom status bar with context usage */}
           <div className="chat-status-bar">
+            {fullAutonomyArmed && (
+              <span className="chat-status-armed">
+                <Zap size={10} />
+                {t("autonomy.armedStatus")}
+              </span>
+            )}
             {(isCodexEngine || selectedEngineId === "claude") && (
               usageLimits ? (
                 <div className="chat-status-usage">

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -6193,6 +6193,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                     selectedEngineId={selectedEngineId}
                     selectedModelId={selectedModelId ?? selectedModel?.id ?? ""}
                     selectedEffort={selectedEffort}
+                    selectedServiceTier={selectedServiceTier}
                     onEngineModelChange={(engineId, modelId) => {
                       manuallyOverrodeThreadSelectionRef.current = true;
                       setHasExplicitComposerRuntime(true);
@@ -6215,43 +6216,30 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                       }
                     }}
                     onEffortChange={(effort) => void onReasoningEffortChange(effort)}
+                    onServiceTierChange={(serviceTier) => {
+                      const updateServiceTier = (): Promise<unknown> =>
+                        onCodexConfigSave({
+                          updatePersonality: false,
+                          personality: null,
+                          updateServiceTier: true,
+                          serviceTier: serviceTier === "inherit" ? null : serviceTier,
+                          updateOutputSchema: false,
+                          outputSchema: null,
+                          updateApprovalPolicy: false,
+                          approvalPolicy: null,
+                        }).catch((error) => {
+                          toast.error(String(error), {
+                            title: t("panel.toasts.speedChangeFailed"),
+                            action: {
+                              label: t("panel.toasts.retry"),
+                              onClick: () => void updateServiceTier(),
+                            },
+                          });
+                        });
+                      void updateServiceTier();
+                    }}
                     disabled={availableModels.length === 0}
                   />
-                  {selectedEngineId === "codex" && (
-                    <>
-                      <button
-                        type="button"
-                        className={`chat-toolbar-btn chat-toolbar-btn-bordered chat-toolbar-btn-fast ${selectedServiceTier === "fast" ? "chat-toolbar-btn-fast-active" : ""}`}
-                        onClick={() => {
-                          const toggleFastTier = (): Promise<unknown> =>
-                            onCodexConfigSave({
-                              updatePersonality: false,
-                              personality: null,
-                              updateServiceTier: true,
-                              serviceTier:
-                                selectedServiceTier === "fast" ? null : "fast",
-                              updateOutputSchema: false,
-                              outputSchema: null,
-                              updateApprovalPolicy: false,
-                              approvalPolicy: null,
-                            }).catch((error) => {
-                              toast.error(String(error), {
-                                title: t("panel.toasts.fastToggleFailed"),
-                                action: {
-                                  label: t("panel.toasts.retry"),
-                                  onClick: () => void toggleFastTier(),
-                                },
-                              });
-                            });
-                          void toggleFastTier();
-                        }}
-                        title={t("configPicker.serviceTierDescription")}
-                      >
-                        <Zap size={11} />
-                        <span style={{ fontSize: 11 }}>{t("modelPicker.fastOn")}</span>
-                      </button>
-                    </>
-                  )}
                 </>
               )}
 

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -4640,7 +4640,8 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
     const previous = defaultAutonomyPreset;
     setDefaultAutonomyPreset(preset);
     try {
-      await ipc.setDefaultAutonomyPreset(preset);
+      const saved = await ipc.setDefaultAutonomyPreset(preset);
+      setDefaultAutonomyPreset(isAutonomyPresetId(saved) ? saved : null);
     } catch (error) {
       setDefaultAutonomyPreset(previous);
       toast.error(t("autonomy.defaultSaveFailed", { error: String(error) }));

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -71,7 +71,10 @@ import {
   isAutonomyPresetId,
 } from "../../lib/autonomyPresets";
 import type { AutonomyPresetId } from "../../lib/autonomyPresets";
-import { codexUsesExternalSandbox } from "../../lib/codexSandbox";
+import {
+  codexUsesExternalSandbox,
+  isCodexExternalSandboxWarning,
+} from "../../lib/codexSandbox";
 import { resolvePreferredOnboardingChatSelection } from "../../lib/onboarding";
 import { recordPerfMetric } from "../../lib/perfTelemetry";
 import { isMacDesktop, usesCustomWindowFrame } from "../../lib/windowActions";
@@ -1712,10 +1715,25 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
   const ensureEngineHealth = useEngineStore((s) => s.ensureHealth);
   const onboardingOpen = useOnboardingStore((s) => s.open);
   const onboardingSelectedChatEngines = useOnboardingStore((s) => s.selectedChatEngines);
-  const codexExternalSandboxActive = useMemo(
-    () => codexUsesExternalSandbox(health),
-    [health],
-  );
+  // The health warning is only a heuristic; the backend answer is what
+  // set_thread_execution_policy actually validates against.
+  const [codexExternalSandboxActive, setCodexExternalSandboxActive] = useState(false);
+  useEffect(() => {
+    let disposed = false;
+    const heuristic = codexUsesExternalSandbox(health);
+    setCodexExternalSandboxActive((prev) => prev || heuristic);
+    void ipc
+      .codexUsesExternalSandbox()
+      .then((active) => {
+        if (!disposed) {
+          setCodexExternalSandboxActive(active);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      disposed = true;
+    };
+  }, [health]);
   const codexProtocolDiagnostics = health.codex?.protocolDiagnostics;
   const preferredOnboardingChatSelection = useMemo(
     () => resolvePreferredOnboardingChatSelection(onboardingSelectedChatEngines, engines),
@@ -4570,6 +4588,19 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
       applyThreadUpdateLocal(updatedThread);
     } catch (error) {
       if (threadExecutionPolicyRequestIdsRef.current[currentThread.id] !== requestId) {
+        return;
+      }
+
+      // If the backend rejects a sandbox override because Codex runs in
+      // external sandbox mode, remember that and retry without the override
+      // so presets keep working even when the health heuristic missed it.
+      if (
+        isCodexThread &&
+        isCodexExternalSandboxWarning(String(error)) &&
+        (nextPatch.sandboxMode === "read-only" || nextPatch.sandboxMode === "workspace-write")
+      ) {
+        setCodexExternalSandboxActive(true);
+        await onThreadExecutionPolicyChange({ ...nextPatch, sandboxMode: "inherit" });
         return;
       }
 

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -6253,6 +6253,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                   <PermissionPicker
                     engineId={activeThreadAutonomyEngineId}
                     presetValue={activeThreadAutonomyPreset}
+                    codexExternalSandbox={codexExternalSandboxActive}
                     onPresetChange={
                       activeThreadAutonomyEngineId ? onAutonomyPresetChange : undefined
                     }

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -5578,7 +5578,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                       {activeThreadAutonomyEngineId && (
                         <button
                           type="button"
-                          className="approval-batch-btn approval-batch-btn-warn"
+                          className="approval-batch-btn"
                           onClick={() => void allowAllPendingApprovals(true)}
                           title={t("autonomy.presets.full.description")}
                         >

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -2522,6 +2522,11 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
       ),
     [activeThread?.engineId, pendingApprovalBannerRows],
   );
+  const canTrustApprovalScope = activeRepo
+    ? activeRepo.trustLevel !== "trusted"
+    : repos.length > 0 && workspaceTrustLevel !== "trusted";
+  const showApprovalBannerHeader =
+    pendingApprovalBannerRows.length > 1 || canTrustApprovalScope;
 
   const pendingToolInputQuestions = useMemo(
     () =>
@@ -5607,59 +5612,61 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
           {/* Pending approvals */}
           {pendingApprovalBannerRows.length > 0 && (
             <div className="chat-approval-banner">
-              <div className="approval-header">
-                <span className="approval-header-icon">
-                  <Shield size={11} />
-                </span>
-                <span className="approval-header-title">
-                  {t("panel.approvalBannerTitleCount", {
-                    count: pendingApprovalBannerRows.length,
-                  })}
-                </span>
-                <span className="approval-header-spacer" />
-                {batchApprovableRows.length > 1 &&
-                  activeThreadApprovalDecisionCapabilities.includes("accept") && (
-                    <>
-                      <button
-                        type="button"
-                        className="approval-batch-btn"
-                        onClick={() => void allowAllPendingApprovals(false)}
-                      >
-                        {t("autonomy.allowAll")}
-                      </button>
-                      {activeThreadAutonomyEngineId && (
+              {showApprovalBannerHeader && (
+                <div className="approval-header">
+                  <span className="approval-header-icon">
+                    <Shield size={11} />
+                  </span>
+                  <span className="approval-header-title">
+                    {t("panel.approvalBannerTitleCount", {
+                      count: pendingApprovalBannerRows.length,
+                    })}
+                  </span>
+                  <span className="approval-header-spacer" />
+                  {batchApprovableRows.length > 1 &&
+                    activeThreadApprovalDecisionCapabilities.includes("accept") && (
+                      <>
                         <button
                           type="button"
                           className="approval-batch-btn"
-                          onClick={() => void allowAllPendingApprovals(true)}
-                          title={t("autonomy.presets.full.description")}
+                          onClick={() => void allowAllPendingApprovals(false)}
                         >
-                          {t("autonomy.allowAllStopAsking")}
+                          {t("autonomy.allowAll")}
                         </button>
-                      )}
-                    </>
+                        {activeThreadAutonomyEngineId && (
+                          <button
+                            type="button"
+                            className="approval-batch-btn"
+                            onClick={() => void allowAllPendingApprovals(true)}
+                            title={t("autonomy.presets.full.description")}
+                          >
+                            {t("autonomy.allowAllStopAsking")}
+                          </button>
+                        )}
+                      </>
+                    )}
+                  {activeRepo && activeRepo.trustLevel !== "trusted" && (
+                    <button
+                      type="button"
+                      className="approval-trust-btn"
+                      onClick={() => void onRepoTrustLevelChange("trusted")}
+                      title={t("panel.setRepoTrusted")}
+                    >
+                      {t("panel.trustRepo")}
+                    </button>
                   )}
-                {activeRepo && activeRepo.trustLevel !== "trusted" && (
-                  <button
-                    type="button"
-                    className="approval-trust-btn"
-                    onClick={() => void onRepoTrustLevelChange("trusted")}
-                    title={t("panel.setRepoTrusted")}
-                  >
-                    {t("panel.trustRepo")}
-                  </button>
-                )}
-                {!activeRepo && repos.length > 0 && workspaceTrustLevel !== "trusted" && (
-                  <button
-                    type="button"
-                    className="approval-trust-btn"
-                    onClick={() => void onWorkspaceTrustLevelChange("trusted")}
-                    title={t("panel.setWorkspaceTrusted")}
-                  >
-                    {t("panel.trustWorkspace")}
-                  </button>
-                )}
-              </div>
+                  {!activeRepo && repos.length > 0 && workspaceTrustLevel !== "trusted" && (
+                    <button
+                      type="button"
+                      className="approval-trust-btn"
+                      onClick={() => void onWorkspaceTrustLevelChange("trusted")}
+                      title={t("panel.setWorkspaceTrusted")}
+                    >
+                      {t("panel.trustWorkspace")}
+                    </button>
+                  )}
+                </div>
+              )}
 
               <div className="approval-rows">
                 {pendingApprovalBannerRows.slice(-3).map((approval) => {

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -66,6 +66,7 @@ import { useTerminalStore, type LayoutMode } from "../../stores/terminalStore";
 import { toast } from "../../stores/toastStore";
 import { ipc } from "../../lib/ipc";
 import {
+  autonomyPresetExecutionPolicyRequest,
   autonomyPresetPatch,
   detectAutonomyPreset,
   isAutonomyPresetId,
@@ -251,6 +252,19 @@ export function canUseApprovalDecisionActions(
   details?: Record<string, unknown>,
 ): boolean {
   return engineId !== "opencode" || !isOpenCodeQuestionApproval(details);
+}
+
+export function canBatchApproveApproval(
+  approval: ApprovalBlock,
+  engineId?: string,
+): boolean {
+  const details = approval.details ?? {};
+  return (
+    canUseApprovalDecisionActions(engineId, details) &&
+    !isRequestUserInputApproval(details) &&
+    !requiresCustomApprovalPayload(details) &&
+    !shouldShowClaudeUnsupportedApproval(details, true, engineId === "claude")
+  );
 }
 
 function approvalRowIcon(actionType: ActionType) {
@@ -2499,6 +2513,13 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
       ),
     [activeThread?.engineId, pendingApprovals, pendingToolInputApproval?.approvalId],
   );
+  const batchApprovableRows = useMemo(
+    () =>
+      pendingApprovalBannerRows.filter((approval) =>
+        canBatchApproveApproval(approval, activeThread?.engineId),
+      ),
+    [activeThread?.engineId, pendingApprovalBannerRows],
+  );
 
   const pendingToolInputQuestions = useMemo(
     () =>
@@ -4648,41 +4669,61 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
     }
   }
 
-  async function allowAllPendingApprovals(stopAsking: boolean) {
-    const engineId = activeThread?.engineId;
-    const rows = pendingApprovalBannerRows.filter((approval) => {
-      const details = approval.details ?? {};
-      if (!canUseApprovalDecisionActions(engineId, details)) {
-        return false;
-      }
-      if (isRequestUserInputApproval(details)) {
-        return false;
-      }
-      if (requiresCustomApprovalPayload(details)) {
-        return false;
-      }
-      if (shouldShowClaudeUnsupportedApproval(details, true, engineId === "claude")) {
-        return false;
-      }
-      return true;
-    });
+  const batchApprovalInFlightRef = useRef(false);
 
-    for (const approval of rows) {
-      const details = approval.details ?? {};
-      await respondApproval(
-        approval.approvalId,
-        isPermissionsRequestApproval(details)
-          ? buildPermissionApprovalResponseForEngine(engineId, details, "accept")
-          : { decision: "accept" },
-      );
+  async function allowAllPendingApprovals(stopAsking: boolean) {
+    if (batchApprovalInFlightRef.current) {
+      return;
+    }
+    const targetThreadId = activeThread?.id;
+    const engineId = activeThread?.engineId;
+    const autonomyEngineId = activeThreadAutonomyEngineId;
+    if (!targetThreadId) {
+      return;
+    }
+    if (batchApprovableRows.length === 0) {
+      return;
     }
 
-    if (stopAsking && activeThreadAutonomyEngineId) {
-      await onThreadExecutionPolicyChange(
-        autonomyPresetPatch("full", activeThreadAutonomyEngineId, {
+    batchApprovalInFlightRef.current = true;
+    try {
+      for (const approval of batchApprovableRows) {
+        const details = approval.details ?? {};
+        const accepted = await respondApproval(
+          approval.approvalId,
+          isPermissionsRequestApproval(details)
+            ? buildPermissionApprovalResponseForEngine(engineId, details, "accept")
+            : { decision: "accept" },
+          targetThreadId,
+        );
+        if (!accepted) {
+          toast.error(t("panel.toasts.approvalBatchFailed"));
+          return;
+        }
+      }
+
+      if (stopAsking && autonomyEngineId) {
+        const request = autonomyPresetExecutionPolicyRequest("full", autonomyEngineId, {
           codexExternalSandbox: codexExternalSandboxActive,
-        }) as ThreadExecutionPolicyPatch,
-      );
+        });
+        if (request) {
+          const requestId =
+            (threadExecutionPolicyRequestIdsRef.current[targetThreadId] ?? 0) + 1;
+          threadExecutionPolicyRequestIdsRef.current[targetThreadId] = requestId;
+          try {
+            const updatedThread = await ipc.setThreadExecutionPolicy(targetThreadId, request);
+            if (threadExecutionPolicyRequestIdsRef.current[targetThreadId] === requestId) {
+              applyThreadUpdateLocal(updatedThread);
+            }
+          } catch (error) {
+            if (threadExecutionPolicyRequestIdsRef.current[targetThreadId] === requestId) {
+              toast.error(t("panel.toasts.updateExecutionPolicyFailed", { error: String(error) }));
+            }
+          }
+        }
+      }
+    } finally {
+      batchApprovalInFlightRef.current = false;
     }
   }
 
@@ -5566,7 +5607,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                   })}
                 </span>
                 <span className="approval-header-spacer" />
-                {pendingApprovalBannerRows.length > 1 &&
+                {batchApprovableRows.length > 1 &&
                   activeThreadApprovalDecisionCapabilities.includes("accept") && (
                     <>
                       <button

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -24,6 +24,10 @@ import {
   SquareTerminal,
   MessageSquare,
   FilePen,
+  Pencil,
+  AlertTriangle,
+  AtSign,
+  DollarSign,
   Plus,
   ListChecks,
   Copy,
@@ -49,9 +53,12 @@ import { useShallow } from "zustand/react/shallow";
 import { useChatStore } from "../../stores/chatStore";
 import { useChatComposerStore } from "../../stores/chatComposerStore";
 import { useEngineStore } from "../../stores/engineStore";
+import { useFileStore } from "../../stores/fileStore";
 import { useOnboardingStore } from "../../stores/onboardingStore";
 import { useThreadStore } from "../../stores/threadStore";
 import { useUiStore } from "../../stores/uiStore";
+import { getHarnessIcon } from "../shared/HarnessLogos";
+import { showWorkspaceEditorForDirectFileOpen } from "../../lib/workspacePaneNavigation";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useGitStore } from "../../stores/gitStore";
 import { useTerminalStore, type LayoutMode } from "../../stores/terminalStore";
@@ -1193,6 +1200,8 @@ interface MessageRowProps {
   assistantEngineId: string;
   onApproval: (approvalId: string, response: ApprovalResponse) => void;
   onLoadActionOutput: (messageId: string, actionId: string) => Promise<void>;
+  onEditResend?: (text: string) => void;
+  onOpenDiffFile?: (filePath: string) => void;
 }
 
 const THINKING_VARIANTS = [
@@ -1273,6 +1282,8 @@ function MessageRowView({
   assistantEngineId,
   onApproval,
   onLoadActionOutput,
+  onEditResend,
+  onOpenDiffFile,
 }: MessageRowProps) {
   const { t, i18n } = useTranslation("chat");
   const isUser = message.role === "user";
@@ -1332,19 +1343,7 @@ function MessageRowView({
     >
       {isUser ? (
         <>
-          <div
-            style={{
-              maxWidth: "75%",
-              padding: "10px 14px",
-              borderRadius: "var(--radius-md)",
-              background: "rgba(var(--accent-rgb), 0.09)",
-              border: "1px solid rgba(var(--accent-rgb), 0.16)",
-              fontSize: 13,
-              lineHeight: 1.6,
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-word",
-            }}
-          >
+          <div className="msg-user-bubble">
             {userAuxiliaryBlocks.length > 0 && (
               <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginBottom: 6 }}>
                 {userAuxiliaryBlocks.map((block, i) => {
@@ -1359,11 +1358,14 @@ function MessageRowView({
                   }
 
                   return (
-                    <span key={i} className="chat-attachment-chip">
+                    <span
+                      key={i}
+                      className={`chat-attachment-chip ${block.type === "skill" ? "chat-attachment-chip--skill" : "chat-attachment-chip--mention"}`}
+                    >
                       {block.type === "skill" ? (
-                        <SquareTerminal size={10} />
+                        <DollarSign size={10} />
                       ) : (
-                        <MessageSquare size={10} />
+                        <AtSign size={10} />
                       )}
                       <span className="chat-attachment-chip-name" style={{ fontSize: 10 }}>
                         {block.name}
@@ -1374,7 +1376,7 @@ function MessageRowView({
               </div>
             )}
             {userPlanMode && (
-              <div style={{ display: "flex", alignItems: "center", gap: 4, marginBottom: 6, fontSize: 10, color: "var(--text-3)" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 4, marginBottom: 6, fontSize: 10, color: "var(--accent-2)" }}>
                 <ListChecks size={10} />
                 <span>{t("panel.planMode")}</span>
               </div>
@@ -1382,56 +1384,72 @@ function MessageRowView({
             {userContent}
           </div>
           <div className="msg-row-timestamp" style={{ display: "flex", alignItems: "center", gap: 2, justifyContent: "flex-end", marginTop: 4, paddingRight: 4 }}>
+            {onEditResend && (
+              <button
+                type="button"
+                className="msg-row-action-btn"
+                onClick={() => onEditResend(userContent)}
+                title={t("panel.editResend")}
+                aria-label={t("panel.editResend")}
+              >
+                <Pencil size={11} />
+              </button>
+            )}
             <MessageCopyButton message={message} />
             {messageTimestamp && <span>{messageTimestamp}</span>}
           </div>
         </>
       ) : showAssistantShell ? (
-        <>
-          <div
-            style={{
-              width: "100%",
-              maxWidth: "100%",
-              padding: "4px 0",
-            }}
-          >
-            {hasAssistantContent ? (
-              <MessageBlocks
-                blocks={message.blocks}
-                status={message.status}
-                engineId={assistantEngineId}
-                onApproval={onApproval}
-                onLoadActionOutput={(actionId) => onLoadActionOutput(message.id, actionId)}
-              />
-            ) : (
-              <div
-                style={{
-                  padding: "4px 14px 8px",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 8,
-                  color: "var(--text-3)",
-                  fontSize: 12,
-                }}
-              >
-                {(() => {
-                  const ThinkIcon = thinkingVariant.icon;
-                  return <ThinkIcon size={12} className="thinking-icon-active" style={{ color: "var(--info)" }} />;
-                })()}
-                <span>{t(thinkingVariant.key)}</span>
-                <span className="chat-streaming-dots">
-                  <span />
-                  <span />
-                  <span />
-                </span>
-              </div>
-            )}
-          </div>
-          <div className="msg-row-timestamp" style={{ display: "flex", alignItems: "center", gap: 2, marginTop: 2, paddingLeft: 14 }}>
-            <MessageCopyButton message={message} />
-            {messageTimestamp && <span>{messageTimestamp}</span>}
-          </div>
-        </>
+        <div
+          style={{
+            width: "100%",
+            maxWidth: "100%",
+            padding: "4px 0",
+          }}
+        >
+          {assistantLabel && (
+            <div className="msg-turn-header">
+              {getHarnessIcon(assistantEngineId, 11)}
+              <span className="msg-turn-header-label">{assistantLabel}</span>
+              <span className="msg-turn-actions">
+                {messageTimestamp && <span style={{ padding: "0 2px" }}>{messageTimestamp}</span>}
+                <MessageCopyButton message={message} />
+              </span>
+            </div>
+          )}
+          {hasAssistantContent ? (
+            <MessageBlocks
+              blocks={message.blocks}
+              status={message.status}
+              engineId={assistantEngineId}
+              onApproval={onApproval}
+              onLoadActionOutput={(actionId) => onLoadActionOutput(message.id, actionId)}
+              onOpenDiffFile={onOpenDiffFile}
+            />
+          ) : (
+            <div
+              style={{
+                padding: "4px 14px 8px",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 8,
+                color: "var(--text-3)",
+                fontSize: 12,
+              }}
+            >
+              {(() => {
+                const ThinkIcon = thinkingVariant.icon;
+                return <ThinkIcon size={12} className="thinking-icon-active" style={{ color: "var(--info)" }} />;
+              })()}
+              <span>{t(thinkingVariant.key)}</span>
+              <span className="chat-streaming-dots">
+                <span />
+                <span />
+                <span />
+              </span>
+            </div>
+          )}
+        </div>
       ) : null}
     </div>
   );
@@ -1446,7 +1464,9 @@ const MessageRow = memo(
     prev.assistantLabel === next.assistantLabel &&
     prev.assistantEngineId === next.assistantEngineId &&
     prev.onApproval === next.onApproval &&
-    prev.onLoadActionOutput === next.onLoadActionOutput,
+    prev.onLoadActionOutput === next.onLoadActionOutput &&
+    prev.onEditResend === next.onEditResend &&
+    prev.onOpenDiffFile === next.onOpenDiffFile,
 );
 
 function getFileExtension(fileName: string): string {
@@ -4644,6 +4664,33 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
     [hydrateActionOutput],
   );
 
+  const handleEditResend = useCallback((text: string) => {
+    if (!text.trim()) {
+      return;
+    }
+    setInput(text);
+    inputRef.current?.focus();
+  }, []);
+
+  const openFileInEditor = useFileStore((s) => s.openFile);
+  const openUsageLimitsModal = useUiStore((s) => s.openUsageLimitsModal);
+
+  const diffFileRootPath = activeRepo?.path ?? activeWorkspace?.rootPath ?? null;
+  const handleOpenDiffFile = useCallback(
+    (filePath: string) => {
+      if (!diffFileRootPath || !activeWorkspaceId) {
+        return;
+      }
+      const normalized = filePath.replace(/\\/g, "/");
+      const absolutePath = /^(\/|[A-Za-z]:)/.test(normalized)
+        ? normalized
+        : `${diffFileRootPath}/${normalized}`;
+      void openFileInEditor(diffFileRootPath, absolutePath);
+      showWorkspaceEditorForDirectFileOpen(activeWorkspaceId);
+    },
+    [activeWorkspaceId, diffFileRootPath, openFileInEditor],
+  );
+
   const virtualizedLayout = useMemo(() => {
     if (!virtualizationEnabled || messages.length === 0) {
       return null;
@@ -5193,33 +5240,49 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
               flexDirection: "column",
               alignItems: "center",
               justifyContent: "center",
-              gap: 16,
+              gap: 14,
               color: "var(--text-3)",
               textAlign: "center",
             }}
           >
-            <div
-              style={{
-                width: 56,
-                height: 56,
-                borderRadius: "var(--radius-lg)",
-                background: "var(--bg-3)",
-                border: "1px solid var(--border)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <Send size={22} style={{ color: "var(--text-2)", opacity: 0.5 }} />
+            <div className="chat-empty-tile">
+              <MessageSquare size={18} />
             </div>
             <div>
               <p style={{ margin: "0 0 4px", fontSize: 14, fontWeight: 500, color: "var(--text-2)" }}>
                 {t("panel.startConversation")}
               </p>
               <p style={{ margin: 0, fontSize: 12.5 }}>
-                {t("panel.emptyHint")}
+                {activeWorkspaceId && (activeRepo || gitStatus?.branch)
+                  ? activeRepo && gitStatus?.branch
+                    ? t("panel.emptyScopeRepoBranch", { repo: activeRepo.name, branch: gitStatus.branch })
+                    : t("panel.emptyScopeRepo", { repo: activeRepo?.name ?? workspaceName })
+                  : t("panel.emptyHint")}
               </p>
             </div>
+            {activeWorkspaceId && (
+              <div className="chat-empty-suggestions">
+                <button
+                  type="button"
+                  className="chat-empty-suggestion"
+                  onClick={() => handleEditResend(t("panel.emptySuggestionSummarize"))}
+                >
+                  {t("panel.emptySuggestionSummarize")}
+                </button>
+                <button
+                  type="button"
+                  className="chat-empty-suggestion"
+                  onClick={() => handleEditResend(t("panel.emptySuggestionTests"))}
+                >
+                  {t("panel.emptySuggestionTests")}
+                </button>
+              </div>
+            )}
+            <p style={{ margin: 0, fontSize: 11 }}>
+              <span className="chat-empty-kbd">⌘K</span> {t("panel.emptyHintCommands")}
+              <span style={{ opacity: 0.5, padding: "0 5px" }}>·</span>
+              <span className="chat-empty-kbd">/</span> {t("panel.emptyHintSlash")}
+            </p>
           </div>
         ) : virtualizationEnabled && virtualWindow ? (
           <div style={{ display: "flex", flexDirection: "column" }}>
@@ -5245,6 +5308,8 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                         assistantEngineId={assistantIdentity?.engineId ?? ""}
                         onApproval={handleApproval}
                         onLoadActionOutput={handleLoadActionOutput}
+                        onEditResend={handleEditResend}
+                        onOpenDiffFile={handleOpenDiffFile}
                       />
                     </MeasuredMessageRow>
                   );
@@ -5269,6 +5334,8 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                   assistantEngineId={assistantIdentity?.engineId ?? ""}
                   onApproval={handleApproval}
                   onLoadActionOutput={handleLoadActionOutput}
+                  onEditResend={handleEditResend}
+                  onOpenDiffFile={handleOpenDiffFile}
                 />
               );
             })}
@@ -5320,41 +5387,13 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
         {autoScrollLocked && messages.length > 0 && (
           <button
             type="button"
+            className={`chat-jump-pill${streaming ? " chat-jump-pill--activity" : ""}`}
             onClick={() => {
               setAutoScrollLocked(false);
               scrollViewportToBottom("smooth");
             }}
-            style={{
-              position: "sticky",
-              left: "100%",
-              bottom: 10,
-              marginLeft: "auto",
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 6,
-              padding: "6px 10px",
-              borderRadius: "var(--radius-sm)",
-              border: streaming ? "1px solid var(--info-border)" : "1px solid var(--border)",
-              background: streaming ? "var(--info-surface)" : "var(--bg-2)",
-              color: streaming ? "var(--info)" : "var(--text-2)",
-              fontSize: 11.5,
-              cursor: "pointer",
-              boxShadow: "var(--shadow-popover)",
-              zIndex: 2,
-            }}
           >
-            {streaming && (
-              <span
-                style={{
-                  width: 6,
-                  height: 6,
-                  borderRadius: "50%",
-                  background: "var(--info)",
-                  animation: "pulse-soft 1.5s ease-in-out infinite",
-                  flexShrink: 0,
-                }}
-              />
-            )}
+            {streaming && <span className="chat-jump-pill-dot" />}
             {streaming ? t("panel.newActivity") : t("panel.jumpToLatest")}
           </button>
         )}
@@ -5378,7 +5417,9 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                   <Shield size={11} />
                 </span>
                 <span className="approval-header-title">
-                  {t("panel.approvalBannerTitle")}
+                  {t("panel.approvalBannerTitleCount", {
+                    count: pendingApprovalBannerRows.length,
+                  })}
                 </span>
                 <span className="approval-header-spacer" />
                 {activeRepo && activeRepo.trustLevel !== "trusted" && (
@@ -5515,22 +5556,6 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                           </>
                         ) : (
                           <>
-                            {supportsCancel && !isPermissionsRequest && (
-                              <button
-                                type="button"
-                                className="approval-btn approval-btn-cancel"
-                                onClick={() =>
-                                  void respondApproval(
-                                    approval.approvalId,
-                                    isToolInputRequest
-                                      ? { action: "cancel" }
-                                      : { decision: "cancel" },
-                                  )
-                                }
-                              >
-                                {t("panel.approvalActions.cancel")}
-                              </button>
-                            )}
                             {supportsDecline && (
                               <button
                                 type="button"
@@ -5550,6 +5575,22 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                                 }
                               >
                                 {t("panel.approvalActions.deny")}
+                              </button>
+                            )}
+                            {supportsCancel && !isPermissionsRequest && (
+                              <button
+                                type="button"
+                                className="approval-btn approval-btn-cancel"
+                                onClick={() =>
+                                  void respondApproval(
+                                    approval.approvalId,
+                                    isToolInputRequest
+                                      ? { action: "cancel" }
+                                      : { decision: "cancel" },
+                                  )
+                                }
+                              >
+                                {t("panel.approvalActions.cancel")}
                               </button>
                             )}
                             {!hidePositiveApprovalActions && (
@@ -5682,14 +5723,6 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
               />
             ) : (
               <>
-                {/* Plan mode indicator banner */}
-                {activePlanMode && (
-                  <div className="chat-plan-mode-banner">
-                    <ListChecks size={12} />
-                    <span>{t("panel.planMode")}</span>
-                  </div>
-                )}
-
                 {/* Attachment chips */}
                 {attachments.length > 0 && (
                   <div className="chat-attachments-bar">
@@ -5885,12 +5918,13 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
               {!showSpecialInputComposer && (
                 <button
                   type="button"
-                  className="chat-toolbar-btn"
+                  className="chat-toolbar-btn chat-toolbar-btn-bordered"
                   onClick={() => void handleAddAttachment()}
                   disabled={!activeWorkspaceId}
                   title={t("panel.attachFiles")}
                 >
                   <Plus size={12} />
+                  <span style={{ fontSize: 11 }}>{t("panel.attachShort")}</span>
                   {attachments.length > 0 && (
                     <span className="chat-toolbar-badge">{attachments.length}</span>
                   )}
@@ -5968,19 +6002,27 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                         type="button"
                         className={`chat-toolbar-btn chat-toolbar-btn-bordered chat-toolbar-btn-fast ${selectedServiceTier === "fast" ? "chat-toolbar-btn-fast-active" : ""}`}
                         onClick={() => {
-                          void onCodexConfigSave({
-                            updatePersonality: false,
-                            personality: null,
-                            updateServiceTier: true,
-                            serviceTier:
-                              selectedServiceTier === "fast" ? null : "fast",
-                            updateOutputSchema: false,
-                            outputSchema: null,
-                            updateApprovalPolicy: false,
-                            approvalPolicy: null,
-                          }).catch((error) => {
-                            toast.error(String(error));
-                          });
+                          const toggleFastTier = (): Promise<unknown> =>
+                            onCodexConfigSave({
+                              updatePersonality: false,
+                              personality: null,
+                              updateServiceTier: true,
+                              serviceTier:
+                                selectedServiceTier === "fast" ? null : "fast",
+                              updateOutputSchema: false,
+                              outputSchema: null,
+                              updateApprovalPolicy: false,
+                              approvalPolicy: null,
+                            }).catch((error) => {
+                              toast.error(String(error), {
+                                title: t("panel.toasts.fastToggleFailed"),
+                                action: {
+                                  label: t("panel.toasts.retry"),
+                                  onClick: () => void toggleFastTier(),
+                                },
+                              });
+                            });
+                          void toggleFastTier();
                         }}
                         title={t("configPicker.serviceTierDescription")}
                       >
@@ -6113,23 +6155,49 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
               <div style={{ flex: 1 }} />
 
               <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                {!showSpecialInputComposer &&
+                  (isCodexEngine || selectedEngineId === "claude") &&
+                  usageLimits?.contextPercent != null && (
+                  <button
+                    type="button"
+                    className={`chat-context-ring${
+                      usageLimits.contextPercent <= 10
+                        ? " chat-context-ring--critical"
+                        : usageLimits.contextPercent <= 25
+                          ? " chat-context-ring--warning"
+                          : ""
+                    }`}
+                    onClick={openUsageLimitsModal}
+                    title={t("status.contextRingTitle", {
+                      percent: formatUsagePercent(usageLimits.contextPercent),
+                    })}
+                    aria-label={t("status.contextRingTitle", {
+                      percent: formatUsagePercent(usageLimits.contextPercent),
+                    })}
+                  >
+                    <svg width="16" height="16" viewBox="0 0 16 16" style={{ transform: "rotate(-90deg)" }} aria-hidden="true">
+                      <circle className="chat-context-ring-track" cx="8" cy="8" r="6" strokeWidth="2" />
+                      <circle
+                        className="chat-context-ring-value"
+                        cx="8"
+                        cy="8"
+                        r="6"
+                        strokeWidth="2"
+                        strokeDasharray={2 * Math.PI * 6}
+                        strokeDashoffset={
+                          2 * Math.PI * 6 * (1 - Math.max(0, Math.min(100, usageLimits.contextPercent)) / 100)
+                        }
+                      />
+                    </svg>
+                    <span>{formatUsagePercent(usageLimits.contextPercent)}</span>
+                  </button>
+                )}
+
                 {streaming && !showSpecialInputComposer && (
                   <button
                     type="button"
+                    className="chat-stop-btn"
                     onClick={() => void cancel()}
-                    style={{
-                      padding: "5px 10px",
-                      borderRadius: "var(--radius-sm)",
-                      background: "var(--danger-surface)",
-                      color: "var(--danger)",
-                      border: "1px solid var(--danger-border)",
-                      fontSize: 12,
-                      fontWeight: 600,
-                      cursor: "pointer",
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 5,
-                    }}
                   >
                     <Square size={11} fill="currentColor" />
                     {t("panel.stop")}
@@ -6139,6 +6207,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                 {(!streaming || canSteerActiveTurn) && !showSpecialInputComposer && (
                 <button
                   type="submit"
+                  className={`chat-send-btn${activeWorkspaceId && input.trim() ? " chat-send-btn--ready" : ""}`}
                   disabled={!activeWorkspaceId || !input.trim() || isSubmitting}
                   title={
                     isSubmitting
@@ -6155,32 +6224,6 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                         : t("panel.sendMessage")
                   }
                   aria-busy={isSubmitting}
-                  style={{
-                    width: 30,
-                    height: 30,
-                    borderRadius: "50%",
-                    background:
-                      activeWorkspaceId && input.trim()
-                        ? "var(--accent-fill)"
-                        : "var(--bg-4)",
-                    color:
-                      activeWorkspaceId && input.trim()
-                        ? "var(--on-accent-icon)"
-                        : "var(--text-3)",
-                    cursor: isSubmitting
-                      ? "wait"
-                      : activeWorkspaceId && input.trim()
-                        ? "pointer"
-                        : "default",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    transition: "all var(--duration-fast) var(--ease-out)",
-                    boxShadow:
-                      activeWorkspaceId && input.trim()
-                        ? "var(--accent-glow)"
-                        : "none",
-                  }}
                 >
                   {isSubmitting ? (
                     <Loader2 size={13} className="chat-send-spinner" aria-hidden="true" />
@@ -6198,23 +6241,12 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
             {(isCodexEngine || selectedEngineId === "claude") && (
               usageLimits ? (
                 <div className="chat-status-usage">
-                  <div className="chat-context-section">
-                    <Zap size={10} />
-                    <span>{t("status.context")}</span>
-                    <div className="chat-context-progress">
-                      <div
-                        className={`chat-context-progress-fill${usageProgressLevelClass(usageLimits.contextPercent)}`}
-                        style={{ width: usagePercentToWidth(usageLimits.contextPercent) }}
-                      />
-                    </div>
-                    <span className="chat-context-percent">
-                      {formatUsagePercent(usageLimits.contextPercent)}
-                    </span>
-                  </div>
-
-                  <span className="chat-context-divider">&middot;</span>
-
-                  <div className="chat-context-section">
+                  <button
+                    type="button"
+                    className="chat-context-section"
+                    onClick={openUsageLimitsModal}
+                    title={t("status.openUsageLimits")}
+                  >
                     <Clock size={10} />
                     <span>{t("status.windowFiveHoursLeft")}</span>
                     <div className="chat-context-progress">
@@ -6233,11 +6265,16 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                         })}
                       </span>
                     )}
-                  </div>
+                  </button>
 
                   <span className="chat-context-divider">&middot;</span>
 
-                  <div className="chat-context-section">
+                  <button
+                    type="button"
+                    className="chat-context-section"
+                    onClick={openUsageLimitsModal}
+                    title={t("status.openUsageLimits")}
+                  >
                     <Clock size={10} />
                     <span>{t("status.windowWeeklyLeft")}</span>
                     <div className="chat-context-progress">
@@ -6256,13 +6293,18 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                         })}
                       </span>
                     )}
-                  </div>
+                  </button>
 
                   {selectedClaudeWeeklyUsage && (
                     <>
                       <span className="chat-context-divider">&middot;</span>
 
-                      <div className="chat-context-section">
+                      <button
+                        type="button"
+                        className="chat-context-section"
+                        onClick={openUsageLimitsModal}
+                        title={t("status.openUsageLimits")}
+                      >
                         <Clock size={10} />
                         <span>{selectedClaudeWeeklyUsage.label}</span>
                         <div className="chat-context-progress">
@@ -6281,7 +6323,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                             })}
                           </span>
                         )}
-                      </div>
+                      </button>
                     </>
                   )}
                 </div>
@@ -6306,17 +6348,8 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
         </form>
 
               {error && (
-                <div
-                  style={{
-                    marginTop: 8,
-                    padding: "8px 12px",
-                    borderRadius: "var(--radius-sm)",
-                    background: "var(--danger-surface)",
-                    border: "1px solid var(--danger-border)",
-                    color: "var(--danger)",
-                    fontSize: 12,
-                  }}
-                >
+                <div className="msg-error-block" style={{ marginTop: 8, fontSize: 12 }}>
+                  <AlertTriangle size={14} style={{ flexShrink: 0, marginTop: 2 }} />
                   {error}
                 </div>
               )}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -2296,7 +2296,6 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
       codexExternalSandboxActive,
     ],
   );
-  const fullAutonomyArmed = activeThreadAutonomyPreset === "full";
   const [defaultAutonomyPreset, setDefaultAutonomyPreset] =
     useState<AutonomyPresetId | null>(null);
 
@@ -5907,7 +5906,7 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
 
           {/* Input container */}
           <div
-            className={`chat-input-box ${activePlanMode && !showSpecialInputComposer ? "chat-input-box-plan" : ""} ${fullAutonomyArmed && !activePlanMode && !showSpecialInputComposer ? "chat-input-box-armed" : ""} ${showSpecialInputComposer ? "chat-input-box-tool-input" : ""}`.trim()}
+            className={`chat-input-box ${activePlanMode && !showSpecialInputComposer ? "chat-input-box-plan" : ""} ${showSpecialInputComposer ? "chat-input-box-tool-input" : ""}`.trim()}
             onPaste={handleInputPaste}
           >
             {showPendingToolInputComposer && pendingToolInputApproval ? (
@@ -6254,7 +6253,6 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
                   <PermissionPicker
                     engineId={activeThreadAutonomyEngineId}
                     presetValue={activeThreadAutonomyPreset}
-                    codexExternalSandbox={codexExternalSandboxActive}
                     onPresetChange={
                       activeThreadAutonomyEngineId ? onAutonomyPresetChange : undefined
                     }

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -59,7 +59,10 @@ import { useThreadStore } from "../../stores/threadStore";
 import { useUiStore } from "../../stores/uiStore";
 import { getHarnessIcon } from "../shared/HarnessLogos";
 import { showWorkspaceEditorForDirectFileOpen } from "../../lib/workspacePaneNavigation";
-import { resolveRelativePathWithinRoot } from "../../lib/fileRootUtils";
+import {
+  resolveRelativePathWithinRoot,
+  resolveThreadFileRootPath,
+} from "../../lib/fileRootUtils";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useGitStore } from "../../stores/gitStore";
 import { useTerminalStore, type LayoutMode } from "../../stores/terminalStore";
@@ -4857,7 +4860,15 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
   const openFileInEditor = useFileStore((s) => s.openFile);
   const openUsageLimitsModal = useUiStore((s) => s.openUsageLimitsModal);
 
-  const diffFileRootPath = activeRepo?.path ?? activeWorkspace?.rootPath ?? null;
+  const diffFileRootPath = useMemo(
+    () =>
+      resolveThreadFileRootPath(
+        activeThread,
+        repos,
+        activeWorkspace?.rootPath ?? null,
+      ),
+    [activeThread, activeWorkspace?.rootPath, repos],
+  );
   const handleOpenDiffFile = useCallback(
     (filePath: string) => {
       if (!diffFileRootPath || !activeWorkspaceId) {

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -59,6 +59,7 @@ import { useThreadStore } from "../../stores/threadStore";
 import { useUiStore } from "../../stores/uiStore";
 import { getHarnessIcon } from "../shared/HarnessLogos";
 import { showWorkspaceEditorForDirectFileOpen } from "../../lib/workspacePaneNavigation";
+import { resolveRelativePathWithinRoot } from "../../lib/fileRootUtils";
 import { useWorkspaceStore } from "../../stores/workspaceStore";
 import { useGitStore } from "../../stores/gitStore";
 import { useTerminalStore, type LayoutMode } from "../../stores/terminalStore";
@@ -4682,10 +4683,13 @@ export function ChatPanel({ embedded = false }: ChatPanelProps = {}) {
         return;
       }
       const normalized = filePath.replace(/\\/g, "/");
-      const absolutePath = /^(\/|[A-Za-z]:)/.test(normalized)
-        ? normalized
-        : `${diffFileRootPath}/${normalized}`;
-      void openFileInEditor(diffFileRootPath, absolutePath);
+      const relativePath = /^(\/|[A-Za-z]:)/.test(normalized)
+        ? resolveRelativePathWithinRoot(normalized, diffFileRootPath)
+        : normalized;
+      if (!relativePath) {
+        return;
+      }
+      void openFileInEditor(diffFileRootPath, relativePath);
       showWorkspaceEditorForDirectFileOpen(activeWorkspaceId);
     },
     [activeWorkspaceId, diffFileRootPath, openFileInEditor],

--- a/src/components/chat/MessageBlocks.tsx
+++ b/src/components/chat/MessageBlocks.tsx
@@ -13,10 +13,15 @@ import {
   CheckCircle2,
   Circle,
   AlertTriangle,
+  AtSign,
   CornerDownRight,
   ChevronRight,
+  DollarSign,
+  ExternalLink,
   FileCode2,
   FileDiff,
+  Maximize2,
+  Minimize2,
   Terminal,
   Shield,
   Loader2,
@@ -84,6 +89,7 @@ interface Props {
   engineId?: string;
   onApproval: (approvalId: string, response: ApprovalResponse) => void;
   onLoadActionOutput?: (actionId: string) => Promise<void>;
+  onOpenDiffFile?: (filePath: string) => void;
 }
 
 function isBlockLike(value: unknown): value is { type: string } {
@@ -214,8 +220,7 @@ type InnerSegment =
 
 type BlockSegment =
   | InnerSegment
-  | { kind: "action-card"; segments: InnerSegment[] }
-  | { kind: "divider" };
+  | { kind: "action-card"; segments: InnerSegment[] };
 
 function isCardSegment(seg: BlockSegment): seg is InnerSegment {
   if (seg.kind === "action-group") return true;
@@ -361,7 +366,13 @@ function buildBlockSegments(blocks: ContentBlock[], isStreaming?: boolean): Bloc
 
 /* ── Diff Block ── */
 
-function MessageDiffBlock({ block }: { block: DiffBlock }) {
+function MessageDiffBlock({
+  block,
+  onOpenDiffFile,
+}: {
+  block: DiffBlock;
+  onOpenDiffFile?: (filePath: string) => void;
+}) {
   const { t } = useTranslation("chat");
   const [expanded, setExpanded] = useState(false);
   const raw = String(block.diff ?? "");
@@ -392,21 +403,35 @@ function MessageDiffBlock({ block }: { block: DiffBlock }) {
           size={11}
           className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
         />
-        <FileDiff size={12} style={{ color: "var(--text-3)", flexShrink: 0 }} />
-        <span style={{ fontSize: 11.5, color: "var(--text-2)", flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <span className="msg-block-tile">
+          <FileDiff size={11} />
+        </span>
+        <span className="msg-block-label msg-block-label--mono">
           <LinkifiedPlainText text={filename ?? t("messageBlocks.diffFallback", { scope: String(block.scope ?? "turn") })} />
         </span>
-        {loadingParse && (
-          <span style={{ fontSize: 10, color: "var(--text-3)", flexShrink: 0 }}>
-            {t("messageBlocks.parsing")}
-          </span>
-        )}
-        {(adds > 0 || dels > 0) && (
-          <span style={{ fontSize: 10, fontFamily: '"Geist Mono", ui-monospace, monospace', display: "flex", gap: 5, flexShrink: 0 }}>
-            {adds > 0 && <span style={{ color: "var(--success)" }}>+{adds}</span>}
-            {dels > 0 && <span style={{ color: "var(--danger)" }}>-{dels}</span>}
-          </span>
-        )}
+        <span className="msg-block-meta">
+          {loadingParse && <span>{t("messageBlocks.parsing")}</span>}
+          {(adds > 0 || dels > 0) && (
+            <span style={{ display: "inline-flex", gap: 5 }}>
+              {adds > 0 && <span style={{ color: "var(--success)" }}>+{adds}</span>}
+              {dels > 0 && <span style={{ color: "var(--danger)" }}>-{dels}</span>}
+            </span>
+          )}
+          {onOpenDiffFile && filename && (
+            <button
+              type="button"
+              className="msg-row-action-btn"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenDiffFile(filename);
+              }}
+              title={t("messageBlocks.openInEditor")}
+              aria-label={t("messageBlocks.openInEditor")}
+            >
+              <ExternalLink size={11} />
+            </button>
+          )}
+        </span>
       </div>
       {expanded && (
         !parseResult && (loadingParse || !parseAttempted) ? (
@@ -420,7 +445,7 @@ function MessageDiffBlock({ block }: { block: DiffBlock }) {
             border: "1px solid var(--border)",
             background: "var(--code-bg)",
           }}>
-            <VirtualizedDiffBody parsed={parseResult.parsed} />
+            <VirtualizedDiffBody parsed={parseResult.parsed} foldContext />
           </div>
         ) : (
           <div style={{ padding: "4px 14px", fontSize: 11.5, color: "var(--text-3)" }}>
@@ -442,9 +467,7 @@ function ThinkingBlockView({ block, isStreaming }: { block: ThinkingBlock; isStr
   const durationSec = block.durationMs != null ? Math.round(block.durationMs / 1000) : null;
   const thinkingLabel = isStreaming
     ? `${t("messageBlocks.thinking")}\u2026`
-    : durationSec != null && durationSec > 0
-      ? t("messageBlocks.thinkingDone", { seconds: durationSec })
-      : t("messageBlocks.thinking");
+    : t("messageBlocks.thought");
   const toggleExpanded = useCallback(() => setExpanded((v) => !v), []);
 
   return (
@@ -461,43 +484,31 @@ function ThinkingBlockView({ block, isStreaming }: { block: ThinkingBlock; isStr
           size={11}
           className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
         />
-        <Brain
-          size={12}
-          className={isStreaming ? "thinking-icon-active" : undefined}
-          style={{ color: "var(--text-3)", flexShrink: 0, verticalAlign: "middle" }}
-        />
-        <span style={{ fontSize: 11.5, color: "var(--text-2)", lineHeight: 1 }}>
+        <span className="msg-block-tile msg-block-tile--violet">
+          <Brain size={11} />
+        </span>
+        <span className={`msg-block-label${isStreaming ? " msg-shimmer" : ""}`}>
           {thinkingLabel}
         </span>
+        {!isStreaming && durationSec != null && durationSec > 0 && (
+          <span className="msg-block-meta">
+            {t("messageBlocks.thinkingDuration", { seconds: durationSec })}
+          </span>
+        )}
       </div>
       {expanded && (
-        isStreaming ? (
-          <pre
-            style={{
-              margin: 0,
-              fontSize: 12.5,
-              color: "var(--text-2)",
-              padding: "2px 12px 8px 30px",
-              minWidth: 0,
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-word",
-              fontFamily: "inherit",
-            }}
-          >
-            {content}
-          </pre>
-        ) : (
+        <div className="msg-block-body">
           <MarkdownContent
             content={content}
+            streaming={isStreaming}
             className="prose"
             style={{
               fontSize: 12.5,
               color: "var(--text-2)",
-              padding: "2px 12px 8px 30px",
               minWidth: 0,
             }}
           />
-        )
+        </div>
       )}
     </div>
   );
@@ -505,13 +516,13 @@ function ThinkingBlockView({ block, isStreaming }: { block: ThinkingBlock; isStr
 
 function NoticeBlockView({ block }: { block: NoticeBlock }) {
   return (
-    <div className="msg-notice-block msg-notice-block--info">
-      <Info size={14} style={{ flexShrink: 0, color: "var(--info)", marginTop: 1 }} />
-      <div style={{ minWidth: 0 }}>
-        <div style={{ fontSize: 11, fontWeight: 600, color: "var(--info)", marginBottom: 2 }}>
-          {block.title}
-        </div>
-        <div>{block.message}</div>
+    <div className="msg-notice">
+      <span className="msg-block-tile msg-block-tile--info">
+        <Info size={11} />
+      </span>
+      <div className="msg-notice-content">
+        <div className="msg-notice-title">{block.title}</div>
+        <div className="msg-notice-message">{block.message}</div>
       </div>
     </div>
   );
@@ -524,16 +535,13 @@ function SteerBlockView({ block }: { block: SteerBlock }) {
   const hasContent = block.content.trim().length > 0;
 
   return (
-    <div className="msg-notice-block msg-notice-block--steer">
-      <CornerDownRight size={14} style={{ flexShrink: 0, color: "var(--danger)", marginTop: 1 }} />
-      <div style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 6, width: "100%" }}>
+    <div className="msg-notice msg-notice--steer">
+      <span className="msg-block-tile msg-block-tile--accent">
+        <CornerDownRight size={11} />
+      </span>
+      <div className="msg-notice-content">
         {hasContent && (
-          <div
-            style={{
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-word",
-            }}
-          >
+          <div className="msg-notice-message">
             {block.content}
           </div>
         )}
@@ -543,19 +551,21 @@ function SteerBlockView({ block }: { block: SteerBlock }) {
             {skillBlocks.map((skill) => (
               <span
                 key={`skill:${skill.path}`}
-                className="chat-attachment-chip"
+                className="chat-attachment-chip chat-attachment-chip--skill"
                 style={{ display: "inline-flex" }}
               >
-                <span className="chat-attachment-chip-name">{`$${skill.name}`}</span>
+                <DollarSign size={10} />
+                <span className="chat-attachment-chip-name">{skill.name}</span>
               </span>
             ))}
             {mentionBlocks.map((mention) => (
               <span
                 key={`mention:${mention.path}`}
-                className="chat-attachment-chip"
+                className="chat-attachment-chip chat-attachment-chip--mention"
                 style={{ display: "inline-flex" }}
               >
-                <span className="chat-attachment-chip-name">{`@${mention.name}`}</span>
+                <AtSign size={10} />
+                <span className="chat-attachment-chip-name">{mention.name}</span>
               </span>
             ))}
             {attachmentBlocks.map((attachment) => {
@@ -649,10 +659,20 @@ function ActionBlockView({
       ? actionDetails.progressMessage
       : null;
   const [expanded, setExpanded] = useState(false);
+  const [outputExpandedFully, setOutputExpandedFully] = useState(false);
+  const [outputCopied, setOutputCopied] = useState(false);
   const [loadingDeferredOutput, setLoadingDeferredOutput] = useState(false);
   const [deferredOutputError, setDeferredOutputError] = useState<string | null>(null);
   const deferredOutputRequestedRef = useRef(false);
   const canToggle = hasBody;
+
+  const handleCopyOutput = useCallback(() => {
+    if (!outputText) return;
+    navigator.clipboard.writeText(outputText).then(() => {
+      setOutputCopied(true);
+      setTimeout(() => setOutputCopied(false), 1500);
+    });
+  }, [outputText]);
 
   const requestDeferredOutput = useCallback(() => {
     if (!onLoadDeferredOutput || deferredOutputRequestedRef.current) {
@@ -689,8 +709,7 @@ function ActionBlockView({
   return (
     <div>
       <div
-        className={canToggle ? "msg-block-header msg-block-header--compact" : undefined}
-        style={canToggle ? undefined : { display: "flex", alignItems: "center", gap: 6, padding: "3px 12px" }}
+        className={`msg-block-header msg-block-header--compact${canToggle ? "" : " msg-block-header--static"}`}
         {...(canToggle ? {
           role: "button" as const,
           tabIndex: 0,
@@ -699,24 +718,32 @@ function ActionBlockView({
           onKeyDown: (e: React.KeyboardEvent) => handleToggleKeyDown(e, toggleExpanded),
         } : {})}
       >
-        {canToggle && (
+        {canToggle ? (
           <ChevronRight
             size={11}
             className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
           />
+        ) : (
+          <span style={{ width: 11, flexShrink: 0 }} aria-hidden="true" />
         )}
-        <Icon size={12} style={{ color: "var(--text-3)", flexShrink: 0 }} />
-        <span style={{ fontSize: 11.5, color: "var(--text-2)", flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <span className="msg-block-tile">
+          <Icon size={11} />
+        </span>
+        <span
+          className={`msg-block-label${block.actionType === "command" ? " msg-block-label--mono" : ""}`}
+        >
           {block.summary}
         </span>
-        <ActionStatusBadge status={block.status} />
-        {block.result?.durationMs != null && block.status === "done" && (
-          <span style={{ fontSize: 9.5, color: "var(--text-3)", flexShrink: 0 }}>
-            {block.result.durationMs < 1000
-              ? `${block.result.durationMs}ms`
-              : `${(block.result.durationMs / 1000).toFixed(1)}s`}
-          </span>
-        )}
+        <span className="msg-block-meta">
+          {block.result?.durationMs != null && block.status === "done" && (
+            <span>
+              {block.result.durationMs < 1000
+                ? `${block.result.durationMs}ms`
+                : `${(block.result.durationMs / 1000).toFixed(1)}s`}
+            </span>
+          )}
+          <ActionStatusBadge status={block.status} />
+        </span>
       </div>
 
       {progressMessage && (
@@ -789,9 +816,50 @@ function ActionBlockView({
           )}
 
           {outputChunks.length > 0 && (
-            <pre className="action-output-pre" style={{ maxHeight: 260 }}>
-              <LinkifiedPlainText text={outputText} />
-            </pre>
+            <>
+              <div className="action-output-well-header">
+                <span>{t("messageBlocks.output")}</span>
+                <span className="action-output-well-actions">
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleCopyOutput();
+                    }}
+                    title={t("messageBlocks.copyOutput")}
+                    aria-label={t("messageBlocks.copyOutput")}
+                    style={outputCopied ? { color: "var(--success)" } : undefined}
+                  >
+                    {outputCopied ? <Check size={11} /> : <Copy size={11} />}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setOutputExpandedFully((v) => !v);
+                    }}
+                    title={
+                      outputExpandedFully
+                        ? t("messageBlocks.collapseOutput")
+                        : t("messageBlocks.expandOutput")
+                    }
+                    aria-label={
+                      outputExpandedFully
+                        ? t("messageBlocks.collapseOutput")
+                        : t("messageBlocks.expandOutput")
+                    }
+                  >
+                    {outputExpandedFully ? <Minimize2 size={11} /> : <Maximize2 size={11} />}
+                  </button>
+                </span>
+              </div>
+              <pre
+                className="action-output-pre"
+                style={{ maxHeight: outputExpandedFully ? undefined : 260 }}
+              >
+                <LinkifiedPlainText text={outputText} />
+              </pre>
+            </>
           )}
 
           {outputTruncated && (
@@ -862,10 +930,9 @@ function ActionGroupView({
 
   const typeBreakdown = useMemo(() => {
     return Object.entries(typeCounts)
-      .map(([type, count]) => {
-        const label = t(`messageBlocks.actionGroup.types.${actionTypeLabels[type] ?? "other"}`);
-        return `${count} ${label}`;
-      })
+      .map(([type, count]) =>
+        t(`messageBlocks.actionGroup.types.${actionTypeLabels[type] ?? "other"}`, { count }),
+      )
       .join(" · ");
   }, [typeCounts, t]);
 
@@ -889,20 +956,22 @@ function ActionGroupView({
           size={11}
           className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
         />
-        <Layers size={12} style={{ color: "var(--text-3)", flexShrink: 0, opacity: 0.7 }} />
-        <span style={{ fontSize: 11.5, color: "var(--text-2)", flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        <span className="msg-block-tile">
+          <Layers size={11} />
+        </span>
+        <span className="msg-block-label">
           {summaryText}
         </span>
-        <span style={{ fontSize: 10, color: "var(--text-3)", flexShrink: 0 }}>
-          {typeBreakdown}
+        <span className="msg-block-meta">
+          <span>{typeBreakdown}</span>
+          {allErrored ? (
+            <XCircle size={11} style={{ color: "var(--danger)", flexShrink: 0 }} />
+          ) : hasAnyError ? (
+            <AlertTriangle size={11} style={{ color: "var(--text-3)", flexShrink: 0 }} />
+          ) : (
+            <CheckCircle2 size={11} style={{ color: "var(--text-3)", flexShrink: 0 }} />
+          )}
         </span>
-        {allErrored ? (
-          <XCircle size={11} style={{ color: "var(--danger)", flexShrink: 0 }} />
-        ) : hasAnyError ? (
-          <AlertTriangle size={11} style={{ color: "var(--text-3)", flexShrink: 0 }} />
-        ) : (
-          <CheckCircle2 size={11} style={{ color: "var(--text-3)", flexShrink: 0 }} />
-        )}
       </div>
       <div className={`action-group-body${expanded ? " action-group-body--expanded" : ""}`}>
         <div
@@ -1008,9 +1077,6 @@ function ToolInputApprovalCard({
   block: ApprovalBlock;
   questions: { id: string; question: string }[];
   isPending: boolean;
-  decisionLabel: string;
-  decisionBackground: string;
-  decisionColor: string;
 }) {
   const { t } = useTranslation("chat");
   if (questions.length <= 0) return null;
@@ -1039,8 +1105,13 @@ function ToolInputApprovalCard({
         {hasAnswers && (
           <ChevronRight size={11} className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`} />
         )}
-        <MessageSquare size={12} style={{ color: isPending ? "var(--info)" : "var(--text-3)", flexShrink: 0, opacity: 0.7 }} />
-        <span style={{ fontSize: 11.5, color: "var(--text-2)", flex: 1 }}>
+        <span
+          className="msg-block-tile"
+          style={isPending ? { background: "var(--info-surface)", color: "var(--info)" } : undefined}
+        >
+          <MessageSquare size={11} />
+        </span>
+        <span className="msg-block-label">
           {isPending
             ? t("messageBlocks.approval.pendingQuestions", { count: questions.length })
             : t("messageBlocks.approval.answeredQuestions", { count: questions.length })}
@@ -1150,22 +1221,16 @@ function ApprovalCard({
   }, [block.approvalId]);
 
   let decisionLabel = t("messageBlocks.approval.decision.answered");
+  let decisionClass = "acard-decision--neutral";
   if (block.decision === "decline") {
     decisionLabel = t("messageBlocks.approval.decision.denied");
+    decisionClass = "acard-decision--denied";
   } else if (block.decision === "cancel") {
     decisionLabel = t("messageBlocks.approval.decision.canceled");
+    decisionClass = "acard-decision--denied";
   } else if (block.decision === "accept" || block.decision === "accept_for_session") {
     decisionLabel = t("messageBlocks.approval.decision.approved");
-  }
-
-  let decisionBackground = "var(--neutral-surface)";
-  let decisionColor = "var(--text-2)";
-  if (block.decision === "decline" || block.decision === "cancel") {
-    decisionBackground = "var(--danger-surface)";
-    decisionColor = "var(--danger)";
-  } else if (block.decision === "accept" || block.decision === "accept_for_session") {
-    decisionBackground = "var(--success-surface)";
-    decisionColor = "var(--success)";
+    decisionClass = "acard-decision--approved";
   }
 
   if (isToolInputRequest && toolInputQuestions.length > 0 && !showClaudeUnsupportedApproval) {
@@ -1175,9 +1240,6 @@ function ApprovalCard({
           block={block}
           questions={toolInputQuestions}
           isPending={isPending}
-          decisionLabel={decisionLabel}
-          decisionBackground={decisionBackground}
-          decisionColor={decisionColor}
         />
       </div>
     );
@@ -1222,10 +1284,7 @@ function ApprovalCard({
         <span className="acard-summary">{block.summary}</span>
         <span className="acard-type">{block.actionType}</span>
         {!isPending && block.decision && (
-          <span
-            className="acard-decision"
-            style={{ background: decisionBackground, color: decisionColor }}
-          >
+          <span className={`acard-decision ${decisionClass}`}>
             {decisionLabel}
           </span>
         )}
@@ -1421,6 +1480,7 @@ function renderSingleBlock(
   engineId: string | undefined,
   onApproval: (approvalId: string, response: ApprovalResponse) => void,
   onLoadActionOutput: ((actionId: string) => Promise<void>) | undefined,
+  onOpenDiffFile: ((filePath: string) => void) | undefined,
 ) {
   const blockKey = getMessageBlockKey(block, index, safeBlocks);
 
@@ -1506,7 +1566,7 @@ function renderSingleBlock(
   if (block.type === "diff") {
     return (
       <div key={blockKey} className="msg-action-card">
-        <MessageDiffBlock block={block} />
+        <MessageDiffBlock block={block} onOpenDiffFile={onOpenDiffFile} />
       </div>
     );
   }
@@ -1581,7 +1641,7 @@ function renderSingleBlock(
   return null;
 }
 
-function MessageBlocksView({ blocks = [], status, engineId, onApproval, onLoadActionOutput }: Props) {
+function MessageBlocksView({ blocks = [], status, engineId, onApproval, onLoadActionOutput, onOpenDiffFile }: Props) {
   const safeBlocks = useMemo(
     () => dedupeDiffBlocksByScope(
       (Array.isArray(blocks) ? blocks : []).filter(isBlockLike) as ContentBlock[],
@@ -1595,10 +1655,6 @@ function MessageBlocksView({ blocks = [], status, engineId, onApproval, onLoadAc
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
       {blockSegments.map((segment, segIdx) => {
-        if (segment.kind === "divider") {
-          return <div key={`divider-${segIdx}`} className="msg-section-divider" />;
-        }
-
         if (segment.kind === "action-card") {
           return (
             <div key={`action-card-${segIdx}`} className="msg-action-card">
@@ -1641,6 +1697,7 @@ function MessageBlocksView({ blocks = [], status, engineId, onApproval, onLoadAc
                     <MessageDiffBlock
                       key={getMessageBlockKey(inner.block, inner.index, safeBlocks)}
                       block={inner.block as DiffBlock}
+                      onOpenDiffFile={onOpenDiffFile}
                     />
                   );
                 }
@@ -1678,6 +1735,7 @@ function MessageBlocksView({ blocks = [], status, engineId, onApproval, onLoadAc
           engineId,
           onApproval,
           onLoadActionOutput,
+          onOpenDiffFile,
         );
       })}
     </div>
@@ -1691,5 +1749,6 @@ export const MessageBlocks = memo(
     prev.status === next.status &&
     prev.engineId === next.engineId &&
     prev.onApproval === next.onApproval &&
-    prev.onLoadActionOutput === next.onLoadActionOutput,
+    prev.onLoadActionOutput === next.onLoadActionOutput &&
+    prev.onOpenDiffFile === next.onOpenDiffFile,
 );

--- a/src/components/chat/MessageBlocks.tsx
+++ b/src/components/chat/MessageBlocks.tsx
@@ -202,6 +202,61 @@ function LinkifiedPlainText({ text }: { text: string }) {
   return <>{nodes}</>;
 }
 
+interface MessageBlockHeaderProps {
+  icon: ReactNode;
+  label: ReactNode;
+  meta?: ReactNode;
+  expanded?: boolean;
+  labelMono?: boolean;
+  tileTone?: "neutral" | "violet" | "amber" | "info";
+  onToggle?: () => void;
+}
+
+function MessageBlockHeader({
+  icon,
+  label,
+  meta,
+  expanded = false,
+  labelMono = false,
+  tileTone = "neutral",
+  onToggle,
+}: MessageBlockHeaderProps) {
+  const interactive = onToggle != null;
+  const tileToneClass = tileTone === "neutral" ? "" : ` msg-block-tile--${tileTone}`;
+
+  return (
+    <div
+      className={`msg-block-header${interactive ? "" : " msg-block-header--static"}`}
+      {...(interactive
+        ? {
+            role: "button" as const,
+            tabIndex: 0,
+            "aria-expanded": expanded,
+            onClick: onToggle,
+            onKeyDown: (event: React.KeyboardEvent) =>
+              handleToggleKeyDown(event, onToggle),
+          }
+        : {})}
+    >
+      {interactive ? (
+        <ChevronRight
+          size={11}
+          className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
+        />
+      ) : (
+        <span className="msg-block-chevron-spacer" aria-hidden="true" />
+      )}
+      <span className={`msg-block-tile${tileToneClass}`}>{icon}</span>
+      <span
+        className={`msg-block-label${labelMono ? " msg-block-label--mono" : ""}`}
+      >
+        {label}
+      </span>
+      {meta != null && <span className="msg-block-meta">{meta}</span>}
+    </div>
+  );
+}
+
 const actionIcons: Record<string, typeof Terminal> = {
   command: Terminal,
   file_write: FileCode2,
@@ -391,25 +446,16 @@ function MessageDiffBlock({
   const toggleExpanded = useCallback(() => setExpanded((v) => !v), []);
   return (
     <div>
-      <div
-        className="msg-block-header"
-        role="button"
-        tabIndex={0}
-        aria-expanded={expanded}
-        onClick={toggleExpanded}
-        onKeyDown={(e) => handleToggleKeyDown(e, toggleExpanded)}
-      >
-        <ChevronRight
-          size={11}
-          className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
-        />
-        <span className="msg-block-tile">
-          <FileDiff size={11} />
-        </span>
-        <span className="msg-block-label msg-block-label--mono">
+      <MessageBlockHeader
+        icon={<FileDiff size={11} />}
+        label={
           <LinkifiedPlainText text={filename ?? t("messageBlocks.diffFallback", { scope: String(block.scope ?? "turn") })} />
-        </span>
-        <span className="msg-block-meta">
+        }
+        labelMono
+        expanded={expanded}
+        onToggle={toggleExpanded}
+        meta={
+          <>
           {loadingParse && <span>{t("messageBlocks.parsing")}</span>}
           {(adds > 0 || dels > 0) && (
             <span style={{ display: "inline-flex", gap: 5 }}>
@@ -431,8 +477,9 @@ function MessageDiffBlock({
               <ExternalLink size={11} />
             </button>
           )}
-        </span>
-      </div>
+          </>
+        }
+      />
       {expanded && (
         !parseResult && (loadingParse || !parseAttempted) ? (
           <div style={{ padding: "4px 14px", fontSize: 11.5, color: "var(--text-3)" }}>
@@ -472,30 +519,18 @@ function ThinkingBlockView({ block, isStreaming }: { block: ThinkingBlock; isStr
 
   return (
     <div>
-      <div
-        className="msg-block-header"
-        role="button"
-        tabIndex={0}
-        aria-expanded={expanded}
-        onClick={toggleExpanded}
-        onKeyDown={(e) => handleToggleKeyDown(e, toggleExpanded)}
-      >
-        <ChevronRight
-          size={11}
-          className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
-        />
-        <span className="msg-block-tile msg-block-tile--violet">
-          <Brain size={11} />
-        </span>
-        <span className={`msg-block-label${isStreaming ? " msg-shimmer" : ""}`}>
-          {thinkingLabel}
-        </span>
-        {!isStreaming && durationSec != null && durationSec > 0 && (
-          <span className="msg-block-meta">
-            {t("messageBlocks.thinkingDuration", { seconds: durationSec })}
-          </span>
-        )}
-      </div>
+      <MessageBlockHeader
+        icon={<Brain size={11} />}
+        label={<span className={isStreaming ? "msg-shimmer" : undefined}>{thinkingLabel}</span>}
+        tileTone="violet"
+        expanded={expanded}
+        onToggle={toggleExpanded}
+        meta={
+          !isStreaming && durationSec != null && durationSec > 0
+            ? t("messageBlocks.thinkingDuration", { seconds: durationSec })
+            : undefined
+        }
+      />
       {expanded && (
         <div className="msg-block-body">
           <MarkdownContent
@@ -589,14 +624,14 @@ function ActionStatusBadge({ status }: { status: string }) {
   const { t } = useTranslation("chat");
   if (status === "done") {
     return (
-      <span style={{ display: "flex", alignItems: "center", gap: 3, color: "var(--text-3)", fontSize: 10 }}>
+      <span className="msg-block-status">
         <CheckCircle2 size={11} />
       </span>
     );
   }
   if (status === "running") {
     return (
-      <span style={{ display: "flex", alignItems: "center", gap: 3, color: "var(--warning)", fontSize: 10, fontWeight: 500 }}>
+      <span className="msg-block-status msg-block-status--warning">
         <Loader2 size={11} style={{ animation: "spin 1s linear infinite" }} />
         {t("messageBlocks.actionStatus.running")}
       </span>
@@ -604,14 +639,14 @@ function ActionStatusBadge({ status }: { status: string }) {
   }
   if (status === "error") {
     return (
-      <span style={{ display: "flex", alignItems: "center", gap: 3, color: "var(--danger)", fontSize: 10 }}>
+      <span className="msg-block-status msg-block-status--danger">
         <XCircle size={11} />
         {t("messageBlocks.actionStatus.error")}
       </span>
     );
   }
   return (
-    <span style={{ display: "flex", alignItems: "center", gap: 3, color: "var(--text-3)", fontSize: 10 }}>
+    <span className="msg-block-status">
       <Circle size={11} />
     </span>
   );
@@ -708,33 +743,14 @@ function ActionBlockView({
   const toggleExpanded = useCallback(() => setExpanded((v) => !v), []);
   return (
     <div>
-      <div
-        className={`msg-block-header msg-block-header--compact${canToggle ? "" : " msg-block-header--static"}`}
-        {...(canToggle ? {
-          role: "button" as const,
-          tabIndex: 0,
-          "aria-expanded": expanded,
-          onClick: toggleExpanded,
-          onKeyDown: (e: React.KeyboardEvent) => handleToggleKeyDown(e, toggleExpanded),
-        } : {})}
-      >
-        {canToggle ? (
-          <ChevronRight
-            size={11}
-            className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
-          />
-        ) : (
-          <span style={{ width: 11, flexShrink: 0 }} aria-hidden="true" />
-        )}
-        <span className="msg-block-tile">
-          <Icon size={11} />
-        </span>
-        <span
-          className={`msg-block-label${block.actionType === "command" ? " msg-block-label--mono" : ""}`}
-        >
-          {block.summary}
-        </span>
-        <span className="msg-block-meta">
+      <MessageBlockHeader
+        icon={<Icon size={11} />}
+        label={block.summary}
+        labelMono={block.actionType === "command"}
+        expanded={expanded}
+        onToggle={canToggle ? toggleExpanded : undefined}
+        meta={
+          <>
           {block.result?.durationMs != null && block.status === "done" && (
             <span>
               {block.result.durationMs < 1000
@@ -743,8 +759,9 @@ function ActionBlockView({
             </span>
           )}
           <ActionStatusBadge status={block.status} />
-        </span>
-      </div>
+          </>
+        }
+      />
 
       {progressMessage && (
         <div
@@ -944,25 +961,13 @@ function ActionGroupView({
   const toggleExpanded = useCallback(() => setExpanded((v) => !v), []);
   return (
     <div className="animate-slide-up">
-      <div
-        className="msg-block-header"
-        role="button"
-        tabIndex={0}
-        aria-expanded={expanded}
-        onClick={toggleExpanded}
-        onKeyDown={(e) => handleToggleKeyDown(e, toggleExpanded)}
-      >
-        <ChevronRight
-          size={11}
-          className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`}
-        />
-        <span className="msg-block-tile">
-          <Layers size={11} />
-        </span>
-        <span className="msg-block-label">
-          {summaryText}
-        </span>
-        <span className="msg-block-meta">
+      <MessageBlockHeader
+        icon={<Layers size={11} />}
+        label={summaryText}
+        expanded={expanded}
+        onToggle={toggleExpanded}
+        meta={
+          <>
           <span>{typeBreakdown}</span>
           {allErrored ? (
             <XCircle size={11} style={{ color: "var(--danger)", flexShrink: 0 }} />
@@ -971,8 +976,9 @@ function ActionGroupView({
           ) : (
             <CheckCircle2 size={11} style={{ color: "var(--text-3)", flexShrink: 0 }} />
           )}
-        </span>
-      </div>
+          </>
+        }
+      />
       <div className={`action-group-body${expanded ? " action-group-body--expanded" : ""}`}>
         <div
           className="action-group-body-inner"
@@ -1092,31 +1098,17 @@ function ToolInputApprovalCard({
 
   return (
     <div>
-      <div
-        className="msg-block-header"
-        {...(hasAnswers ? {
-          role: "button" as const,
-          tabIndex: 0,
-          "aria-expanded": expanded,
-          onClick: toggleExpanded,
-          onKeyDown: (e: React.KeyboardEvent) => handleToggleKeyDown(e, toggleExpanded),
-        } : { style: { cursor: "default" } })}
-      >
-        {hasAnswers && (
-          <ChevronRight size={11} className={`msg-block-chevron${expanded ? " msg-block-chevron-open" : ""}`} />
-        )}
-        <span
-          className="msg-block-tile"
-          style={isPending ? { background: "var(--info-surface)", color: "var(--info)" } : undefined}
-        >
-          <MessageSquare size={11} />
-        </span>
-        <span className="msg-block-label">
-          {isPending
+      <MessageBlockHeader
+        icon={<MessageSquare size={11} />}
+        tileTone={isPending ? "info" : "neutral"}
+        expanded={expanded}
+        onToggle={hasAnswers ? toggleExpanded : undefined}
+        label={
+          isPending
             ? t("messageBlocks.approval.pendingQuestions", { count: questions.length })
-            : t("messageBlocks.approval.answeredQuestions", { count: questions.length })}
-        </span>
-      </div>
+            : t("messageBlocks.approval.answeredQuestions", { count: questions.length })
+        }
+      />
       {hasAnswers && expanded && (
         <div className="tool-input-qa-body">
           {questions.map((q) => {
@@ -1221,16 +1213,18 @@ function ApprovalCard({
   }, [block.approvalId]);
 
   let decisionLabel = t("messageBlocks.approval.decision.answered");
-  let decisionClass = "acard-decision--neutral";
+  let decisionStatusClass = "msg-block-status";
+  let DecisionIcon = CheckCircle2;
   if (block.decision === "decline") {
     decisionLabel = t("messageBlocks.approval.decision.denied");
-    decisionClass = "acard-decision--denied";
+    decisionStatusClass = "msg-block-status msg-block-status--danger";
+    DecisionIcon = XCircle;
   } else if (block.decision === "cancel") {
     decisionLabel = t("messageBlocks.approval.decision.canceled");
-    decisionClass = "acard-decision--denied";
+    DecisionIcon = XCircle;
   } else if (block.decision === "accept" || block.decision === "accept_for_session") {
     decisionLabel = t("messageBlocks.approval.decision.approved");
-    decisionClass = "acard-decision--approved";
+    decisionStatusClass = "msg-block-status msg-block-status--success";
   }
 
   if (isToolInputRequest && toolInputQuestions.length > 0 && !showClaudeUnsupportedApproval) {
@@ -1277,18 +1271,28 @@ function ApprovalCard({
   }
 
   return (
-    <div className="acard">
-      {/* Header */}
-      <div className="acard-header">
-        <Shield size={12} className="acard-header-icon" />
-        <span className="acard-summary">{block.summary}</span>
-        <span className="acard-type">{block.actionType}</span>
-        {!isPending && block.decision && (
-          <span className={`acard-decision ${decisionClass}`}>
-            {decisionLabel}
-          </span>
-        )}
-      </div>
+    <div className="msg-approval-block">
+      <MessageBlockHeader
+        icon={<Shield size={11} />}
+        label={block.summary}
+        tileTone="amber"
+        meta={
+          <>
+            <span>{block.actionType}</span>
+            {isPending ? (
+              <span className="msg-block-status msg-block-status--warning">
+                <Circle size={11} />
+                {t("messageBlocks.actionStatus.pending")}
+              </span>
+            ) : block.decision ? (
+              <span className={decisionStatusClass}>
+                <DecisionIcon size={11} />
+                {decisionLabel}
+              </span>
+            ) : null}
+          </>
+        }
+      />
 
       {/* Details — collapsed for resolved approvals */}
       {!isToolInputRequest && (command || displayReason || commandActionCount > 0 || requestedPermissions || mcpUrl || mcpSchema || hasRemainingDetails) && (isPending || !block.decision) && (

--- a/src/components/chat/ModelPicker.test.ts
+++ b/src/components/chat/ModelPicker.test.ts
@@ -5,6 +5,7 @@ import {
   filterOpenCodeModelsForQuery,
   formatCompactTokenLimit,
   formatOpenCodeProviderName,
+  getModelPickerSectionIds,
   getOpenCodeProviderId,
   groupOpenCodeModels,
   modelMetadataChips,
@@ -27,6 +28,32 @@ function makeModel(id: string, hidden = false): EngineModel {
 }
 
 describe("OpenCode model provider grouping", () => {
+  it("shows only runtime sections supported by the selected harness and model", () => {
+    const reasoningModel = {
+      ...makeModel("gpt-5"),
+      supportedReasoningEfforts: [
+        { reasoningEffort: "medium", description: "Balanced" },
+      ],
+    };
+
+    expect(getModelPickerSectionIds("codex", reasoningModel)).toEqual([
+      "harness",
+      "model",
+      "reasoning",
+      "speed",
+    ]);
+    expect(getModelPickerSectionIds("opencode", reasoningModel)).toEqual([
+      "harness",
+      "provider",
+      "model",
+      "reasoning",
+    ]);
+    expect(getModelPickerSectionIds("claude", makeModel("claude"))).toEqual([
+      "harness",
+      "model",
+    ]);
+  });
+
   it("uses compact labels when a model exposes five or more effort levels", () => {
     expect(shouldUseCompactEffortLabels(4)).toBe(false);
     expect(shouldUseCompactEffortLabels(5)).toBe(true);

--- a/src/components/chat/ModelPicker.tsx
+++ b/src/components/chat/ModelPicker.tsx
@@ -689,7 +689,6 @@ export function ModelPicker({
             {browsingEngine?.id !== "opencode" ? (
               <div className="mp-models-header">
                 <span className="mp-models-title">{t("modelPicker.models")}</span>
-                <span className="mp-models-count">{activeModels.length}</span>
               </div>
             ) : null}
 

--- a/src/components/chat/ModelPicker.tsx
+++ b/src/components/chat/ModelPicker.tsx
@@ -9,14 +9,14 @@ import {
   Image as ImageIcon,
   Paperclip,
   Search,
+  Zap,
 } from "lucide-react";
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { useEngineStore } from "../../stores/engineStore";
 import { getHarnessIcon } from "../shared/HarnessLogos";
 import type { EngineHealth, EngineInfo, EngineModel } from "../../types";
-
-/* ── Props ── */
+import type { CodexServiceTierValue } from "./CodexConfigPicker";
 
 interface ModelPickerProps {
   engines: EngineInfo[];
@@ -24,12 +24,12 @@ interface ModelPickerProps {
   selectedEngineId: string;
   selectedModelId: string | null;
   selectedEffort: string;
+  selectedServiceTier: CodexServiceTierValue;
   onEngineModelChange: (engineId: string, modelId: string) => void;
   onEffortChange: (effort: string) => void;
+  onServiceTierChange: (serviceTier: CodexServiceTierValue) => void;
   disabled?: boolean;
 }
-
-/* ── Helpers ── */
 
 export interface OpenCodeProviderModelGroup {
   providerId: string;
@@ -38,6 +38,13 @@ export interface OpenCodeProviderModelGroup {
   legacyModels: EngineModel[];
   totalModelCount: number;
 }
+
+export type ModelPickerSectionId =
+  | "harness"
+  | "provider"
+  | "model"
+  | "reasoning"
+  | "speed";
 
 const PROVIDER_LABELS: Record<string, string> = {
   anthropic: "Anthropic",
@@ -85,12 +92,12 @@ function formatModelName(name: string): string {
       part
         .split(/[-_\s]+/)
         .filter(Boolean)
-        .map((s) => {
-          const lower = s.toLowerCase();
+        .map((segment) => {
+          const lower = segment.toLowerCase();
           if (tokens[lower]) return tokens[lower];
-          if (/^\d+(\.\d+)*$/.test(s)) return s;
-          if (/^[a-z]?\d+(\.\d+)*$/i.test(s)) return s.toUpperCase();
-          return s.charAt(0).toUpperCase() + s.slice(1);
+          if (/^\d+(\.\d+)*$/.test(segment)) return segment;
+          if (/^[a-z]?\d+(\.\d+)*$/i.test(segment)) return segment.toUpperCase();
+          return segment.charAt(0).toUpperCase() + segment.slice(1);
         })
         .join(" "),
     )
@@ -273,7 +280,6 @@ function shouldShowModelDescription(engineId: string, model: EngineModel): boole
   if (!model.description) {
     return false;
   }
-
   return !(engineId === "opencode" && model.description.trim() === "OpenCode model");
 }
 
@@ -307,7 +313,23 @@ export function shouldUseCompactEffortLabels(effortCount: number): boolean {
   return effortCount >= 5;
 }
 
-/* ── Component ── */
+export function getModelPickerSectionIds(
+  engineId: string,
+  model: EngineModel | null,
+): ModelPickerSectionId[] {
+  const sections: ModelPickerSectionId[] = ["harness"];
+  if (engineId === "opencode") {
+    sections.push("provider");
+  }
+  sections.push("model");
+  if ((model?.supportedReasoningEfforts?.length ?? 0) > 0) {
+    sections.push("reasoning");
+  }
+  if (engineId === "codex") {
+    sections.push("speed");
+  }
+  return sections;
+}
 
 export function ModelPicker({
   engines,
@@ -315,14 +337,15 @@ export function ModelPicker({
   selectedEngineId,
   selectedModelId,
   selectedEffort,
+  selectedServiceTier,
   onEngineModelChange,
   onEffortChange,
+  onServiceTierChange,
   disabled = false,
 }: ModelPickerProps) {
   const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
-  const [activeEngineId, setActiveEngineId] = useState(selectedEngineId);
-  const [activeOpenCodeProviderId, setActiveOpenCodeProviderId] = useState<string | null>(null);
+  const [activeSection, setActiveSection] = useState<ModelPickerSectionId>("model");
   const [openCodeModelQuery, setOpenCodeModelQuery] = useState("");
   const [legacyExpanded, setLegacyExpanded] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -330,16 +353,6 @@ export function ModelPicker({
   const wasOpenRef = useRef(false);
   const [pos, setPos] = useState({ bottom: 0, left: 0 });
   const ensureEngineHealth = useEngineStore((state) => state.ensureHealth);
-
-  // Sync active engine when selection changes externally
-  useEffect(() => {
-    setActiveEngineId(selectedEngineId);
-  }, [selectedEngineId]);
-
-  // Reset legacy expanded when engine changes
-  useEffect(() => {
-    setLegacyExpanded(false);
-  }, [activeEngineId]);
 
   useEffect(() => {
     if (!open) {
@@ -363,24 +376,22 @@ export function ModelPicker({
     }
   }, [engines, ensureEngineHealth, health, open]);
 
-  // Position popover above trigger
   useLayoutEffect(() => {
     if (!open || !triggerRef.current) return;
     const rect = triggerRef.current.getBoundingClientRect();
-    const popoverWidth = activeEngineId === "opencode" ? 680 : 440;
+    const popoverWidth = Math.min(620, window.innerWidth - 16);
     const left = Math.max(8, Math.min(rect.left, window.innerWidth - popoverWidth - 8));
     setPos({
       bottom: window.innerHeight - rect.top + 6,
       left,
     });
-  }, [activeEngineId, open]);
+  }, [open]);
 
-  // Click outside + Escape
   useEffect(() => {
     if (!open) return;
 
-    function onPointerDown(e: PointerEvent) {
-      const target = e.target as Node;
+    function onPointerDown(event: PointerEvent) {
+      const target = event.target as Node;
       if (
         triggerRef.current?.contains(target) ||
         popoverRef.current?.contains(target)
@@ -390,8 +401,10 @@ export function ModelPicker({
       setOpen(false);
     }
 
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
     }
 
     document.addEventListener("pointerdown", onPointerDown, true);
@@ -404,144 +417,97 @@ export function ModelPicker({
 
   const toggle = useCallback(() => {
     if (disabled) return;
-    setOpen((prev) => !prev);
+    setOpen((previous) => !previous);
   }, [disabled]);
 
-  // Resolve current selection for trigger label
-  const currentEngine = engines.find((e) => e.id === selectedEngineId) ?? engines[0];
+  const currentEngine = engines.find((engine) => engine.id === selectedEngineId) ?? engines[0];
   const currentModel =
-    currentEngine?.models.find((m) => m.id === selectedModelId) ??
-    currentEngine?.models.find((m) => !m.hidden) ??
+    currentEngine?.models.find((model) => model.id === selectedModelId) ??
+    currentEngine?.models.find((model) => model.isDefault && !model.hidden) ??
+    currentEngine?.models.find((model) => !model.hidden) ??
     null;
-
-  // Active engine in popover (for browsing)
-  const browsingEngine = engines.find((e) => e.id === activeEngineId) ?? engines[0];
-  const browsingModels = browsingEngine?.models ?? [];
-  const activeModels = browsingModels.filter((m) => !m.hidden);
-  const legacyModels = browsingModels.filter((m) => m.hidden);
+  const currentModels = currentEngine?.models ?? [];
+  const currentEfforts = currentModel?.supportedReasoningEfforts ?? [];
   const openCodeProviderGroups = useMemo(
-    () => groupOpenCodeModels(browsingModels),
-    [browsingModels],
+    () => groupOpenCodeModels(currentModels),
+    [currentModels],
   );
-  const selectedOpenCodeProviderId =
-    selectedEngineId === "opencode" && selectedModelId
-      ? getOpenCodeProviderId(selectedModelId)
+  const currentOpenCodeProviderId =
+    selectedEngineId === "opencode" && currentModel
+      ? getOpenCodeProviderId(currentModel.id)
       : null;
-  const activeOpenCodeProvider =
-    openCodeProviderGroups.find((group) => group.providerId === activeOpenCodeProviderId) ??
-    openCodeProviderGroups.find((group) => group.providerId === selectedOpenCodeProviderId) ??
+  const currentOpenCodeProvider =
+    openCodeProviderGroups.find((group) => group.providerId === currentOpenCodeProviderId) ??
     openCodeProviderGroups[0] ??
     null;
+  const sectionIds = getModelPickerSectionIds(selectedEngineId, currentModel);
 
   useEffect(() => {
-    if (activeEngineId !== "opencode") {
-      setActiveOpenCodeProviderId(null);
-      setOpenCodeModelQuery("");
-      return;
+    if (!sectionIds.includes(activeSection)) {
+      setActiveSection("model");
     }
+  }, [activeSection, sectionIds]);
 
-    setActiveOpenCodeProviderId((current) => {
-      if (current && openCodeProviderGroups.some((group) => group.providerId === current)) {
-        return current;
-      }
-      return selectedOpenCodeProviderId ?? openCodeProviderGroups[0]?.providerId ?? null;
-    });
-  }, [activeEngineId, openCodeProviderGroups, selectedOpenCodeProviderId]);
+  useEffect(() => {
+    setLegacyExpanded(false);
+    if (selectedEngineId !== "opencode") {
+      setOpenCodeModelQuery("");
+    }
+  }, [selectedEngineId, selectedModelId]);
 
-  function handleModelSelect(engineId: string, modelId: string) {
-    onEngineModelChange(engineId, modelId);
-    // Keep popover open so the user can adjust reasoning effort
-  }
-
-  function renderFlatModelList() {
+  function defaultModelForEngine(engine: EngineInfo): EngineModel | null {
     return (
-      <div className="mp-models-list">
-        {activeModels.map((model) => (
-          <ModelRow
-            key={model.id}
-            model={model}
-            engineId={activeEngineId}
-            isSelected={
-              selectedEngineId === activeEngineId &&
-              model.id === (selectedModelId ?? currentModel?.id)
-            }
-            selectedEffort={selectedEffort}
-            onSelect={handleModelSelect}
-            onEffortChange={onEffortChange}
-          />
-        ))}
-
-        {legacyModels.length > 0 && (
-          <>
-            <button
-              type="button"
-              className="mp-legacy-toggle"
-              onClick={() => setLegacyExpanded((prev) => !prev)}
-            >
-              <span className="mp-legacy-toggle-label">
-                {t("modelPicker.legacy", { count: legacyModels.length })}
-              </span>
-              <ChevronRight
-                size={11}
-                className={`mp-legacy-chevron${legacyExpanded ? " mp-legacy-chevron-open" : ""}`}
-              />
-            </button>
-            {legacyExpanded &&
-              legacyModels.map((model) => (
-                <ModelRow
-                  key={model.id}
-                  model={model}
-                  engineId={activeEngineId}
-                  isSelected={
-                    selectedEngineId === activeEngineId &&
-                    model.id === (selectedModelId ?? currentModel?.id)
-                  }
-                  selectedEffort={selectedEffort}
-                  onSelect={handleModelSelect}
-                  onEffortChange={onEffortChange}
-                />
-              ))}
-          </>
-        )}
-      </div>
+      engine.models.find((model) => !model.hidden && model.isDefault) ??
+      engine.models.find((model) => !model.hidden) ??
+      engine.models[0] ??
+      null
     );
   }
 
-  function renderOpenCodeProviderTree() {
-    const provider = activeOpenCodeProvider;
-    const providerActiveModels = provider
-      ? filterOpenCodeModelsForQuery(provider.activeModels, openCodeModelQuery)
-      : [];
-    const providerLegacyModels = provider
-      ? filterOpenCodeModelsForQuery(provider.legacyModels, openCodeModelQuery)
-      : [];
-    const providerVisibleCount = providerActiveModels.length + providerLegacyModels.length;
-    return (
-      <div className="mp-provider-tree">
-        <div className="mp-provider-list">
-          <div className="mp-provider-list-heading">{t("modelPicker.providers")}</div>
-          {openCodeProviderGroups.map((group) => {
-            const isActive = group.providerId === provider?.providerId;
-            const isSelected = group.providerId === selectedOpenCodeProviderId;
-            return (
-              <button
-                key={group.providerId}
-                type="button"
-                className={`mp-provider-row${isActive ? " mp-provider-row-active" : ""}${isSelected ? " mp-provider-row-selected" : ""}`}
-                onClick={() => {
-                  setLegacyExpanded(false);
-                  setActiveOpenCodeProviderId(group.providerId);
-                }}
-              >
-                <span className="mp-provider-name">{group.providerLabel}</span>
-                <span className="mp-provider-count">{group.totalModelCount}</span>
-                <ChevronRight size={12} className="mp-provider-chevron" />
-              </button>
-            );
-          })}
-        </div>
+  function handleHarnessSelect(engine: EngineInfo) {
+    if (engine.id === selectedEngineId) {
+      return;
+    }
+    const nextModel = defaultModelForEngine(engine);
+    if (!nextModel) {
+      return;
+    }
+    onEngineModelChange(engine.id, nextModel.id);
+    setActiveSection(engine.id === "opencode" ? "provider" : "model");
+  }
 
-        <div className="mp-provider-models">
+  function handleProviderSelect(group: OpenCodeProviderModelGroup) {
+    const nextModel =
+      group.activeModels.find((model) => model.isDefault) ??
+      group.activeModels[0] ??
+      group.legacyModels[0] ??
+      null;
+    if (!nextModel) {
+      return;
+    }
+    onEngineModelChange("opencode", nextModel.id);
+    setOpenCodeModelQuery("");
+  }
+
+  function handleModelSelect(engineId: string, modelId: string) {
+    onEngineModelChange(engineId, modelId);
+  }
+
+  function renderModelOptions() {
+    const activeModels = selectedEngineId === "opencode"
+      ? currentOpenCodeProvider?.activeModels ?? []
+      : currentModels.filter((model) => !model.hidden);
+    const legacyModels = selectedEngineId === "opencode"
+      ? currentOpenCodeProvider?.legacyModels ?? []
+      : currentModels.filter((model) => model.hidden);
+    const filteredActiveModels = filterOpenCodeModelsForQuery(activeModels, openCodeModelQuery);
+    const filteredLegacyModels = filterOpenCodeModelsForQuery(legacyModels, openCodeModelQuery);
+    const visibleCount = filteredActiveModels.length + filteredLegacyModels.length;
+    const totalCount = activeModels.length + legacyModels.length;
+
+    return (
+      <>
+        {selectedEngineId === "opencode" ? (
           <div className="mp-model-search">
             <Search size={12} className="mp-model-search-icon" />
             <input
@@ -551,78 +517,208 @@ export function ModelPicker({
               placeholder={t("modelPicker.searchModels")}
               aria-label={t("modelPicker.searchModels")}
             />
-            {provider ? (
-              <span className="mp-model-search-count">
-                {openCodeModelQuery.trim()
-                  ? `${providerVisibleCount}/${provider.totalModelCount}`
-                  : provider.totalModelCount}
-              </span>
-            ) : null}
+            <span className="mp-model-search-count">
+              {openCodeModelQuery.trim() ? `${visibleCount}/${totalCount}` : totalCount}
+            </span>
           </div>
+        ) : null}
 
-          <div className="mp-models-list mp-models-list-provider">
-            {providerActiveModels.map((model) => (
-              <ModelRow
-                key={model.id}
-                model={model}
-                engineId={activeEngineId}
-                isSelected={
-                  selectedEngineId === activeEngineId &&
-                  model.id === (selectedModelId ?? currentModel?.id)
-                }
-                selectedEffort={selectedEffort}
-                onSelect={handleModelSelect}
-                onEffortChange={onEffortChange}
-              />
-            ))}
+        <div className="mp-models-list">
+          {filteredActiveModels.map((model) => (
+            <ModelRow
+              key={model.id}
+              model={model}
+              engineId={selectedEngineId}
+              isSelected={model.id === (selectedModelId ?? currentModel?.id)}
+              onSelect={handleModelSelect}
+            />
+          ))}
 
-            {provider && providerLegacyModels.length > 0 && (
-              <>
-                <button
-                  type="button"
-                  className="mp-legacy-toggle"
-                  onClick={() => setLegacyExpanded((prev) => !prev)}
-                >
-                  <span className="mp-legacy-toggle-label">
-                    {t("modelPicker.legacy", { count: providerLegacyModels.length })}
-                  </span>
-                  <ChevronRight
-                    size={11}
-                    className={`mp-legacy-chevron${legacyExpanded ? " mp-legacy-chevron-open" : ""}`}
-                  />
-                </button>
-                {legacyExpanded &&
-                  providerLegacyModels.map((model) => (
+          {filteredLegacyModels.length > 0 ? (
+            <>
+              <button
+                type="button"
+                className="mp-legacy-toggle"
+                onClick={() => setLegacyExpanded((previous) => !previous)}
+                aria-expanded={legacyExpanded}
+              >
+                <span className="mp-legacy-toggle-label">
+                  {t("modelPicker.legacy", { count: filteredLegacyModels.length })}
+                </span>
+                <ChevronRight
+                  size={11}
+                  className={`mp-legacy-chevron${legacyExpanded ? " mp-legacy-chevron-open" : ""}`}
+                />
+              </button>
+              {legacyExpanded
+                ? filteredLegacyModels.map((model) => (
                     <ModelRow
                       key={model.id}
                       model={model}
-                      engineId={activeEngineId}
-                      isSelected={
-                        selectedEngineId === activeEngineId &&
-                        model.id === (selectedModelId ?? currentModel?.id)
-                      }
-                      selectedEffort={selectedEffort}
+                      engineId={selectedEngineId}
+                      isSelected={model.id === (selectedModelId ?? currentModel?.id)}
                       onSelect={handleModelSelect}
-                      onEffortChange={onEffortChange}
                     />
-                  ))}
-              </>
-            )}
-            {provider && providerVisibleCount === 0 ? (
-              <div className="mp-empty">{t("modelPicker.noModels")}</div>
-            ) : null}
-          </div>
+                  ))
+                : null}
+            </>
+          ) : null}
+
+          {visibleCount === 0 ? (
+            <div className="mp-empty">{t("modelPicker.noModels")}</div>
+          ) : null}
         </div>
-      </div>
+      </>
     );
   }
 
-  // Build trigger label
+  function renderPanelContent() {
+    switch (activeSection) {
+      case "harness":
+        return (
+          <div className="mp-options">
+            {engines.map((engine) => {
+              const selected = engine.id === selectedEngineId;
+              const available = health[engine.id]?.available !== false;
+              return (
+                <button
+                  key={engine.id}
+                  type="button"
+                  className={`mp-option${selected ? " mp-option-selected" : ""}`}
+                  onClick={() => handleHarnessSelect(engine)}
+                  aria-pressed={selected}
+                >
+                  <span className="mp-option-icon">{getHarnessIcon(engine.id, 16)}</span>
+                  <span className="mp-option-label">{engine.name}</span>
+                  <span
+                    className={`mp-health-dot${available ? " mp-health-dot-ok" : " mp-health-dot-error"}`}
+                    title={available ? t("modelPicker.available") : t("modelPicker.unavailable")}
+                  />
+                  {selected ? <Check size={13} className="mp-option-check" /> : null}
+                </button>
+              );
+            })}
+          </div>
+        );
+      case "provider":
+        return (
+          <div className="mp-options">
+            {openCodeProviderGroups.map((group) => {
+              const selected = group.providerId === currentOpenCodeProvider?.providerId;
+              return (
+                <button
+                  key={group.providerId}
+                  type="button"
+                  className={`mp-option${selected ? " mp-option-selected" : ""}`}
+                  onClick={() => handleProviderSelect(group)}
+                  aria-pressed={selected}
+                >
+                  <span className="mp-option-label">{group.providerLabel}</span>
+                  <span className="mp-option-count">{group.totalModelCount}</span>
+                  {selected ? <Check size={13} className="mp-option-check" /> : null}
+                </button>
+              );
+            })}
+          </div>
+        );
+      case "model":
+        return renderModelOptions();
+      case "reasoning":
+        return (
+          <div className="mp-options">
+            {currentEfforts.map((option) => {
+              const selected = option.reasoningEffort === selectedEffort;
+              return (
+                <button
+                  key={option.reasoningEffort}
+                  type="button"
+                  className={`mp-option mp-option-with-description${selected ? " mp-option-selected" : ""}`}
+                  onClick={() => onEffortChange(option.reasoningEffort)}
+                  aria-pressed={selected}
+                >
+                  <span className="mp-option-copy">
+                    <span className="mp-option-label">
+                      {effortDisplayLabel(t, option.reasoningEffort)}
+                    </span>
+                    {option.description ? (
+                      <span className="mp-option-description">{option.description}</span>
+                    ) : null}
+                  </span>
+                  {selected ? <Check size={13} className="mp-option-check" /> : null}
+                </button>
+              );
+            })}
+          </div>
+        );
+      case "speed": {
+        const options: Array<{
+          value: CodexServiceTierValue;
+          label: string;
+          description: string;
+        }> = [
+          {
+            value: "inherit",
+            label: t("modelPicker.speedOptions.standard.label"),
+            description: t("modelPicker.speedOptions.standard.description"),
+          },
+          {
+            value: "fast",
+            label: t("modelPicker.speedOptions.fast.label"),
+            description: t("modelPicker.speedOptions.fast.description"),
+          },
+          {
+            value: "flex",
+            label: t("modelPicker.speedOptions.flex.label"),
+            description: t("modelPicker.speedOptions.flex.description"),
+          },
+        ];
+        return (
+          <div className="mp-options">
+            {options.map((option) => {
+              const selected = option.value === selectedServiceTier;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`mp-option mp-option-with-description${selected ? " mp-option-selected" : ""}`}
+                  onClick={() => onServiceTierChange(option.value)}
+                  aria-pressed={selected}
+                >
+                  <span className="mp-option-copy">
+                    <span className="mp-option-label">{option.label}</span>
+                    <span className="mp-option-description">{option.description}</span>
+                  </span>
+                  {selected ? <Check size={13} className="mp-option-check" /> : null}
+                </button>
+              );
+            })}
+          </div>
+        );
+      }
+    }
+  }
+
+  const sectionLabels: Record<ModelPickerSectionId, string> = {
+    harness: t("modelPicker.harness"),
+    provider: t("modelPicker.provider"),
+    model: t("modelPicker.model"),
+    reasoning: t("modelPicker.reasoning"),
+    speed: t("modelPicker.speed"),
+  };
+  const speedLabel = selectedServiceTier === "inherit"
+    ? t("modelPicker.speedOptions.standard.label")
+    : t(`modelPicker.speedOptions.${selectedServiceTier}.label`);
+  const sectionValues: Record<ModelPickerSectionId, string> = {
+    harness: currentEngine?.name ?? "",
+    provider: currentOpenCodeProvider?.providerLabel ?? "",
+    model: currentModel ? formatModelName(currentModel.displayName) : "",
+    reasoning: selectedEffort ? effortDisplayLabel(t, selectedEffort) : "",
+    speed: speedLabel,
+  };
   const triggerLabel = currentModel
     ? formatModelName(currentModel.displayName)
     : currentEngine?.name ?? t("modelPicker.selectModel");
 
-  /* ── Trigger ── */
   const trigger = (
     <button
       ref={triggerRef}
@@ -631,13 +727,21 @@ export function ModelPicker({
       onClick={toggle}
       disabled={disabled}
       title={t("modelPicker.selectModel")}
+      aria-expanded={open}
+      aria-haspopup="dialog"
     >
       <span className="mp-trigger-icon">
         {getHarnessIcon(selectedEngineId, 12)}
       </span>
       <span className="mp-trigger-label">{triggerLabel}</span>
-      {selectedEffort && currentModel?.supportedReasoningEfforts?.length ? (
+      {selectedEffort && currentEfforts.length > 0 ? (
         <span className="mp-trigger-effort">{shortEffortLabel(t, selectedEffort)}</span>
+      ) : null}
+      {selectedEngineId === "codex" && selectedServiceTier !== "inherit" ? (
+        <span className="mp-trigger-speed">
+          <Zap size={9} />
+          {speedLabel}
+        </span>
       ) : null}
       <ChevronDown
         size={10}
@@ -646,55 +750,45 @@ export function ModelPicker({
     </button>
   );
 
-  /* ── Popover ── */
   const popover = open
     ? createPortal(
         <div
           ref={popoverRef}
-          className={`mp-popover${browsingEngine?.id === "opencode" ? " mp-popover-opencode" : ""}`}
+          className="mp-popover"
           style={{
             position: "fixed",
             bottom: pos.bottom,
             left: pos.left,
           }}
+          role="dialog"
+          aria-label={t("modelPicker.runtimeConfiguration")}
         >
-          {/* Engine rail */}
-          <div className="mp-rail">
-            <div className="mp-rail-label">{t("modelPicker.engine")}</div>
-            {engines.map((engine) => {
-              const isActive = engine.id === activeEngineId;
-              const engineHealth = health[engine.id];
-              const available = engineHealth?.available !== false;
-              return (
-                <button
-                  key={engine.id}
-                  type="button"
-                  className={`mp-rail-engine${isActive ? " mp-rail-engine-active" : ""}`}
-                  onClick={() => setActiveEngineId(engine.id)}
-                >
-                  <span className="mp-rail-engine-icon">
-                    {getHarnessIcon(engine.id, 15)}
-                  </span>
-                  <span className="mp-rail-engine-name">{engine.name}</span>
-                  <span
-                    className={`mp-rail-dot${available ? " mp-rail-dot-ok" : " mp-rail-dot-err"}`}
-                  />
-                </button>
-              );
-            })}
+          <div className="mp-runtime-menu">
+            {sectionIds.map((sectionId) => (
+              <button
+                key={sectionId}
+                type="button"
+                className={`mp-runtime-row${activeSection === sectionId ? " mp-runtime-row-active" : ""}`}
+                onClick={() => setActiveSection(sectionId)}
+                onPointerEnter={() => setActiveSection(sectionId)}
+                aria-pressed={activeSection === sectionId}
+              >
+                <span className="mp-runtime-row-label">{sectionLabels[sectionId]}</span>
+                <span className="mp-runtime-row-value">
+                  {sectionId === "harness" ? (
+                    <span className="mp-runtime-row-harness-icon">
+                      {getHarnessIcon(selectedEngineId, 12)}
+                    </span>
+                  ) : null}
+                  <span>{sectionValues[sectionId]}</span>
+                </span>
+                <ChevronRight size={12} className="mp-runtime-row-chevron" />
+              </button>
+            ))}
           </div>
 
-          {/* Models panel */}
-          <div className="mp-models">
-            {browsingEngine?.id !== "opencode" ? (
-              <div className="mp-models-header">
-                <span className="mp-models-title">{t("modelPicker.models")}</span>
-              </div>
-            ) : null}
-
-            {browsingEngine?.id === "opencode"
-              ? renderOpenCodeProviderTree()
-              : renderFlatModelList()}
+          <div className="mp-runtime-panel">
+            <div className="mp-runtime-panel-content">{renderPanelContent()}</div>
           </div>
         </div>,
         document.body,
@@ -709,94 +803,41 @@ export function ModelPicker({
   );
 }
 
-/* ── Model Row ── */
-
 function ModelRow({
   model,
   engineId,
   isSelected,
-  selectedEffort,
   onSelect,
-  onEffortChange,
 }: {
   model: EngineModel;
   engineId: string;
   isSelected: boolean;
-  selectedEffort: string;
   onSelect: (engineId: string, modelId: string) => void;
-  onEffortChange: (effort: string) => void;
 }) {
   const { t } = useTranslation("chat");
-  const efforts = model.supportedReasoningEfforts ?? [];
-  const showControls = efforts.length > 0;
-  const useCompactEffortLabels = shouldUseCompactEffortLabels(efforts.length);
   const metadataChips = modelMetadataChips(t, model);
-  const showMetadataChips = isSelected;
   const showDescription = shouldShowModelDescription(engineId, model);
-  const modelClassName = [
-    "mp-model",
-    isSelected ? "mp-model-selected" : "",
-  ]
-    .filter(Boolean)
-    .join(" ");
 
   return (
-    <div className={modelClassName}>
-      <button
-        type="button"
-        className="mp-model-btn"
-        onClick={() => onSelect(engineId, model.id)}
-      >
-        <div className="mp-model-info">
-          <div className="mp-model-name-row">
-            <span className="mp-model-name">
-              {formatModelName(model.displayName)}
-            </span>
-            {model.isDefault && (
-              <span className="mp-model-default">{t("modelPicker.default")}</span>
-            )}
-            {showMetadataChips && !showControls && metadataChips.length > 0 ? (
-              <ModelMetadata chips={metadataChips} />
-            ) : null}
-          </div>
-          {showDescription && (
-            <span className="mp-model-desc">{model.description}</span>
-          )}
-        </div>
-        {isSelected && (
-          <Check size={13} className="mp-model-check" />
-        )}
-      </button>
-
-      {isSelected && showControls && (
-        <div className="mp-model-controls">
-          <div className="mp-model-controls-header">
-            <span className="mp-model-controls-label">{t("modelPicker.thinking")}</span>
-            {metadataChips.length > 0 ? <ModelMetadata chips={metadataChips} /> : null}
-          </div>
-          <div className="mp-model-option-pills">
-            {efforts.map((opt) => {
-              const active = opt.reasoningEffort === selectedEffort;
-              const fullLabel = effortDisplayLabel(t, opt.reasoningEffort);
-              return (
-                <button
-                  key={opt.reasoningEffort}
-                  type="button"
-                  className={`mp-model-option-pill${active ? " mp-model-option-pill-active" : ""}`}
-                  onClick={() => onEffortChange(opt.reasoningEffort)}
-                  aria-label={fullLabel}
-                  aria-pressed={active}
-                  title={`${fullLabel}: ${opt.description}`}
-                >
-                  {useCompactEffortLabels
-                    ? shortEffortLabel(t, opt.reasoningEffort)
-                    : fullLabel}
-                </button>
-                );
-              })}
-          </div>
-        </div>
-      )}
-    </div>
+    <button
+      type="button"
+      className={`mp-model${isSelected ? " mp-model-selected" : ""}`}
+      onClick={() => onSelect(engineId, model.id)}
+      aria-pressed={isSelected}
+    >
+      <span className="mp-model-info">
+        <span className="mp-model-name-row">
+          <span className="mp-model-name">{formatModelName(model.displayName)}</span>
+          {model.isDefault ? (
+            <span className="mp-model-default">{t("modelPicker.default")}</span>
+          ) : null}
+        </span>
+        {showDescription ? <span className="mp-model-desc">{model.description}</span> : null}
+        {isSelected && metadataChips.length > 0 ? (
+          <ModelMetadata chips={metadataChips} />
+        ) : null}
+      </span>
+      {isSelected ? <Check size={13} className="mp-model-check" /> : null}
+    </button>
   );
 }

--- a/src/components/chat/PermissionPicker.tsx
+++ b/src/components/chat/PermissionPicker.tsx
@@ -365,8 +365,9 @@ export function PermissionPicker({
         <span className="pp-trigger-icon">
           <Shield size={12} />
         </span>
-        <span className="pp-trigger-label">{t("permissionPicker.title")}</span>
-        {trustOption ? <span className="pp-trigger-pill">{trustOption.label}</span> : null}
+        <span className="pp-trigger-label">
+          {trustOption ? trustOption.label : t("permissionPicker.title")}
+        </span>
         {customPolicyCount > 0 ? (
           <span className="pp-trigger-pill pp-trigger-pill-accent">{t("permissionPicker.custom")}</span>
         ) : null}

--- a/src/components/chat/PermissionPicker.tsx
+++ b/src/components/chat/PermissionPicker.tsx
@@ -1,8 +1,23 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { Check, ChevronDown, Monitor, Shield, SquareTerminal } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  Eye,
+  FolderOpen,
+  Monitor,
+  Shield,
+  SquareTerminal,
+  Zap,
+} from "lucide-react";
 import { useTranslation } from "react-i18next";
-import type { TrustLevel } from "../../types";
+import {
+  autonomyPresetPatch,
+  availableAutonomyPresets,
+} from "../../lib/autonomyPresets";
+import type { AutonomyPresetId } from "../../lib/autonomyPresets";
+import type { ChatEngineId, TrustLevel } from "../../types";
 
 type PermissionOption<T extends string = string> = {
   value: T;
@@ -29,6 +44,11 @@ interface PermissionPickerProps {
   trustOptions?: PermissionOption<TrustLevel>[];
   onTrustChange?: (value: TrustLevel) => void;
   customPolicyCount?: number;
+  engineId?: ChatEngineId;
+  presetValue?: AutonomyPresetId | null;
+  onPresetChange?: (preset: AutonomyPresetId) => void;
+  defaultPreset?: AutonomyPresetId | null;
+  onDefaultPresetChange?: (preset: AutonomyPresetId | null) => void;
   approvalTitle?: string;
   approvalValue?: string;
   approvalSelectedLabel?: string | null;
@@ -45,6 +65,28 @@ interface PermissionPickerProps {
   networkDisabled?: boolean;
   networkNotice?: string | null;
 }
+
+const ENGINE_DISPLAY_NAMES: Record<ChatEngineId, string> = {
+  codex: "Codex",
+  claude: "Claude",
+  opencode: "OpenCode",
+};
+
+const PRESET_ICONS: Record<AutonomyPresetId, ReactNode> = {
+  inherit: <Shield size={13} />,
+  "read-only": <Eye size={13} />,
+  ask: <Shield size={13} />,
+  auto: <FolderOpen size={13} />,
+  full: <Zap size={13} />,
+};
+
+const PRESET_TRIGGER_ICONS: Record<AutonomyPresetId, ReactNode> = {
+  inherit: <Shield size={12} />,
+  "read-only": <Eye size={12} />,
+  ask: <Shield size={12} />,
+  auto: <FolderOpen size={12} />,
+  full: <Zap size={12} />,
+};
 
 function findOption<T extends string>(
   options: PermissionOption<T>[] | undefined,
@@ -63,6 +105,11 @@ export function PermissionPicker({
   trustOptions,
   onTrustChange,
   customPolicyCount = 0,
+  engineId,
+  presetValue,
+  onPresetChange,
+  defaultPreset,
+  onDefaultPresetChange,
   approvalTitle,
   approvalValue,
   approvalSelectedLabel,
@@ -82,6 +129,11 @@ export function PermissionPicker({
   const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
   const [activeSection, setActiveSection] = useState<string>("");
+  const presetsAvailable =
+    engineId !== undefined && presetValue !== undefined && onPresetChange !== undefined;
+  const [view, setView] = useState<"presets" | "advanced">(
+    presetsAvailable ? "presets" : "advanced",
+  );
   const triggerRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState({ bottom: 0, left: 0 });
@@ -183,8 +235,9 @@ export function PermissionPicker({
       }
     } else {
       setActiveSection("");
+      setView(presetsAvailable ? "presets" : "advanced");
     }
-  }, [activeSection, open, railItems]);
+  }, [activeSection, open, presetsAvailable, railItems]);
 
   const summaryLines = useMemo(() => {
     const lines: string[] = [];
@@ -241,7 +294,7 @@ export function PermissionPicker({
       bottom: window.innerHeight - rect.top + 6,
       left,
     });
-  }, [open]);
+  }, [open, view]);
 
   useEffect(() => {
     if (!open) {
@@ -281,76 +334,250 @@ export function PermissionPicker({
     setOpen((prev) => !prev);
   }, [disabled]);
 
+  const presetLabel = useCallback(
+    (preset: AutonomyPresetId) => t(`autonomy.presets.${preset}.label`),
+    [t],
+  );
+
+  const mappingRows = useMemo(() => {
+    if (!presetsAvailable || !engineId) {
+      return [];
+    }
+    const patch = autonomyPresetPatch(presetValue ?? "inherit", engineId);
+    const rows: Array<{ key: string; label: string; hot: boolean }> = [
+      {
+        key: resolvedApprovalTitle,
+        label:
+          findOption(approvalOptions, patch.approvalPolicy)?.label ?? patch.approvalPolicy,
+        hot: presetValue === "full",
+      },
+    ];
+    if (patch.sandboxMode !== undefined) {
+      rows.push({
+        key: t("permissionPicker.sandbox"),
+        label: findOption(sandboxOptions, patch.sandboxMode)?.label ?? patch.sandboxMode,
+        hot: presetValue === "full" && patch.sandboxMode === "danger-full-access",
+      });
+    }
+    if (patch.networkPolicy !== undefined) {
+      rows.push({
+        key: t("permissionPicker.network"),
+        label:
+          findOption(networkOptions, patch.networkPolicy)?.label ?? patch.networkPolicy,
+        hot: presetValue === "full" && patch.networkPolicy === "enabled",
+      });
+    }
+    return rows;
+  }, [
+    approvalOptions,
+    engineId,
+    networkOptions,
+    presetValue,
+    presetsAvailable,
+    resolvedApprovalTitle,
+    sandboxOptions,
+    t,
+  ]);
+
+  const mappingNote = useMemo(() => {
+    if (!presetsAvailable || !engineId) {
+      return null;
+    }
+    if (engineId === "opencode") {
+      return t("autonomy.openCodeNote");
+    }
+    if (engineId === "claude" && presetValue === "full") {
+      return t("autonomy.claudeFullNote");
+    }
+    return null;
+  }, [engineId, presetValue, presetsAvailable, t]);
+
   const title = summaryLines.length > 0 ? summaryLines.join(" | ") : t("permissionPicker.title");
   const activeItem = railItems.find((item) => item.id === activeSection) ?? null;
+  const showCustomPill = presetsAvailable
+    ? presetValue === null
+    : customPolicyCount > 0;
+
+  const presetPanel = presetsAvailable && engineId && (
+    <div className="pp-panel">
+      <div className="pp-panel-header">
+        <div className="pp-panel-title">
+          <span>{t("autonomy.sectionTitle")}</span>
+        </div>
+        {showCustomPill ? (
+          <span className="pp-header-badge">{t("autonomy.custom")}</span>
+        ) : null}
+      </div>
+      <div className="pp-panel-content">
+        <div className="pp-options">
+          {availableAutonomyPresets(engineId).map((preset) => {
+            const selected = preset === presetValue;
+            return (
+              <button
+                key={preset}
+                type="button"
+                className={`pp-option pp-preset-option${selected ? " pp-option-selected" : ""}`}
+                data-tone={preset === "full" ? "warn" : undefined}
+                onClick={() => onPresetChange?.(preset)}
+              >
+                <span className="pp-preset-icon">{PRESET_ICONS[preset]}</span>
+                <div className="pp-option-copy">
+                  <span className="pp-option-label">{presetLabel(preset)}</span>
+                  <span className="pp-option-description">
+                    {t(`autonomy.presets.${preset}.description`)}
+                  </span>
+                </div>
+                {selected ? <Check size={13} className="pp-option-check" /> : null}
+              </button>
+            );
+          })}
+        </div>
+        <div className="pp-map">
+          <span className="pp-map-title">
+            {t("autonomy.mapsTo", { engine: ENGINE_DISPLAY_NAMES[engineId] })}
+          </span>
+          <div className="pp-map-rows">
+            {mappingRows.map((row) => (
+              <span
+                key={row.key}
+                className={`pp-map-chip${row.hot ? " pp-map-chip-hot" : ""}`}
+              >
+                {row.key}: {row.label}
+              </span>
+            ))}
+          </div>
+          {mappingNote ? <p className="pp-map-note">{mappingNote}</p> : null}
+        </div>
+      </div>
+      <div className="pp-preset-footer">
+        {onDefaultPresetChange ? (
+          <label
+            className={`pp-default-toggle${presetValue == null ? " pp-default-toggle-disabled" : ""}`}
+          >
+            <input
+              type="checkbox"
+              checked={presetValue != null && defaultPreset === presetValue}
+              disabled={presetValue == null}
+              onChange={(event) => {
+                if (presetValue == null) {
+                  return;
+                }
+                onDefaultPresetChange(event.target.checked ? presetValue : null);
+              }}
+            />
+            {t("autonomy.defaultForNewThreads")}
+          </label>
+        ) : (
+          <span />
+        )}
+        {railItems.length > 0 ? (
+          <button
+            type="button"
+            className="pp-advanced-btn"
+            onClick={() => setView("advanced")}
+          >
+            {t("autonomy.advanced")}
+            <ChevronDown size={10} style={{ transform: "rotate(-90deg)" }} />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  const advancedPanel = (
+    <>
+      <div className="pp-rail">
+        {presetsAvailable ? (
+          <button
+            type="button"
+            className="pp-rail-item pp-rail-back"
+            onClick={() => setView("presets")}
+          >
+            <span className="pp-rail-item-icon">
+              <ChevronLeft size={13} />
+            </span>
+            <span className="pp-rail-item-name">{t("autonomy.backToPresets")}</span>
+          </button>
+        ) : (
+          <div className="pp-rail-label">{t("permissionPicker.policy")}</div>
+        )}
+        {railItems.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className={`pp-rail-item${activeSection === item.id ? " pp-rail-item-active" : ""}`}
+            onClick={() => setActiveSection(item.id)}
+          >
+            <span className="pp-rail-item-icon">{item.icon}</span>
+            <span className="pp-rail-item-name">{item.title}</span>
+          </button>
+        ))}
+      </div>
+
+      {activeItem ? (
+        <div className="pp-panel">
+          <div className="pp-panel-header">
+            <div className="pp-panel-title">
+              <span>{activeItem.title}</span>
+            </div>
+            {customPolicyCount > 0 ? (
+              <span className="pp-header-badge">{t("permissionPicker.custom")}</span>
+            ) : null}
+          </div>
+          <div className="pp-panel-content">
+            <div className="pp-options">
+              {activeItem.options.map((option) => {
+                const selected = option.value === activeItem.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={`pp-option${selected ? " pp-option-selected" : ""}`}
+                    onClick={() => activeItem.onChange?.(option.value)}
+                    disabled={activeItem.disabled}
+                  >
+                    <div className="pp-option-copy">
+                      <span className="pp-option-label">{option.label}</span>
+                      {option.description ? (
+                        <span className="pp-option-description">{option.description}</span>
+                      ) : null}
+                    </div>
+                    {selected ? <Check size={13} className="pp-option-check" /> : null}
+                  </button>
+                );
+              })}
+            </div>
+            {activeItem.note ? <p className="pp-section-note">{activeItem.note}</p> : null}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
 
   const popover = open
     ? createPortal(
         <div
           ref={popoverRef}
-          className="pp-popover"
+          className={`pp-popover${view === "presets" && presetsAvailable ? " pp-popover-presets" : ""}`}
           style={{
             position: "fixed",
             bottom: pos.bottom,
             left: pos.left,
           }}
         >
-          <div className="pp-rail">
-            <div className="pp-rail-label">{t("permissionPicker.policy")}</div>
-            {railItems.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                className={`pp-rail-item${activeSection === item.id ? " pp-rail-item-active" : ""}`}
-                onClick={() => setActiveSection(item.id)}
-              >
-                <span className="pp-rail-item-icon">{item.icon}</span>
-                <span className="pp-rail-item-name">{item.title}</span>
-              </button>
-            ))}
-          </div>
-
-          {activeItem ? (
-            <div className="pp-panel">
-              <div className="pp-panel-header">
-                <div className="pp-panel-title">
-                  <span>{activeItem.title}</span>
-                </div>
-                {customPolicyCount > 0 ? (
-                  <span className="pp-header-badge">{t("permissionPicker.custom")}</span>
-                ) : null}
-              </div>
-              <div className="pp-panel-content">
-                <div className="pp-options">
-                  {activeItem.options.map((option) => {
-                    const selected = option.value === activeItem.value;
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        className={`pp-option${selected ? " pp-option-selected" : ""}`}
-                        onClick={() => activeItem.onChange?.(option.value)}
-                        disabled={activeItem.disabled}
-                      >
-                        <div className="pp-option-copy">
-                          <span className="pp-option-label">{option.label}</span>
-                          {option.description ? (
-                            <span className="pp-option-description">{option.description}</span>
-                          ) : null}
-                        </div>
-                        {selected ? <Check size={13} className="pp-option-check" /> : null}
-                      </button>
-                    );
-                  })}
-                </div>
-                {activeItem.note ? <p className="pp-section-note">{activeItem.note}</p> : null}
-              </div>
-            </div>
-          ) : null}
+          {view === "presets" && presetsAvailable ? presetPanel : advancedPanel}
         </div>,
         document.body,
       )
     : null;
+
+  const triggerLabel = presetsAvailable
+    ? presetValue != null
+      ? presetLabel(presetValue)
+      : t("autonomy.custom")
+    : trustOption
+      ? trustOption.label
+      : t("permissionPicker.title");
 
   return (
     <div className="pp-root">
@@ -358,18 +585,21 @@ export function PermissionPicker({
         ref={triggerRef}
         type="button"
         className={`pp-trigger${open ? " pp-trigger-open" : ""}`}
+        data-tone={presetsAvailable && presetValue === "full" ? "warn" : undefined}
         onClick={toggle}
         disabled={disabled}
         title={title}
       >
         <span className="pp-trigger-icon">
-          <Shield size={12} />
+          {presetsAvailable && presetValue != null
+            ? PRESET_TRIGGER_ICONS[presetValue]
+            : <Shield size={12} />}
         </span>
-        <span className="pp-trigger-label">
-          {trustOption ? trustOption.label : t("permissionPicker.title")}
-        </span>
-        {customPolicyCount > 0 ? (
-          <span className="pp-trigger-pill pp-trigger-pill-accent">{t("permissionPicker.custom")}</span>
+        <span className="pp-trigger-label">{triggerLabel}</span>
+        {showCustomPill ? (
+          <span className="pp-trigger-pill pp-trigger-pill-accent">
+            {presetsAvailable ? t("autonomy.custom") : t("permissionPicker.custom")}
+          </span>
         ) : null}
         <ChevronDown
           size={10}

--- a/src/components/chat/PermissionPicker.tsx
+++ b/src/components/chat/PermissionPicker.tsx
@@ -46,6 +46,7 @@ interface PermissionPickerProps {
   customPolicyCount?: number;
   engineId?: ChatEngineId;
   presetValue?: AutonomyPresetId | null;
+  codexExternalSandbox?: boolean;
   onPresetChange?: (preset: AutonomyPresetId) => void;
   defaultPreset?: AutonomyPresetId | null;
   onDefaultPresetChange?: (preset: AutonomyPresetId | null) => void;
@@ -107,6 +108,7 @@ export function PermissionPicker({
   customPolicyCount = 0,
   engineId,
   presetValue,
+  codexExternalSandbox = false,
   onPresetChange,
   defaultPreset,
   onDefaultPresetChange,
@@ -343,7 +345,9 @@ export function PermissionPicker({
     if (!presetsAvailable || !engineId) {
       return [];
     }
-    const patch = autonomyPresetPatch(presetValue ?? "inherit", engineId);
+    const patch = autonomyPresetPatch(presetValue ?? "inherit", engineId, {
+      codexExternalSandbox,
+    });
     const rows: Array<{ key: string; label: string; hot: boolean }> = [
       {
         key: resolvedApprovalTitle,
@@ -370,6 +374,7 @@ export function PermissionPicker({
     return rows;
   }, [
     approvalOptions,
+    codexExternalSandbox,
     engineId,
     networkOptions,
     presetValue,

--- a/src/components/chat/PermissionPicker.tsx
+++ b/src/components/chat/PermissionPicker.tsx
@@ -12,7 +12,11 @@ import {
   Zap,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { availableAutonomyPresets } from "../../lib/autonomyPresets";
+import {
+  autonomyPresetDescriptionKey,
+  availableAutonomyPresets,
+  isDefaultAutonomyPreset,
+} from "../../lib/autonomyPresets";
 import type { AutonomyPresetId } from "../../lib/autonomyPresets";
 import type { ChatEngineId, TrustLevel } from "../../types";
 
@@ -43,6 +47,7 @@ interface PermissionPickerProps {
   customPolicyCount?: number;
   engineId?: ChatEngineId;
   presetValue?: AutonomyPresetId | null;
+  codexExternalSandbox?: boolean;
   onPresetChange?: (preset: AutonomyPresetId) => void;
   defaultPreset?: AutonomyPresetId | null;
   onDefaultPresetChange?: (preset: AutonomyPresetId | null) => void;
@@ -98,6 +103,7 @@ export function PermissionPicker({
   customPolicyCount = 0,
   engineId,
   presetValue,
+  codexExternalSandbox = false,
   onPresetChange,
   defaultPreset,
   onDefaultPresetChange,
@@ -335,6 +341,9 @@ export function PermissionPicker({
   const showCustomPill = presetsAvailable
     ? presetValue === null
     : customPolicyCount > 0;
+  const defaultPresetSelected = isDefaultAutonomyPreset(presetValue, defaultPreset);
+  const defaultPresetDisabled =
+    presetValue == null || (presetValue === "inherit" && defaultPresetSelected);
 
   const presetPanel = presetsAvailable && engineId && (
     <div className="pp-panel">
@@ -361,7 +370,11 @@ export function PermissionPicker({
                 <div className="pp-option-copy">
                   <span className="pp-option-label">{presetLabel(preset)}</span>
                   <span className="pp-option-description">
-                    {t(`autonomy.presets.${preset}.description`)}
+                    {t(
+                      autonomyPresetDescriptionKey(preset, engineId, {
+                        codexExternalSandbox,
+                      }),
+                    )}
                   </span>
                 </div>
                 {selected ? <Check size={13} className="pp-option-check" /> : null}
@@ -373,12 +386,12 @@ export function PermissionPicker({
       <div className="pp-preset-footer">
         {onDefaultPresetChange ? (
           <label
-            className={`pp-default-toggle${presetValue == null ? " pp-default-toggle-disabled" : ""}`}
+            className={`pp-default-toggle${defaultPresetDisabled ? " pp-default-toggle-disabled" : ""}`}
           >
             <input
               type="checkbox"
-              checked={presetValue != null && defaultPreset === presetValue}
-              disabled={presetValue == null}
+              checked={defaultPresetSelected}
+              disabled={defaultPresetDisabled}
               onChange={(event) => {
                 if (presetValue == null) {
                   return;

--- a/src/components/chat/PermissionPicker.tsx
+++ b/src/components/chat/PermissionPicker.tsx
@@ -12,10 +12,7 @@ import {
   Zap,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import {
-  autonomyPresetPatch,
-  availableAutonomyPresets,
-} from "../../lib/autonomyPresets";
+import { availableAutonomyPresets } from "../../lib/autonomyPresets";
 import type { AutonomyPresetId } from "../../lib/autonomyPresets";
 import type { ChatEngineId, TrustLevel } from "../../types";
 
@@ -46,7 +43,6 @@ interface PermissionPickerProps {
   customPolicyCount?: number;
   engineId?: ChatEngineId;
   presetValue?: AutonomyPresetId | null;
-  codexExternalSandbox?: boolean;
   onPresetChange?: (preset: AutonomyPresetId) => void;
   defaultPreset?: AutonomyPresetId | null;
   onDefaultPresetChange?: (preset: AutonomyPresetId | null) => void;
@@ -66,12 +62,6 @@ interface PermissionPickerProps {
   networkDisabled?: boolean;
   networkNotice?: string | null;
 }
-
-const ENGINE_DISPLAY_NAMES: Record<ChatEngineId, string> = {
-  codex: "Codex",
-  claude: "Claude",
-  opencode: "OpenCode",
-};
 
 const PRESET_ICONS: Record<AutonomyPresetId, ReactNode> = {
   inherit: <Shield size={13} />,
@@ -108,7 +98,6 @@ export function PermissionPicker({
   customPolicyCount = 0,
   engineId,
   presetValue,
-  codexExternalSandbox = false,
   onPresetChange,
   defaultPreset,
   onDefaultPresetChange,
@@ -341,69 +330,6 @@ export function PermissionPicker({
     [t],
   );
 
-  const mappingRows = useMemo(() => {
-    if (!presetsAvailable || !engineId) {
-      return [];
-    }
-    const patch = autonomyPresetPatch(presetValue ?? "inherit", engineId, {
-      codexExternalSandbox,
-    });
-    const rows: Array<{ key: string; label: string; hot: boolean }> = [
-      {
-        key: resolvedApprovalTitle,
-        label:
-          findOption(approvalOptions, patch.approvalPolicy)?.label ?? patch.approvalPolicy,
-        hot: presetValue === "full",
-      },
-    ];
-    if (patch.sandboxMode !== undefined) {
-      rows.push({
-        key: t("permissionPicker.sandbox"),
-        label: findOption(sandboxOptions, patch.sandboxMode)?.label ?? patch.sandboxMode,
-        hot: presetValue === "full" && patch.sandboxMode === "danger-full-access",
-      });
-    }
-    if (patch.networkPolicy !== undefined) {
-      rows.push({
-        key: t("permissionPicker.network"),
-        label:
-          findOption(networkOptions, patch.networkPolicy)?.label ?? patch.networkPolicy,
-        hot: presetValue === "full" && patch.networkPolicy === "enabled",
-      });
-    }
-    return rows;
-  }, [
-    approvalOptions,
-    codexExternalSandbox,
-    engineId,
-    networkOptions,
-    presetValue,
-    presetsAvailable,
-    resolvedApprovalTitle,
-    sandboxOptions,
-    t,
-  ]);
-
-  const mappingNote = useMemo(() => {
-    if (!presetsAvailable || !engineId) {
-      return null;
-    }
-    if (engineId === "opencode") {
-      return t("autonomy.openCodeNote");
-    }
-    if (engineId === "claude" && presetValue === "full") {
-      return t("autonomy.claudeFullNote");
-    }
-    if (
-      engineId === "codex" &&
-      codexExternalSandbox &&
-      (presetValue === "read-only" || presetValue === "ask" || presetValue === "auto")
-    ) {
-      return t("autonomy.codexExternalSandboxNote");
-    }
-    return null;
-  }, [codexExternalSandbox, engineId, presetValue, presetsAvailable, t]);
-
   const title = summaryLines.length > 0 ? summaryLines.join(" | ") : t("permissionPicker.title");
   const activeItem = railItems.find((item) => item.id === activeSection) ?? null;
   const showCustomPill = presetsAvailable
@@ -429,7 +355,6 @@ export function PermissionPicker({
                 key={preset}
                 type="button"
                 className={`pp-option pp-preset-option${selected ? " pp-option-selected" : ""}`}
-                data-tone={preset === "full" ? "warn" : undefined}
                 onClick={() => onPresetChange?.(preset)}
               >
                 <span className="pp-preset-icon">{PRESET_ICONS[preset]}</span>
@@ -443,22 +368,6 @@ export function PermissionPicker({
               </button>
             );
           })}
-        </div>
-        <div className="pp-map">
-          <span className="pp-map-title">
-            {t("autonomy.mapsTo", { engine: ENGINE_DISPLAY_NAMES[engineId] })}
-          </span>
-          <div className="pp-map-rows">
-            {mappingRows.map((row) => (
-              <span
-                key={row.key}
-                className={`pp-map-chip${row.hot ? " pp-map-chip-hot" : ""}`}
-              >
-                {row.key}: {row.label}
-              </span>
-            ))}
-          </div>
-          {mappingNote ? <p className="pp-map-note">{mappingNote}</p> : null}
         </div>
       </div>
       <div className="pp-preset-footer">
@@ -597,7 +506,6 @@ export function PermissionPicker({
         ref={triggerRef}
         type="button"
         className={`pp-trigger${open ? " pp-trigger-open" : ""}`}
-        data-tone={presetsAvailable && presetValue === "full" ? "warn" : undefined}
         onClick={toggle}
         disabled={disabled}
         title={title}

--- a/src/components/chat/PermissionPicker.tsx
+++ b/src/components/chat/PermissionPicker.tsx
@@ -394,8 +394,15 @@ export function PermissionPicker({
     if (engineId === "claude" && presetValue === "full") {
       return t("autonomy.claudeFullNote");
     }
+    if (
+      engineId === "codex" &&
+      codexExternalSandbox &&
+      (presetValue === "read-only" || presetValue === "ask" || presetValue === "auto")
+    ) {
+      return t("autonomy.codexExternalSandboxNote");
+    }
     return null;
-  }, [engineId, presetValue, presetsAvailable, t]);
+  }, [codexExternalSandbox, engineId, presetValue, presetsAvailable, t]);
 
   const title = summaryLines.length > 0 ? summaryLines.join(" | ") : t("permissionPicker.title");
   const activeItem = railItems.find((item) => item.id === activeSection) ?? null;

--- a/src/components/chat/claudeToolInputGating.test.ts
+++ b/src/components/chat/claudeToolInputGating.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ApprovalBlock } from "../../types";
 import {
   buildPermissionApprovalResponseForEngine,
+  canBatchApproveApproval,
   canUseApprovalDecisionActions,
   filterPendingApprovalBannerRows,
   isOpenCodeQuestionApproval,
@@ -180,6 +181,23 @@ describe("Claude tool-input gating", () => {
     expect(canUseApprovalDecisionActions("opencode", openCodeQuestion.details)).toBe(false);
     expect(canUseApprovalDecisionActions("opencode", openCodePermission.details)).toBe(true);
     expect(canUseApprovalDecisionActions("claude", openCodeQuestion.details)).toBe(true);
+    expect(canBatchApproveApproval(openCodeQuestion, "opencode")).toBe(false);
+    expect(canBatchApproveApproval(openCodePermission, "opencode")).toBe(true);
+  });
+
+  it("excludes custom approval payloads from batch acceptance", () => {
+    const customApproval = makeApprovalBlock("custom", {
+      _serverMethod: "item/tool/requestUserInput",
+      questions: [
+        {
+          id: "question-1",
+          question: "Choose an option",
+          options: [{ label: "A", description: "First" }],
+        },
+      ],
+    });
+
+    expect(canBatchApproveApproval(customApproval, "codex")).toBe(false);
   });
 
   it("uses OpenCode-native decision payloads for permission approvals", () => {

--- a/src/components/onboarding/HarnessLaunchSettingsModal.tsx
+++ b/src/components/onboarding/HarnessLaunchSettingsModal.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { X } from "lucide-react";
+import { useHarnessStore } from "../../stores/harnessStore";
+import { toast } from "../../stores/toastStore";
+import { getHarnessIcon } from "../shared/HarnessLogos";
+import type { HarnessInfo } from "../../types";
+
+const SUGGESTED_FLAGS: Record<string, string> = {
+  codex: "--yolo",
+  "claude-code": "--dangerously-skip-permissions",
+};
+
+interface Props {
+  harness: HarnessInfo;
+  onClose: () => void;
+}
+
+export function HarnessLaunchSettingsModal({ harness, onClose }: Props) {
+  const { t } = useTranslation("app");
+  const savedArgs = useHarnessStore((s) => s.launchArgs[harness.id] ?? "");
+  const saveLaunchArgs = useHarnessStore((s) => s.saveLaunchArgs);
+  const [value, setValue] = useState(savedArgs);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [onClose]);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    const ok = await saveLaunchArgs(harness.id, value);
+    setSaving(false);
+    if (ok) {
+      toast.success(t("harnesses.launchSettings.saved"));
+      onClose();
+    } else {
+      toast.error(t("harnesses.launchSettings.saveFailed"));
+    }
+  }, [harness.id, onClose, saveLaunchArgs, t, value]);
+
+  const trimmed = value.trim();
+  const preview = trimmed ? `${harness.command} ${trimmed}` : harness.command;
+
+  return createPortal(
+    <div
+      className="confirm-dialog-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="ws-modal" style={{ width: "min(460px, calc(100vw - 40px))" }}>
+        <div className="ws-header">
+          <div className="ws-header-icon">{getHarnessIcon(harness.id, 18)}</div>
+          <div className="ws-header-text">
+            <h2 className="ws-header-title">{t("harnesses.launchSettings.title")}</h2>
+            <p style={{ margin: "3px 0 0", fontSize: 11.5, color: "var(--text-3)" }}>
+              {t("harnesses.launchSettings.description", { name: harness.name })}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="ws-close"
+            onClick={onClose}
+            aria-label={t("harnesses.launchSettings.cancel")}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="ws-divider" />
+
+        <div className="ws-body">
+          <label className="hp-args-field">
+            <span>{t("harnesses.launchSettings.argsLabel")}</span>
+            <input
+              className="hp-args-input"
+              value={value}
+              onChange={(event) => setValue(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !saving) void handleSave();
+              }}
+              placeholder={SUGGESTED_FLAGS[harness.id] ?? t("harnesses.launchSettings.argsPlaceholder")}
+              spellCheck={false}
+              autoFocus
+            />
+          </label>
+          <div className="hp-args-preview">
+            <span>{t("harnesses.launchSettings.preview")}</span>
+            <code>{preview}</code>
+          </div>
+        </div>
+
+        <div className="ws-footer">
+          <span className="ws-footer-meta" />
+          <div className="ws-footer-actions">
+            <button type="button" className="ws-prop-btn" onClick={onClose}>
+              {t("harnesses.launchSettings.cancel")}
+            </button>
+            <button
+              type="button"
+              className="ws-prop-btn ws-prop-btn-accent"
+              disabled={saving}
+              onClick={() => void handleSave()}
+            >
+              {t("harnesses.launchSettings.save")}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/onboarding/HarnessPanel.tsx
+++ b/src/components/onboarding/HarnessPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { open } from "@tauri-apps/plugin-shell";
 import {
@@ -11,6 +11,7 @@ import {
   Loader2,
   Play,
   RefreshCw,
+  SlidersHorizontal,
   Terminal,
 } from "lucide-react";
 import { useHarnessStore } from "../../stores/harnessStore";
@@ -26,6 +27,7 @@ import {
 } from "../../lib/harnessInstallActions";
 import { handleDragDoubleClick, handleDragMouseDown } from "../../lib/windowDrag";
 import { getHarnessIcon } from "../shared/HarnessLogos";
+import { HarnessLaunchSettingsModal } from "./HarnessLaunchSettingsModal";
 import type { HarnessInfo } from "../../types";
 
 /* ─── Harness tile ─── */
@@ -33,18 +35,22 @@ function HarnessTile({
   harness,
   description,
   preferredInstallMethod,
+  launchArgs,
   onInstallInTerminal,
   onCopyCommand,
   onLaunch,
   onOpenWebsite,
+  onOpenLaunchSettings,
 }: {
   harness: HarnessInfo;
   description: string;
   preferredInstallMethod: string | null;
+  launchArgs: string | undefined;
   onInstallInTerminal: () => void;
   onCopyCommand: () => void;
   onLaunch: () => void;
   onOpenWebsite: () => void;
+  onOpenLaunchSettings: () => void;
 }) {
   const { t } = useTranslation("app");
   const installCmd = getHarnessInstallCommand(harness.id, preferredInstallMethod);
@@ -62,53 +68,73 @@ function HarnessTile({
           {harness.native && <span className="hp-tile-badge">{t("harnesses.native")}</span>}
         </div>
         <p className="hp-tile-desc">{description}</p>
-        {harness.found && (
+        {(harness.found || launchArgs) && (
           <div className="hp-tile-meta">
-            <span className="hp-tile-status-ok">
-              <CheckCircle2 size={10} />
-              {t("harnesses.installed")}
-            </span>
-            {harness.version && <span className="hp-tile-version">{harness.version}</span>}
+            {harness.found && (
+              <span className="hp-tile-status-ok">
+                <CheckCircle2 size={10} />
+                {t("harnesses.installed")}
+              </span>
+            )}
+            {harness.found && harness.version && (
+              <span className="hp-tile-version">{harness.version}</span>
+            )}
+            {launchArgs && (
+              <span className="hp-tile-flags" title={launchArgs}>
+                {launchArgs}
+              </span>
+            )}
           </div>
         )}
       </div>
 
       <div className="hp-tile-action">
-        {action === "launch" ? (
-          <button type="button" className="hp-btn hp-btn-launch" onClick={onLaunch}>
-            <Play size={11} />
-            {t("harnesses.launch")}
-          </button>
-        ) : action === "install" && installCmd ? (
-          <div className="hp-tile-action-group">
-            <button
-              type="button"
-              className="hp-btn hp-btn-copy"
-              onClick={onCopyCommand}
-              title={installCmd}
-            >
-              <ClipboardCopy size={11} />
-            </button>
-            <button
-              type="button"
-              className="hp-btn hp-btn-install"
-              onClick={onInstallInTerminal}
-            >
-              <Download size={11} />
-              {t("harnesses.install")}
-            </button>
-          </div>
-        ) : action === "manual" ? (
+        <div className="hp-tile-action-group">
           <button
             type="button"
             className="hp-btn hp-btn-copy"
-            onClick={onOpenWebsite}
-            title={harness.website}
+            onClick={onOpenLaunchSettings}
+            title={t("harnesses.launchSettings.title")}
+            aria-label={t("harnesses.launchSettings.title")}
           >
-            <ExternalLink size={11} />
-            {t("harnesses.website")}
+            <SlidersHorizontal size={11} />
           </button>
-        ) : null}
+          {action === "launch" ? (
+            <button type="button" className="hp-btn hp-btn-launch" onClick={onLaunch}>
+              <Play size={11} />
+              {t("harnesses.launch")}
+            </button>
+          ) : action === "install" && installCmd ? (
+            <>
+              <button
+                type="button"
+                className="hp-btn hp-btn-copy"
+                onClick={onCopyCommand}
+                title={installCmd}
+              >
+                <ClipboardCopy size={11} />
+              </button>
+              <button
+                type="button"
+                className="hp-btn hp-btn-install"
+                onClick={onInstallInTerminal}
+              >
+                <Download size={11} />
+                {t("harnesses.install")}
+              </button>
+            </>
+          ) : action === "manual" ? (
+            <button
+              type="button"
+              className="hp-btn hp-btn-copy"
+              onClick={onOpenWebsite}
+              title={harness.website}
+            >
+              <ExternalLink size={11} />
+              {t("harnesses.website")}
+            </button>
+          ) : null}
+        </div>
       </div>
     </div>
   );
@@ -125,10 +151,15 @@ export function HarnessPanel() {
   const ensureScanned = useHarnessStore((s) => s.ensureScanned);
   const launch = useHarnessStore((s) => s.launch);
   const preferredInstallMethod = useHarnessStore((s) => s.preferredInstallMethod);
+  const launchArgs = useHarnessStore((s) => s.launchArgs);
+  const launchArgsLoaded = useHarnessStore((s) => s.launchArgsLoaded);
+  const loadLaunchArgs = useHarnessStore((s) => s.loadLaunchArgs);
 
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const createSession = useTerminalStore((s) => s.createSession);
   const setActiveView = useUiStore((s) => s.setActiveView);
+
+  const [settingsHarness, setSettingsHarness] = useState<HarnessInfo | null>(null);
 
   const installedCount = harnesses.filter((h) => h.found).length;
   const goBack = useCallback(() => setActiveView("chat"), [setActiveView]);
@@ -139,6 +170,13 @@ export function HarnessPanel() {
     }
     void ensureScanned();
   }, [ensureScanned, loadedOnce]);
+
+  useEffect(() => {
+    if (launchArgsLoaded) {
+      return;
+    }
+    void loadLaunchArgs();
+  }, [launchArgsLoaded, loadLaunchArgs]);
 
   const spawnInTerminal = useCallback(
     async (command: string) => {
@@ -253,10 +291,12 @@ export function HarnessPanel() {
                   harness={h}
                   description={t(`harnesses.descriptions.${h.id}`, { defaultValue: h.description })}
                   preferredInstallMethod={preferredInstallMethod}
+                  launchArgs={launchArgs[h.id]}
                   onInstallInTerminal={() => handleInstallInTerminal(h.id)}
                   onCopyCommand={() => handleCopyCommand(h.id)}
                   onLaunch={() => void handleLaunch(h.id)}
                   onOpenWebsite={() => handleOpenWebsite(h.website)}
+                  onOpenLaunchSettings={() => setSettingsHarness(h)}
                 />
               ))}
             </div>
@@ -283,6 +323,13 @@ export function HarnessPanel() {
           </div>
         </div>
       </div>
+
+      {settingsHarness && (
+        <HarnessLaunchSettingsModal
+          harness={settingsHarness}
+          onClose={() => setSettingsHarness(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/shared/DiffViewer.tsx
+++ b/src/components/shared/DiffViewer.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { useTranslation } from "react-i18next";
+import { UnfoldVertical } from "lucide-react";
 import {
   extractDiffFilename,
   LINE_CLASS,
@@ -67,6 +69,70 @@ function scheduleDiffWorkerIdleTermination() {
 
 function getDiffLineHeight(line: ParsedLine): number {
   return line.type === "hunk" ? DIFF_HUNK_HEIGHT : DIFF_LINE_HEIGHT;
+}
+
+/* ── Context folding: long unchanged runs collapse behind an explicit count ── */
+
+const FOLD_MIN_RUN = 12;
+const FOLD_EDGE_KEEP = 4;
+
+type DiffDisplayRow =
+  | { kind: "line"; line: ParsedLine; key: number }
+  | { kind: "fold"; id: number; count: number };
+
+function getDisplayRowHeight(row: DiffDisplayRow): number {
+  return row.kind === "fold" ? DIFF_LINE_HEIGHT : getDiffLineHeight(row.line);
+}
+
+function buildDisplayRows(
+  parsed: ParsedLine[],
+  foldContext: boolean,
+  expandedFolds: ReadonlySet<number>,
+): DiffDisplayRow[] {
+  if (!foldContext) {
+    return parsed.map((line, index) => ({ kind: "line", line, key: index }));
+  }
+
+  const rows: DiffDisplayRow[] = [];
+  let index = 0;
+  while (index < parsed.length) {
+    if (parsed[index].type !== "context") {
+      rows.push({ kind: "line", line: parsed[index], key: index });
+      index += 1;
+      continue;
+    }
+
+    let runEnd = index;
+    while (runEnd < parsed.length && parsed[runEnd].type === "context") {
+      runEnd += 1;
+    }
+    const runLength = runEnd - index;
+    if (runLength < FOLD_MIN_RUN) {
+      for (let k = index; k < runEnd; k += 1) {
+        rows.push({ kind: "line", line: parsed[k], key: k });
+      }
+      index = runEnd;
+      continue;
+    }
+
+    const foldStart = index + FOLD_EDGE_KEEP;
+    const foldEnd = runEnd - FOLD_EDGE_KEEP;
+    for (let k = index; k < foldStart; k += 1) {
+      rows.push({ kind: "line", line: parsed[k], key: k });
+    }
+    if (expandedFolds.has(foldStart)) {
+      for (let k = foldStart; k < foldEnd; k += 1) {
+        rows.push({ kind: "line", line: parsed[k], key: k });
+      }
+    } else {
+      rows.push({ kind: "fold", id: foldStart, count: foldEnd - foldStart });
+    }
+    for (let k = foldEnd; k < runEnd; k += 1) {
+      rows.push({ kind: "line", line: parsed[k], key: k });
+    }
+    index = runEnd;
+  }
+  return rows;
 }
 
 function renderDiffLine(line: ParsedLine, key: number | string) {
@@ -238,6 +304,7 @@ interface VirtualizedDiffBodyProps {
   fillAvailableHeight?: boolean;
   maxHeight?: number;
   style?: CSSProperties;
+  foldContext?: boolean;
 }
 
 export function VirtualizedDiffBody({
@@ -245,23 +312,60 @@ export function VirtualizedDiffBody({
   fillAvailableHeight = false,
   maxHeight = DIFF_VIEWPORT_FALLBACK_HEIGHT,
   style,
+  foldContext = false,
 }: VirtualizedDiffBodyProps) {
+  const { t } = useTranslation("common");
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportHeight, setViewportHeight] = useState(maxHeight);
+  const [expandedFolds, setExpandedFolds] = useState<ReadonlySet<number>>(
+    () => new Set<number>(),
+  );
+
+  useEffect(() => {
+    setExpandedFolds(new Set<number>());
+  }, [parsed]);
+
+  const rows = useMemo(
+    () => buildDisplayRows(parsed, foldContext, expandedFolds),
+    [parsed, foldContext, expandedFolds],
+  );
 
   const virtualizationEnabled =
-    parsed.length >= DIFF_VIRTUALIZATION_THRESHOLD_LINES;
+    rows.length >= DIFF_VIRTUALIZATION_THRESHOLD_LINES;
 
   const offsets = useMemo(() => {
-    const nextOffsets = new Array<number>(parsed.length + 1);
+    const nextOffsets = new Array<number>(rows.length + 1);
     nextOffsets[0] = 0;
-    for (let index = 0; index < parsed.length; index += 1) {
+    for (let index = 0; index < rows.length; index += 1) {
       nextOffsets[index + 1] =
-        nextOffsets[index] + getDiffLineHeight(parsed[index]);
+        nextOffsets[index] + getDisplayRowHeight(rows[index]);
     }
     return nextOffsets;
-  }, [parsed]);
+  }, [rows]);
+
+  const renderRow = (row: DiffDisplayRow) => {
+    if (row.kind === "fold") {
+      return (
+        <button
+          key={`fold-${row.id}`}
+          type="button"
+          className="git-diff-fold"
+          onClick={() =>
+            setExpandedFolds((current) => {
+              const next = new Set(current);
+              next.add(row.id);
+              return next;
+            })
+          }
+        >
+          <UnfoldVertical size={11} />
+          {t("diff.unchangedLines", { count: row.count })}
+        </button>
+      );
+    }
+    return renderDiffLine(row.line, row.key);
+  };
 
   useEffect(() => {
     const container = containerRef.current;
@@ -316,7 +420,7 @@ export function VirtualizedDiffBody({
       return null;
     }
 
-    const rowCount = parsed.length;
+    const rowCount = rows.length;
     const totalHeight = offsets[rowCount];
     const visibleStart = Math.max(0, scrollTop - DIFF_OVERSCAN_PX);
     const visibleEnd = scrollTop + viewportHeight + DIFF_OVERSCAN_PX;
@@ -354,7 +458,7 @@ export function VirtualizedDiffBody({
       totalHeight,
       topOffset: offsets[startIndex],
     };
-  }, [offsets, parsed, scrollTop, viewportHeight, virtualizationEnabled]);
+  }, [offsets, rows, scrollTop, viewportHeight, virtualizationEnabled]);
 
   const viewportStyle: CSSProperties = fillAvailableHeight
     ? {
@@ -379,7 +483,7 @@ export function VirtualizedDiffBody({
             padding: `${DIFF_CONTENT_VERTICAL_PADDING}px 0`,
           }}
         >
-          {parsed.map((line, index) => renderDiffLine(line, index))}
+          {rows.map((row) => renderRow(row))}
         </div>
       </div>
     );
@@ -403,13 +507,9 @@ export function VirtualizedDiffBody({
             top: virtualWindow.topOffset + DIFF_CONTENT_VERTICAL_PADDING,
           }}
         >
-          {parsed
+          {rows
             .slice(virtualWindow.startIndex, virtualWindow.endIndexExclusive)
-            .map((line, relativeIndex) => {
-              const absoluteIndex =
-                virtualWindow.startIndex + relativeIndex;
-              return renderDiffLine(line, absoluteIndex);
-            })}
+            .map((row) => renderRow(row))}
         </div>
       </div>
     </div>

--- a/src/components/shared/ToastContainer.tsx
+++ b/src/components/shared/ToastContainer.tsx
@@ -17,11 +17,15 @@ function ToastItem({
   id,
   variant,
   message,
+  title,
+  action,
   duration,
 }: {
   id: string;
   variant: "success" | "error" | "warning" | "info";
   message: string;
+  title?: string;
+  action?: { label: string; onClick: () => void };
   duration: number;
 }) {
   const { t } = useTranslation("common");
@@ -49,6 +53,11 @@ function ToastItem({
     };
   }, [duration, dismiss]);
 
+  const handleAction = useCallback(() => {
+    action?.onClick();
+    dismiss();
+  }, [action, dismiss]);
+
   const Icon = ICONS[variant];
 
   return (
@@ -59,7 +68,19 @@ function ToastItem({
     >
       <div className="toast-accent" />
       <Icon size={16} className="toast-icon" />
-      <span className="toast-message">{message}</span>
+      {title || action ? (
+        <div className="toast-content">
+          {title && <span className="toast-title">{title}</span>}
+          <span className="toast-message">{message}</span>
+          {action && (
+            <button type="button" className="toast-action" onClick={handleAction}>
+              {action.label}
+            </button>
+          )}
+        </div>
+      ) : (
+        <span className="toast-message">{message}</span>
+      )}
       <button className="toast-dismiss" onClick={dismiss} aria-label={t("actions.dismiss")}>
         <X size={12} />
       </button>
@@ -80,6 +101,8 @@ export function ToastContainer() {
           id={t.id}
           variant={t.variant}
           message={t.message}
+          title={t.title}
+          action={t.action}
           duration={t.duration}
         />
       ))}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -440,11 +440,21 @@ function SidebarContent({ onPin }: { onPin?: () => void }) {
                                 {getThreadLabel(thread)}
                               </span>
                               <span className="sb-thread-trailing">
-                                <span className="sb-thread-time">
-                                  {thread.lastActivityAt
-                                    ? formatRelativeTime(thread.lastActivityAt, i18n.language)
-                                    : ""}
-                                </span>
+                                {thread.status === "awaiting_approval" ? (
+                                  <span
+                                    className="sb-thread-approval"
+                                    title={t("app:sidebar.needsApproval")}
+                                  >
+                                    <span className="sb-thread-approval-dot" />
+                                    {t("app:sidebar.needsApproval")}
+                                  </span>
+                                ) : (
+                                  <span className="sb-thread-time">
+                                    {thread.lastActivityAt
+                                      ? formatRelativeTime(thread.lastActivityAt, i18n.language)
+                                      : ""}
+                                  </span>
+                                )}
                                 <button
                                   type="button"
                                   title={t("app:sidebar.archiveThread")}

--- a/src/globals.css
+++ b/src/globals.css
@@ -5160,20 +5160,6 @@ button, input, textarea, select {
   gap: 5px;
 }
 
-.chat-status-armed {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 1px 7px;
-  border-radius: 99px;
-  font-size: 10px;
-  font-weight: 500;
-  color: var(--warning);
-  background: var(--warning-surface);
-  border: 1px solid var(--warning-border);
-  white-space: nowrap;
-}
-
 .chat-status-branch {
   display: flex;
   align-items: center;
@@ -9444,6 +9430,10 @@ button.chat-context-section:hover {
 .pp-preset-option {
   align-items: flex-start;
   gap: 9px;
+}
+
+.pp-preset-option .pp-option-copy {
+  flex: 1;
 }
 
 .pp-preset-icon {

--- a/src/globals.css
+++ b/src/globals.css
@@ -4834,7 +4834,7 @@ button, input, textarea, select {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 9px 10px;
+  padding: 10px 11px;
   border-radius: var(--radius-md);
   background: var(--bg-2);
   border: 1px solid var(--warning-border);
@@ -4843,24 +4843,51 @@ button, input, textarea, select {
 
 .approval-row-info {
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.approval-row-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.approval-row-icon {
+  display: inline-flex;
+  color: var(--warning);
+  flex-shrink: 0;
 }
 
 .approval-row-summary {
-  font-size: 12.5px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--text-1);
   line-height: 1.35;
+  min-width: 0;
 }
 
-.approval-row-detail {
-  margin-top: 3px;
+.approval-row-command {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--text-2);
+  background: var(--code-bg);
+  border: 1px solid var(--divider);
+  border-radius: 8px;
+  padding: 7px 9px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 96px;
+  overflow-y: auto;
+}
+
+.approval-row-reason {
   font-size: 11px;
   color: var(--text-3);
-  font-family: var(--font-mono);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  line-height: 1.4;
+  line-height: 1.45;
 }
 
 .approval-row-hint {
@@ -4872,7 +4899,8 @@ button, input, textarea, select {
 .approval-actions {
   display: flex;
   align-items: center;
-  gap: 4px;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 /* Spacer between allow-group and deny-group */
@@ -4882,9 +4910,9 @@ button, input, textarea, select {
 
 .approval-btn {
   padding: 4px 12px;
-  font-size: 11px;
+  font-size: 11.5px;
   font-weight: 500;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all var(--duration-fast) var(--ease-out);
   white-space: nowrap;
@@ -4902,17 +4930,16 @@ button, input, textarea, select {
   background: var(--accent-fill-hover);
 }
 
-/* Allow session / Allow + policy — secondary, text-only */
+/* Allow session / Allow + policy — secondary outline */
 .approval-btn-session {
   background: transparent;
   color: var(--text-2);
-  border-color: var(--wash-1);
+  border-color: var(--border-active);
 }
 
 .approval-btn-session:hover {
-  color: var(--text-1);
-  background: var(--wash-05);
-  border-color: var(--wash-18);
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 /* Deny — red text, no border until hover */

--- a/src/globals.css
+++ b/src/globals.css
@@ -4813,17 +4813,6 @@ button, input, textarea, select {
   border-color: var(--border-active);
 }
 
-.approval-batch-btn-warn {
-  color: var(--warning);
-  border-color: var(--warning-border);
-}
-
-.approval-batch-btn-warn:hover {
-  color: var(--warning);
-  background: var(--warning-surface);
-  border-color: var(--warning);
-}
-
 .approval-rows {
   display: flex;
   flex-direction: column;
@@ -4837,7 +4826,7 @@ button, input, textarea, select {
   padding: 10px 11px;
   border-radius: var(--radius-md);
   background: var(--bg-2);
-  border: 1px solid var(--warning-border);
+  border: 1px solid var(--wash-08);
   animation: fade-in var(--duration-fast) var(--ease-out) both;
 }
 
@@ -4857,7 +4846,7 @@ button, input, textarea, select {
 
 .approval-row-icon {
   display: inline-flex;
-  color: var(--warning);
+  color: var(--text-3);
   flex-shrink: 0;
 }
 

--- a/src/globals.css
+++ b/src/globals.css
@@ -8804,6 +8804,20 @@ button.chat-context-section:hover {
   color: var(--text-3);
 }
 
+.hp-tile-flags {
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  background: var(--accent-dim);
+  border: 1px solid rgba(var(--accent-rgb), 0.12);
+  border-radius: var(--radius-sm);
+  padding: 0 5px;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .hp-tile-action {
   flex-shrink: 0;
   opacity: 0;
@@ -8877,6 +8891,59 @@ button.chat-context-section:hover {
   color: var(--text-1);
   border-color: var(--border);
   background: var(--wash-04);
+}
+
+/* Launch settings modal */
+
+.hp-args-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hp-args-field > span {
+  font-size: 11.5px;
+  color: var(--text-2);
+}
+
+.hp-args-input {
+  width: 100%;
+  padding: 6px 9px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--text-1);
+  transition: border-color var(--duration-fast) var(--ease-out);
+}
+
+.hp-args-input:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.hp-args-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 12px;
+}
+
+.hp-args-preview > span {
+  font-size: 10.5px;
+  color: var(--text-3);
+}
+
+.hp-args-preview > code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-2);
+  background: var(--wash-03);
+  border: 1px solid var(--wash-06);
+  border-radius: var(--radius-sm);
+  padding: 6px 9px;
+  overflow-wrap: anywhere;
 }
 
 /* Install log */

--- a/src/globals.css
+++ b/src/globals.css
@@ -1142,16 +1142,16 @@ button, input, textarea, select {
   border-radius: var(--radius-sm);
 }
 .msg-block-header:hover { background: var(--wash-02); }
-.msg-block-header:hover span { color: var(--text-1) !important; }
+.msg-block-header:hover .msg-block-label { color: var(--text-1); }
 .msg-block-header--static { cursor: default; }
 .msg-block-header--static:hover { background: none; }
-.msg-block-header--static:hover span { color: inherit !important; }
+.msg-block-header--static:hover .msg-block-label { color: var(--text-2); }
 .msg-block-chevron {
   flex-shrink: 0; color: var(--text-3); opacity: 0.5;
   transition: transform var(--duration-fast) var(--ease-out);
 }
 .msg-block-chevron-open { transform: rotate(90deg); }
-.msg-block-header--compact { padding: 2px 12px; }
+.msg-block-chevron-spacer { width: 11px; flex-shrink: 0; }
 
 .msg-block-tile {
   width: 18px; height: 18px; flex-shrink: 0;
@@ -1177,6 +1177,15 @@ button, input, textarea, select {
   font-size: 10px; color: var(--text-3);
   white-space: nowrap;
 }
+
+.msg-block-status {
+  display: inline-flex; align-items: center; gap: 3px;
+  color: var(--text-3);
+  font-size: 10px;
+}
+.msg-block-status--success { color: var(--success); }
+.msg-block-status--warning { color: var(--warning); font-weight: 500; }
+.msg-block-status--danger { color: var(--danger); }
 
 /* Indented expanded body under a hairline guide */
 .msg-block-body {
@@ -1216,8 +1225,6 @@ button, input, textarea, select {
   display: flex;
   flex-direction: column;
 }
-.msg-action-card .acard { background: none; border: none; margin: 0; }
-.msg-action-card .acard-header { background: none; border-bottom: none; padding: 6px 12px; }
 
 /* ── Chat Block Shared Styles ── */
 
@@ -4756,8 +4763,8 @@ button, input, textarea, select {
 .approval-header {
   display: flex;
   align-items: center;
-  gap: 7px;
-  padding: 0 2px 6px;
+  gap: 6px;
+  padding: 0 3px 5px;
 }
 
 .approval-header-icon {
@@ -4767,9 +4774,9 @@ button, input, textarea, select {
 }
 
 .approval-header-title {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--warning);
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--text-3);
 }
 
 .approval-header-spacer {
@@ -4820,11 +4827,11 @@ button, input, textarea, select {
 }
 
 .chat-approval-row {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px 11px;
-  border-radius: var(--radius-md);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px 12px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
   background: var(--bg-2);
   border: 1px solid var(--wash-08);
   animation: fade-in var(--duration-fast) var(--ease-out) both;
@@ -4834,28 +4841,38 @@ button, input, textarea, select {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 5px;
 }
 
 .approval-row-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+  min-height: 26px;
   min-width: 0;
 }
 
 .approval-row-icon {
   display: inline-flex;
-  color: var(--text-3);
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+  color: var(--warning);
+  background: var(--warning-surface);
   flex-shrink: 0;
 }
 
 .approval-row-summary {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 11.5px;
+  font-weight: 550;
   color: var(--text-1);
-  line-height: 1.35;
+  line-height: 1.4;
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .approval-row-command {
@@ -4886,20 +4903,25 @@ button, input, textarea, select {
 }
 
 .approval-actions {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: center;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 6px;
+  flex-wrap: nowrap;
+  gap: 4px;
 }
 
 /* Spacer between allow-group and deny-group */
 .approval-actions-gap {
-  flex: 1;
+  width: 4px;
+  flex: 0 0 4px;
 }
 
 .approval-btn {
-  padding: 4px 12px;
-  font-size: 11.5px;
+  min-height: 26px;
+  padding: 3px 9px;
+  font-size: 10.5px;
   font-weight: 500;
   border-radius: var(--radius-sm);
   cursor: pointer;
@@ -4935,7 +4957,7 @@ button, input, textarea, select {
 .approval-btn-deny {
   background: transparent;
   color: var(--danger);
-  border-color: var(--danger-border);
+  border-color: transparent;
 }
 
 .approval-btn-deny:hover {
@@ -4953,72 +4975,20 @@ button, input, textarea, select {
   color: var(--text-2);
 }
 
-/* ── Approval Card (in-message) ── */
+@media (max-width: 720px) {
+  .chat-approval-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
 
-.acard {
-  border-radius: var(--radius-sm);
-  background: var(--bg-3);
-  border: 1px solid var(--wash-08);
-  overflow: hidden;
-  margin: 0 16px;
-}
-
-.acard-header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background: var(--warning-surface);
-  border-bottom: 1px solid var(--wash-05);
+  .approval-actions {
+    grid-column: 1;
+    grid-row: auto;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+  }
 }
 
-.acard-header-icon {
-  color: var(--warning);
-  flex-shrink: 0;
-}
-
-.acard-summary {
-  flex: 1;
-  font-size: 12.5px;
-  font-weight: 500;
-  color: var(--text-1);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.acard-type {
-  font-size: 10px;
-  font-family: var(--font-mono);
-  padding: 1px 6px;
-  border-radius: 3px;
-  background: var(--wash-05);
-  color: var(--text-3);
-  flex-shrink: 0;
-}
-
-.acard-decision {
-  font-size: 10.5px;
-  font-weight: 500;
-  padding: 2px 7px;
-  border-radius: 3px;
-  flex-shrink: 0;
-}
-
-/* Decision states as CSS variants instead of JS-computed inline colors */
-.acard-decision--approved {
-  background: var(--success-surface);
-  color: var(--success);
-}
-.acard-decision--denied {
-  background: var(--danger-surface);
-  color: var(--danger);
-}
-.acard-decision--neutral {
-  background: var(--neutral-surface);
-  color: var(--text-2);
-}
+/* ── Approval details (in-message) ── */
 
 .acard-details {
   padding: 8px 12px;

--- a/src/globals.css
+++ b/src/globals.css
@@ -7377,17 +7377,6 @@ button, input, textarea, select {
   box-shadow: 0 0 16px rgba(167, 139, 250, 0.12) !important;
 }
 
-/* Full-autonomy armed ring: same treatment as plan mode, warning tone */
-.chat-input-box-armed {
-  border-color: rgba(var(--warning-rgb), 0.3) !important;
-  box-shadow: 0 0 12px rgba(var(--warning-rgb), 0.08) !important;
-}
-
-.chat-input-box-armed:focus-within {
-  border-color: rgba(var(--warning-rgb), 0.45) !important;
-  box-shadow: 0 0 16px rgba(var(--warning-rgb), 0.12) !important;
-}
-
 .chat-input-box-tool-input {
   border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
   box-shadow: 0 0 0 1px rgba(var(--accent-rgb), 0.08);
@@ -9458,66 +9447,6 @@ button.chat-context-section:hover {
   flex-shrink: 0;
 }
 
-.pp-preset-option[data-tone="warn"].pp-option-selected {
-  background: var(--warning-surface);
-  color: var(--warning);
-  box-shadow: inset 0 0 0 1px var(--warning-border);
-}
-
-.pp-preset-option[data-tone="warn"].pp-option-selected .pp-option-description {
-  color: color-mix(in oklch, var(--warning) 72%, var(--text-3));
-}
-
-.pp-preset-option[data-tone="warn"].pp-option-selected .pp-option-check {
-  color: var(--warning);
-}
-
-.pp-map {
-  margin: 4px 6px 0;
-  border-top: 1px solid var(--wash-06);
-  padding: 8px 4px 4px;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.pp-map-title {
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-3);
-}
-
-.pp-map-rows {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.pp-map-chip {
-  font-family: var(--font-mono);
-  font-size: 9.5px;
-  white-space: nowrap;
-  padding: 1px 6px;
-  border-radius: 99px;
-  border: 1px solid var(--border);
-  color: var(--text-3);
-}
-
-.pp-map-chip-hot {
-  color: var(--warning);
-  border-color: var(--warning-border);
-  background: var(--warning-surface);
-}
-
-.pp-map-note {
-  margin: 0;
-  color: var(--text-3);
-  font-size: 10px;
-  line-height: 1.5;
-}
-
 .pp-preset-footer {
   display: flex;
   align-items: center;
@@ -9565,19 +9494,6 @@ button.chat-context-section:hover {
 .pp-rail-back {
   color: var(--text-3);
   margin-bottom: 4px;
-}
-
-.pp-trigger[data-tone="warn"] {
-  color: var(--warning);
-  background: var(--warning-surface);
-  border-color: var(--warning-border);
-}
-
-.pp-trigger[data-tone="warn"]:hover,
-.pp-trigger[data-tone="warn"].pp-trigger-open {
-  color: var(--warning);
-  background: var(--warning-surface);
-  border-color: var(--warning);
 }
 
 .mp-root {

--- a/src/globals.css
+++ b/src/globals.css
@@ -4410,6 +4410,35 @@ button, input, textarea, select {
   pointer-events: none;
 }
 
+.sb-thread-approval {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 6px;
+  border-radius: 99px;
+  font-size: 9.5px;
+  font-weight: 600;
+  color: var(--warning);
+  background: var(--warning-surface);
+  border: 1px solid var(--warning-border);
+  white-space: nowrap;
+  transition: opacity var(--duration-fast) var(--ease-out);
+}
+
+.sb-thread-approval-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--warning);
+  animation: pulse-soft 1.4s ease-in-out infinite;
+}
+
+.sb-thread:hover .sb-thread-approval,
+.sb-thread:focus-within .sb-thread-approval {
+  opacity: 0;
+  pointer-events: none;
+}
+
 .sb-thread-archive {
   display: flex;
   align-items: center;
@@ -4765,6 +4794,36 @@ button, input, textarea, select {
   border-color: var(--success);
 }
 
+.approval-batch-btn {
+  padding: 2px 8px;
+  font-size: 10.5px;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+  white-space: nowrap;
+}
+
+.approval-batch-btn:hover {
+  color: var(--text-1);
+  background: var(--wash-04);
+  border-color: var(--border-active);
+}
+
+.approval-batch-btn-warn {
+  color: var(--warning);
+  border-color: var(--warning-border);
+}
+
+.approval-batch-btn-warn:hover {
+  color: var(--warning);
+  background: var(--warning-surface);
+  border-color: var(--warning);
+}
+
 .approval-rows {
   display: flex;
   flex-direction: column;
@@ -5099,6 +5158,20 @@ button, input, textarea, select {
   display: flex;
   align-items: center;
   gap: 5px;
+}
+
+.chat-status-armed {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 1px 7px;
+  border-radius: 99px;
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--warning);
+  background: var(--warning-surface);
+  border: 1px solid var(--warning-border);
+  white-space: nowrap;
 }
 
 .chat-status-branch {
@@ -7302,6 +7375,17 @@ button, input, textarea, select {
   box-shadow: 0 0 16px rgba(167, 139, 250, 0.12) !important;
 }
 
+/* Full-autonomy armed ring: same treatment as plan mode, warning tone */
+.chat-input-box-armed {
+  border-color: rgba(var(--warning-rgb), 0.3) !important;
+  box-shadow: 0 0 12px rgba(var(--warning-rgb), 0.08) !important;
+}
+
+.chat-input-box-armed:focus-within {
+  border-color: rgba(var(--warning-rgb), 0.45) !important;
+  box-shadow: 0 0 16px rgba(var(--warning-rgb), 0.12) !important;
+}
+
 .chat-input-box-tool-input {
   border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
   box-shadow: 0 0 0 1px rgba(var(--accent-rgb), 0.08);
@@ -9349,6 +9433,145 @@ button.chat-context-section:hover {
   color: var(--warning);
   font-size: 10px;
   line-height: 1.5;
+}
+
+/* Autonomy preset view */
+.pp-popover-presets {
+  width: 400px;
+  flex-direction: column;
+}
+
+.pp-preset-option {
+  align-items: flex-start;
+  gap: 9px;
+}
+
+.pp-preset-icon {
+  display: inline-flex;
+  margin-top: 1px;
+  flex-shrink: 0;
+}
+
+.pp-preset-option[data-tone="warn"].pp-option-selected {
+  background: var(--warning-surface);
+  color: var(--warning);
+  box-shadow: inset 0 0 0 1px var(--warning-border);
+}
+
+.pp-preset-option[data-tone="warn"].pp-option-selected .pp-option-description {
+  color: color-mix(in oklch, var(--warning) 72%, var(--text-3));
+}
+
+.pp-preset-option[data-tone="warn"].pp-option-selected .pp-option-check {
+  color: var(--warning);
+}
+
+.pp-map {
+  margin: 4px 6px 0;
+  border-top: 1px solid var(--wash-06);
+  padding: 8px 4px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.pp-map-title {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-3);
+}
+
+.pp-map-rows {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.pp-map-chip {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  white-space: nowrap;
+  padding: 1px 6px;
+  border-radius: 99px;
+  border: 1px solid var(--border);
+  color: var(--text-3);
+}
+
+.pp-map-chip-hot {
+  color: var(--warning);
+  border-color: var(--warning-border);
+  background: var(--warning-surface);
+}
+
+.pp-map-note {
+  margin: 0;
+  color: var(--text-3);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.pp-preset-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--wash-06);
+}
+
+.pp-default-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 10.5px;
+  color: var(--text-2);
+  cursor: pointer;
+}
+
+.pp-default-toggle input {
+  accent-color: var(--accent);
+}
+
+.pp-default-toggle-disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.pp-advanced-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  color: var(--text-3);
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.pp-advanced-btn:hover {
+  color: var(--text-1);
+  background: var(--wash-06);
+}
+
+.pp-rail-back {
+  color: var(--text-3);
+  margin-bottom: 4px;
+}
+
+.pp-trigger[data-tone="warn"] {
+  color: var(--warning);
+  background: var(--warning-surface);
+  border-color: var(--warning-border);
+}
+
+.pp-trigger[data-tone="warn"]:hover,
+.pp-trigger[data-tone="warn"].pp-trigger-open {
+  color: var(--warning);
+  background: var(--warning-surface);
+  border-color: var(--warning);
 }
 
 .mp-root {

--- a/src/globals.css
+++ b/src/globals.css
@@ -9666,219 +9666,6 @@ button.chat-context-section:hover {
   overflow: hidden;
 }
 
-.mp-popover-opencode {
-  width: 680px;
-  height: min(430px, calc(100vh - 24px));
-  max-height: calc(100vh - 24px);
-}
-
-/* Left rail — engine selector */
-.mp-rail {
-  display: flex;
-  flex-direction: column;
-  width: 120px;
-  flex-shrink: 0;
-  padding: 8px 0;
-  background: var(--bg-2);
-  border-right: 1px solid var(--border);
-}
-
-.mp-rail-label {
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-3);
-  padding: 4px 12px 8px;
-}
-
-.mp-rail-engine {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  width: calc(100% - 8px);
-  margin: 0 4px;
-  padding: 6px 8px;
-  border: none;
-  border-radius: 4px;
-  background: transparent;
-  color: var(--text-3);
-  font-size: 11px;
-  cursor: pointer;
-  transition: all var(--duration-fast) var(--ease-out);
-}
-
-.mp-rail-engine:hover {
-  background: var(--wash-05);
-  color: var(--text-1);
-}
-
-.mp-rail-engine-active {
-  background: var(--selection-bg);
-  color: var(--selection-fg);
-  box-shadow: inset 0 0 0 1px var(--selection-border);
-}
-
-.mp-rail-engine-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.mp-rail-engine-name {
-  flex: 1;
-  text-align: left;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-weight: 500;
-}
-
-.mp-rail-dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.mp-rail-dot-ok {
-  background: var(--success-indicator);
-  box-shadow: 0 0 0 1px var(--success);
-}
-
-.mp-rail-dot-err {
-  background: var(--danger);
-  animation: pulse-soft 2s ease-in-out infinite;
-}
-
-/* Right panel — model list */
-.mp-models {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.mp-models-header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 10px 14px 8px;
-  border-bottom: 1px solid var(--wash-06);
-}
-
-.mp-models-title {
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-3);
-}
-
-.mp-models-list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 5px;
-}
-
-.mp-provider-tree {
-  display: grid;
-  grid-template-columns: minmax(150px, 0.8fr) minmax(260px, 1.4fr);
-  min-height: 0;
-  flex: 1;
-  overflow: hidden;
-}
-
-.mp-provider-list {
-  min-width: 0;
-  padding: 6px 4px;
-  border-right: 1px solid var(--wash-06);
-  overflow-y: auto;
-  min-height: 0;
-}
-
-.mp-provider-list-heading {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-  margin: -6px -4px 8px;
-  padding: 10px 12px 8px;
-  background: var(--bg-3);
-  border-bottom: 1px solid var(--wash-06);
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-3);
-}
-
-.mp-provider-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  align-items: center;
-  gap: 7px;
-  width: 100%;
-  padding: 7px 8px;
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--text-3);
-  cursor: pointer;
-  text-align: left;
-  transition:
-    background var(--duration-fast) var(--ease-out),
-    border-color var(--duration-fast) var(--ease-out),
-    color var(--duration-fast) var(--ease-out);
-}
-
-.mp-provider-row:hover {
-  background: var(--bg-4);
-  color: var(--text-1);
-}
-
-.mp-provider-row-active {
-  background: var(--selection-bg);
-  color: var(--selection-fg);
-}
-
-.mp-provider-row-selected {
-  border-color: var(--selection-border);
-}
-
-.mp-provider-name {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 11.5px;
-  font-weight: 500;
-}
-
-.mp-provider-count {
-  min-width: 18px;
-  padding: 1px 5px;
-  border-radius: 99px;
-  background: var(--wash-05);
-  color: var(--text-3);
-  font-size: 9.5px;
-  line-height: 1.5;
-  text-align: center;
-}
-
-.mp-provider-chevron {
-  opacity: 0.45;
-}
-
-.mp-provider-models {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  overflow: hidden;
-}
-
 .mp-model-search {
   display: flex;
   align-items: center;
@@ -9921,48 +9708,6 @@ button.chat-context-section:hover {
   color: var(--text-3);
   font-size: 11px;
   text-align: center;
-}
-
-.mp-models-list-provider {
-  min-height: 0;
-  flex: 1;
-}
-
-/* Model row */
-.mp-model {
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  transition:
-    background var(--duration-fast) var(--ease-out),
-    border-color var(--duration-fast) var(--ease-out);
-}
-
-.mp-model + .mp-model {
-  margin-top: 1px;
-}
-
-.mp-model-selected {
-  background: var(--selection-bg);
-  border-color: var(--selection-border);
-}
-
-.mp-model-btn {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  width: 100%;
-  min-height: 30px;
-  padding: 6px 9px;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  cursor: pointer;
-  text-align: left;
-  transition: background var(--duration-fast) var(--ease-out);
-}
-
-.mp-model:not(.mp-model-selected) .mp-model-btn:hover {
-  background: color-mix(in srgb, var(--bg-4) 52%, transparent);
 }
 
 .mp-model-info {
@@ -10046,83 +9791,6 @@ button.chat-context-section:hover {
   flex-shrink: 0;
 }
 
-/* Inline model controls */
-.mp-model-controls {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 4px;
-  min-width: 0;
-  padding: 4px 10px 8px;
-}
-
-.mp-model-controls-label {
-  font-size: 9px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--text-3);
-  flex-shrink: 0;
-}
-
-.mp-model-controls-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  min-width: 0;
-}
-
-.mp-model-option-pills {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(0, 1fr);
-  align-items: center;
-  gap: 2px;
-  width: 100%;
-  background: var(--segmented-bg);
-  border: 1px solid var(--divider);
-  border-radius: 99px;
-  padding: 2px;
-  min-width: 0;
-}
-
-.mp-model-option-pill {
-  min-width: 0;
-  font-size: 9.5px;
-  font-weight: 500;
-  padding: 2px 4px;
-  border-radius: 99px;
-  color: var(--text-3);
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  transition: all var(--duration-fast) var(--ease-out);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.mp-model-option-pill:hover {
-  color: var(--text-2);
-  background: var(--wash-06);
-}
-
-.mp-model-option-pill-active {
-  background: var(--selection-bg);
-  color: var(--selection-fg);
-  box-shadow: inset 0 0 0 1px var(--selection-border);
-}
-
-.mp-model-option-pill-active:hover {
-  background: var(--selection-bg);
-  color: var(--selection-fg);
-}
-
-.mp-model-option-pill:focus-visible {
-  outline: 1px solid var(--focus-ring);
-  outline-offset: 1px;
-}
-
 /* Legacy section toggle */
 .mp-legacy-toggle {
   display: flex;
@@ -10157,6 +9825,331 @@ button.chat-context-section:hover {
 
 .mp-legacy-chevron-open {
   transform: rotate(90deg);
+}
+
+/* Unified runtime picker */
+.mp-trigger-speed {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 5px;
+  border-radius: 99px;
+  background: var(--wash-06);
+  color: var(--text-2);
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.mp-popover {
+  width: min(620px, calc(100vw - 16px));
+  height: auto;
+  max-height: none;
+  align-items: flex-end;
+  gap: 6px;
+  overflow: visible;
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  animation: none;
+}
+
+.mp-runtime-menu {
+  display: flex;
+  flex-direction: column;
+  width: 250px;
+  flex-shrink: 0;
+  gap: 2px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-2);
+  box-shadow: var(--shadow-popover);
+  backdrop-filter: blur(18px);
+  animation: chat-popover-in var(--duration-fast) var(--ease-out) both;
+}
+
+.mp-runtime-row {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr) 12px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 34px;
+  padding: 6px 8px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.mp-runtime-row:hover {
+  background: var(--wash-06);
+  color: var(--text-1);
+}
+
+.mp-runtime-row-active {
+  background: var(--bg-4);
+  color: var(--text-1);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.mp-runtime-row-label {
+  font-weight: 500;
+}
+
+.mp-runtime-row-value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
+  min-width: 0;
+  color: var(--text-3);
+}
+
+.mp-runtime-row-value > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mp-runtime-row-active .mp-runtime-row-value {
+  color: var(--text-2);
+}
+
+.mp-runtime-row-harness-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.mp-runtime-row-chevron {
+  opacity: 0.45;
+}
+
+.mp-runtime-panel {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  max-height: min(420px, calc(100vh - 24px));
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-3);
+  box-shadow: var(--shadow-popover);
+  backdrop-filter: blur(18px);
+  animation: chat-popover-in var(--duration-fast) var(--ease-out) both;
+}
+
+.mp-runtime-panel-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.mp-options {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+  padding: 6px;
+}
+
+.mp-option {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 9px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.mp-option:hover {
+  background: var(--wash-05);
+  color: var(--text-1);
+}
+
+.mp-option-selected {
+  background: var(--selection-bg);
+  border-color: var(--selection-border);
+  color: var(--selection-fg);
+}
+
+.mp-option-with-description {
+  align-items: flex-start;
+  min-height: 48px;
+}
+
+.mp-option-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  flex-shrink: 0;
+}
+
+.mp-option-label {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: inherit;
+  font-size: 11.5px;
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mp-option-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.mp-option-copy .mp-option-label {
+  flex: none;
+}
+
+.mp-option-description {
+  color: var(--text-3);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+
+.mp-option-count {
+  min-width: 22px;
+  padding: 1px 6px;
+  border-radius: 99px;
+  background: var(--wash-06);
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.mp-option-check {
+  flex-shrink: 0;
+  align-self: center;
+  color: var(--accent);
+}
+
+.mp-health-dot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+.mp-health-dot-ok {
+  background: var(--success-indicator);
+}
+
+.mp-health-dot-error {
+  background: var(--danger);
+}
+
+.mp-models-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 6px;
+}
+
+.mp-model {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  min-height: 36px;
+  padding: 7px 9px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-2);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.mp-model:hover {
+  background: var(--wash-05);
+}
+
+.mp-model + .mp-model {
+  margin-top: 2px;
+}
+
+.mp-model-selected,
+.mp-model-selected:hover {
+  background: var(--selection-bg);
+  border-color: var(--selection-border);
+}
+
+.mp-model-info {
+  gap: 3px;
+}
+
+.mp-model-meta {
+  margin-top: 2px;
+}
+
+.mp-model-check {
+  align-self: center;
+}
+
+.mp-trigger:focus-visible,
+.mp-runtime-row:focus-visible,
+.mp-option:focus-visible,
+.mp-model:focus-visible,
+.mp-legacy-toggle:focus-visible {
+  outline: 1px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+@media (max-width: 560px) {
+  .mp-runtime-menu {
+    width: 190px;
+  }
+
+  .mp-runtime-row {
+    grid-template-columns: 66px minmax(0, 1fr) 12px;
+    gap: 5px;
+    padding-inline: 6px;
+    font-size: 11px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mp-runtime-menu,
+  .mp-runtime-panel {
+    animation: none;
+  }
 }
 
 /* ── Workspace Settings Page ── */

--- a/src/globals.css
+++ b/src/globals.css
@@ -9454,6 +9454,12 @@ button.chat-context-section:hover {
   gap: 8px;
   padding: 8px 14px;
   border-top: 1px solid var(--wash-06);
+  flex-shrink: 0;
+}
+
+.pp-preset-footer > * {
+  position: relative;
+  top: -3px;
 }
 
 .pp-default-toggle {

--- a/src/globals.css
+++ b/src/globals.css
@@ -175,10 +175,6 @@
   /* Chat block colors */
   --block-error-bg: rgba(var(--danger-rgb), 0.06);
   --block-error-border: rgba(var(--danger-rgb), 0.16);
-  --block-notice-bg: rgba(87, 182, 255, 0.08);
-  --block-notice-border: rgba(87, 182, 255, 0.18);
-  --block-steer-bg: rgba(var(--accent-rgb), 0.06);
-  --block-steer-border: rgba(var(--accent-rgb), 0.16);
 
   /* Text drawn on top of accent-filled surfaces (buttons, launch chips) */
   --on-accent: var(--brand-mint-950);
@@ -341,10 +337,6 @@
 
   --block-error-bg: rgba(var(--danger-rgb), 0.08);
   --block-error-border: rgba(var(--danger-rgb), 0.22);
-  --block-notice-bg: rgba(0, 110, 184, 0.08);
-  --block-notice-border: rgba(0, 110, 184, 0.20);
-  --block-steer-bg: rgba(var(--accent-rgb), 0.06);
-  --block-steer-border: rgba(var(--accent-rgb), 0.18);
 
   /* Light-theme washes stay close to their named opacity so hover and
      selected states remain visible without turning large rows gray. */
@@ -1032,7 +1024,18 @@ button, input, textarea, select {
     animation: none;
   }
 
-  @keyframes slash-menu-in { from, to { opacity: 1; transform: none; } }
+  @keyframes chat-popover-in { from, to { opacity: 1; transform: none; } }
+
+  .msg-shimmer {
+    animation: none;
+    background: none;
+    color: var(--text-2) !important;
+  }
+
+  .thinking-icon-active,
+  .chat-jump-pill-dot {
+    animation: none;
+  }
 }
 
 @keyframes thinking-pulse {
@@ -1131,19 +1134,70 @@ button, input, textarea, select {
 .prose blockquote { margin: 8px 0; padding: 4px 12px; border-left: 3px solid var(--border-active); color: var(--text-2); }
 .prose hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
 
-/* ── Collapsible block headers ── */
+/* ── Collapsible block headers (shared block grammar) ── */
 .msg-block-header {
-  display: flex; align-items: center; gap: 6px; padding: 6px 12px;
+  display: flex; align-items: center; gap: 6px;
+  min-height: 28px; padding: 2px 12px;
   cursor: pointer; user-select: none;
   border-radius: var(--radius-sm);
 }
+.msg-block-header:hover { background: var(--wash-02); }
 .msg-block-header:hover span { color: var(--text-1) !important; }
+.msg-block-header--static { cursor: default; }
+.msg-block-header--static:hover { background: none; }
+.msg-block-header--static:hover span { color: inherit !important; }
 .msg-block-chevron {
   flex-shrink: 0; color: var(--text-3); opacity: 0.5;
   transition: transform var(--duration-fast) var(--ease-out);
 }
 .msg-block-chevron-open { transform: rotate(90deg); }
-.msg-block-header--compact { padding: 3px 12px; }
+.msg-block-header--compact { padding: 2px 12px; }
+
+.msg-block-tile {
+  width: 18px; height: 18px; flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 5px;
+  background: var(--wash-06);
+  color: var(--text-3);
+}
+.msg-block-tile--violet { background: var(--accent-2-dim); color: var(--accent-2); }
+.msg-block-tile--amber { background: var(--warning-surface); color: var(--warning); }
+
+.msg-block-label {
+  font-size: 11.5px; color: var(--text-2);
+  flex: 1; min-width: 0;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.msg-block-label--mono { font-family: var(--font-mono); font-size: 11px; }
+
+.msg-block-meta {
+  margin-left: auto; flex-shrink: 0;
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 10px; color: var(--text-3);
+  white-space: nowrap;
+}
+
+/* Indented expanded body under a hairline guide */
+.msg-block-body {
+  margin: 2px 12px 4px 20px;
+  padding: 2px 0 4px 13px;
+  border-left: 1px solid var(--divider);
+  min-width: 0;
+}
+
+.msg-shimmer {
+  background: linear-gradient(90deg, var(--text-3) 0%, var(--text-1) 50%, var(--text-3) 100%);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent !important;
+  animation: msg-shimmer-move 2s linear infinite;
+}
+@keyframes msg-shimmer-move {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
 
 /* ── Action Group ── */
 .action-group-body {
@@ -1167,18 +1221,30 @@ button, input, textarea, select {
 
 /* ── Chat Block Shared Styles ── */
 
-.msg-notice-block {
-  margin: 2px 12px 8px; padding: 9px 12px;
-  border-radius: var(--radius-sm);
-  color: var(--text-2); font-size: 12px; line-height: 1.5;
+/* Notices and steers: quiet tile-plus-content rows on the block grammar */
+.msg-notice {
+  margin: 2px 12px 8px;
+  padding: 3px 0;
   display: flex; align-items: flex-start; gap: 8px;
 }
-.msg-notice-block--info {
-  background: var(--block-notice-bg); border: 1px solid var(--block-notice-border);
+.msg-notice > .msg-block-tile { margin-top: 1px; }
+.msg-notice-content {
+  min-width: 0; flex: 1;
+  display: flex; flex-direction: column; gap: 4px;
 }
-.msg-notice-block--steer {
-  background: var(--block-steer-bg); border: 1px solid var(--block-steer-border);
+.msg-notice-title {
+  font-size: 11.5px; font-weight: 550; color: var(--text-1);
+  line-height: 1.4;
 }
+.msg-notice-message {
+  font-size: 12px; color: var(--text-2); line-height: 1.55;
+  max-width: 70ch;
+  white-space: pre-wrap; word-break: break-word;
+}
+.msg-notice--steer .msg-notice-message { color: var(--text-1); font-size: 12.5px; }
+
+.msg-block-tile--info { background: var(--info-surface); color: var(--info); }
+.msg-block-tile--accent { background: var(--accent-dim); color: var(--accent); }
 
 .msg-error-block {
   padding: 10px 14px;
@@ -1197,6 +1263,31 @@ button, input, textarea, select {
   font-family: var(--font-mono);
   white-space: pre-wrap; overflow: auto;
   color: var(--text-2);
+}
+
+/* Titled output well: header row with copy and expand controls */
+.action-output-well-header {
+  display: flex; align-items: center; gap: 8px;
+  padding: 3px 9px;
+  background: var(--code-bg);
+  border-bottom: 1px solid var(--divider);
+  font-family: var(--font-mono);
+  font-size: 9.5px; color: var(--text-3);
+}
+.action-output-well-actions {
+  margin-left: auto;
+  display: inline-flex; gap: 2px;
+}
+.action-output-well-actions button {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 2px 3px; border-radius: 4px;
+  border: none; background: none;
+  color: var(--text-3); cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+.action-output-well-actions button:hover {
+  color: var(--text-1);
+  background: var(--wash-06);
 }
 
 .action-output-error {
@@ -1225,7 +1316,48 @@ button, input, textarea, select {
 }
 .msg-row:hover .msg-row-timestamp,
 .msg-row:focus-within .msg-row-timestamp { opacity: 1; pointer-events: auto; }
-.msg-section-divider { height: 1px; background: var(--border); opacity: 0.4; margin: 4px 12px; }
+
+/* ── User bubble ── */
+.msg-user-bubble {
+  max-width: 75%;
+  padding: 9px 13px;
+  border-radius: 12px 12px 4px 12px;
+  background: var(--bg-3);
+  border: 1px solid var(--border);
+  font-size: 13px; line-height: 1.6;
+  white-space: pre-wrap; word-break: break-word;
+}
+
+/* ── Assistant turn header ── */
+.msg-turn-header {
+  display: flex; align-items: center; gap: 7px;
+  padding: 0 14px 4px 14px;
+  font-size: 10.5px; color: var(--text-3);
+}
+.msg-turn-header-label {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  min-width: 0;
+}
+.msg-turn-actions {
+  margin-left: auto;
+  display: inline-flex; align-items: center; gap: 2px;
+  opacity: 0; transition: opacity var(--duration-fast) var(--ease-out);
+}
+.msg-row:hover .msg-turn-actions,
+.msg-row:focus-within .msg-turn-actions { opacity: 1; }
+.msg-turn-actions button,
+.msg-row-action-btn {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px; border-radius: 4px;
+  border: none; background: none;
+  color: var(--text-3); cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+.msg-turn-actions button:hover,
+.msg-row-action-btn:hover {
+  color: var(--text-1);
+  background: var(--wash-06);
+}
 
 /* ── Tauri window drag area ── */
 .drag-region {
@@ -1757,6 +1889,25 @@ button, input, textarea, select {
   font-size: 11px;
   line-height: 1.7;
   min-height: 19px;
+}
+.git-diff-fold {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 19px;
+  border: none;
+  background: var(--wash-02);
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+.git-diff-fold:hover {
+  background: var(--wash-06);
+  color: var(--text-1);
 }
 .git-diff-gutter {
   width: 18px;
@@ -4566,14 +4717,10 @@ button, input, textarea, select {
   flex-shrink: 0;
 }
 
-/* ── Approval Banner ── */
+/* ── Approval Banner: stacked cards above the composer ── */
 
 .chat-approval-banner {
-  border-radius: var(--radius-sm);
-  background: var(--bg-3);
-  border: 1px solid var(--wash-08);
   padding: 0;
-  overflow: hidden;
   animation: slide-up var(--duration-normal) var(--ease-out) both;
 }
 
@@ -4581,9 +4728,7 @@ button, input, textarea, select {
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 7px 10px;
-  background: var(--warning-surface);
-  border-bottom: 1px solid var(--wash-05);
+  padding: 0 2px 6px;
 }
 
 .approval-header-icon {
@@ -4623,17 +4768,17 @@ button, input, textarea, select {
 .approval-rows {
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  padding: 4px;
+  gap: 6px;
 }
 
 .chat-approval-row {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 8px;
-  border-radius: 4px;
-  background: var(--wash-03);
+  padding: 9px 10px;
+  border-radius: var(--radius-md);
+  background: var(--bg-2);
+  border: 1px solid var(--warning-border);
   animation: fade-in var(--duration-fast) var(--ease-out) both;
 }
 
@@ -4784,6 +4929,20 @@ button, input, textarea, select {
   padding: 2px 7px;
   border-radius: 3px;
   flex-shrink: 0;
+}
+
+/* Decision states as CSS variants instead of JS-computed inline colors */
+.acard-decision--approved {
+  background: var(--success-surface);
+  color: var(--success);
+}
+.acard-decision--denied {
+  background: var(--danger-surface);
+  color: var(--danger);
+}
+.acard-decision--neutral {
+  background: var(--neutral-surface);
+  color: var(--text-2);
 }
 
 .acard-details {
@@ -4965,7 +5124,7 @@ button, input, textarea, select {
 
 .toast-item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   padding: 10px 12px;
   border-radius: var(--radius-md);
@@ -5006,14 +5165,52 @@ button, input, textarea, select {
 
 .toast-icon {
   flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.toast-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.toast-title {
+  font-weight: 600;
+  color: var(--text-1);
 }
 
 .toast-message {
   flex: 1;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  line-height: 1.45;
+}
+
+.toast-content .toast-message {
+  flex: initial;
+  color: var(--text-2);
+  font-size: 12px;
+}
+
+.toast-action {
+  align-self: flex-start;
+  margin-top: 6px;
+  padding: 2px 9px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-active);
+  background: transparent;
+  color: var(--text-2);
+  font-size: 10.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.toast-action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .toast-dismiss {
@@ -7019,6 +7216,20 @@ button, input, textarea, select {
   font-size: 10.5px;
 }
 
+/* Typed reference chips: @-mentions and $skills read differently from files */
+.chat-attachment-chip--mention {
+  background: var(--info-surface);
+  border-color: var(--info-border);
+  color: var(--info);
+}
+.chat-attachment-chip--mention > svg { color: var(--info); }
+.chat-attachment-chip--skill {
+  background: var(--accent-2-dim);
+  border-color: color-mix(in srgb, var(--accent-2) 30%, transparent);
+  color: var(--accent-2);
+}
+.chat-attachment-chip--skill > svg { color: var(--accent-2); }
+
 .chat-attachment-chip-image {
   padding-left: 4px;
   max-width: 260px;
@@ -7091,22 +7302,6 @@ button, input, textarea, select {
   box-shadow: 0 0 16px rgba(167, 139, 250, 0.12) !important;
 }
 
-.chat-plan-mode-banner {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--accent-2);
-  background: var(--accent-2-dim);
-  border-bottom: 1px solid rgba(167, 139, 250, 0.12);
-}
-
-.chat-plan-mode-banner > svg {
-  flex-shrink: 0;
-}
-
 .chat-input-box-tool-input {
   border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
   box-shadow: 0 0 0 1px rgba(var(--accent-rgb), 0.08);
@@ -7114,8 +7309,8 @@ button, input, textarea, select {
 
 .chat-tool-input-panel {
   display: grid;
-  gap: 14px;
-  padding: 16px 18px 14px;
+  gap: 10px;
+  padding: 12px 14px 12px;
   animation: slide-up var(--duration-normal) var(--ease-out) both;
 }
 
@@ -7127,7 +7322,7 @@ button, input, textarea, select {
 }
 
 .chat-tool-input-step-count {
-  font-size: 11px;
+  font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.16em;
   text-transform: uppercase;
@@ -7143,8 +7338,8 @@ button, input, textarea, select {
 }
 
 .chat-tool-input-question {
-  font-size: 15px;
-  line-height: 1.45;
+  font-size: 13px;
+  line-height: 1.5;
   font-weight: 600;
   color: var(--text-1);
 }
@@ -7159,13 +7354,13 @@ button, input, textarea, select {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 14px;
+  padding: 5px 11px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--wash-12);
   background: var(--wash-03);
   color: var(--text-2);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 11.5px;
+  font-weight: 550;
   cursor: pointer;
   transition: border-color var(--duration-fast) var(--ease-out),
               background var(--duration-fast) var(--ease-out),
@@ -7213,12 +7408,12 @@ button, input, textarea, select {
 
 .chat-tool-input-textarea {
   width: 100%;
-  min-height: 84px;
+  min-height: 66px;
   resize: none;
   border: none;
   background: transparent;
   color: var(--text-1);
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.6;
   font-family: inherit;
   outline: none;
@@ -7245,12 +7440,12 @@ button, input, textarea, select {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 34px;
-  padding: 8px 14px;
+  min-height: 28px;
+  padding: 4px 12px;
   border-radius: var(--radius-sm);
   border: 1px solid transparent;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: 11.5px;
+  font-weight: 600;
   font-family: inherit;
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-out),
@@ -7387,6 +7582,173 @@ button, input, textarea, select {
   color: var(--on-accent);
 }
 
+/* ── Composer send / stop (classed variants of the pill system) ── */
+
+.chat-stop-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--danger-border);
+  background: var(--danger-surface);
+  color: var(--danger);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.chat-stop-btn:hover {
+  border-color: var(--danger);
+}
+
+.chat-send-btn {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: var(--bg-4);
+  color: var(--text-3);
+  cursor: default;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.chat-send-btn--ready {
+  background: var(--accent-fill);
+  color: var(--on-accent-icon);
+  cursor: pointer;
+  box-shadow: var(--accent-glow);
+}
+
+.chat-send-btn[aria-busy="true"] {
+  cursor: wait;
+}
+
+/* ── Context ring: context-left next to the send button ── */
+
+.chat-context-ring {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 7px;
+  border-radius: 99px;
+  border: none;
+  background: transparent;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.chat-context-ring:hover {
+  background: var(--wash-06);
+  color: var(--text-1);
+}
+
+.chat-context-ring-track {
+  stroke: var(--wash-08);
+  fill: none;
+}
+
+.chat-context-ring-value {
+  stroke: var(--accent);
+  fill: none;
+  stroke-linecap: round;
+}
+
+.chat-context-ring--warning .chat-context-ring-value { stroke: var(--warning); }
+.chat-context-ring--critical .chat-context-ring-value { stroke: var(--danger); }
+
+/* ── Empty thread state ── */
+
+.chat-empty-tile {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  background: var(--accent-dim);
+  border: 1px solid var(--border-accent);
+  color: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-empty-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+}
+
+.chat-empty-suggestion {
+  padding: 5px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-active);
+  background: transparent;
+  color: var(--text-2);
+  font-size: 11.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.chat-empty-suggestion:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-dim);
+}
+
+.chat-empty-kbd {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  padding: 1px 4px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  color: var(--text-3);
+}
+
+/* ── Jump-to-latest pill ── */
+
+.chat-jump-pill {
+  position: sticky;
+  left: 100%;
+  bottom: 10px;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 99px;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--text-2);
+  font-size: 11.5px;
+  cursor: pointer;
+  box-shadow: var(--shadow-popover);
+  z-index: 2;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.chat-jump-pill--activity {
+  border-color: var(--info-border);
+  background: var(--info-surface);
+  color: var(--info);
+}
+
+.chat-jump-pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--info);
+  animation: pulse-soft 1.5s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
 .oc-agent-root {
   position: relative;
   display: inline-flex;
@@ -7439,11 +7801,6 @@ button, input, textarea, select {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-3);
-  box-shadow: var(--shadow-popover);
-  animation: mp-enter 150ms var(--ease-out) both;
 }
 
 .oc-agent-header {
@@ -7520,11 +7877,6 @@ button, input, textarea, select {
 .codex-config-popover {
   width: min(420px, calc(100vw - 16px));
   padding: 12px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: var(--bg-3);
-  box-shadow: var(--shadow-popover);
-  backdrop-filter: blur(18px);
 }
 
 .codex-config-header {
@@ -7645,6 +7997,24 @@ button, input, textarea, select {
   white-space: nowrap;
 }
 
+/* Usage segments are buttons that open the usage limits view */
+button.chat-context-section {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 1px 5px;
+  margin: -1px -5px;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+button.chat-context-section:hover {
+  background: var(--wash-06);
+  color: var(--text-1);
+}
+
 .chat-context-section > svg {
   flex-shrink: 0;
   opacity: 0.6;
@@ -7740,21 +8110,30 @@ button, input, textarea, select {
 
 /* ── Slash Command Menu ── */
 
-.slash-menu {
-  padding: 5px;
+/* ── Popover primitive: one chrome spec for every chat popover ── */
+.chat-popover,
+.slash-menu,
+.pp-popover,
+.mp-popover,
+.oc-agent-popover,
+.codex-config-popover {
   border-radius: 12px;
   border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg-2) 80%, var(--bg-1));
+  background: var(--bg-3);
   box-shadow: var(--shadow-popover);
   backdrop-filter: blur(18px);
-  overflow-y: auto;
-  max-height: 300px;
-  animation: slash-menu-in var(--duration-normal) var(--ease-out) both;
+  animation: chat-popover-in var(--duration-fast) var(--ease-out) both;
 }
 
-@keyframes slash-menu-in {
+@keyframes chat-popover-in {
   from { opacity: 0; transform: translateY(6px) scale(0.97); }
   to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.slash-menu {
+  padding: 5px;
+  overflow-y: auto;
+  max-height: 300px;
 }
 
 .slash-menu-item {
@@ -8692,28 +9071,12 @@ button, input, textarea, select {
   transform: rotate(180deg);
 }
 
-@keyframes pp-enter {
-  from {
-    opacity: 0;
-    transform: translateY(6px) scale(0.97);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
 .pp-popover {
   z-index: 9999;
   display: flex;
   width: 440px;
   max-height: 360px;
-  border-radius: var(--radius-lg);
-  background: var(--bg-3);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-popover);
   overflow: hidden;
-  animation: pp-enter 150ms var(--ease-out) both;
 }
 
 .pp-header-badge {
@@ -8998,29 +9361,13 @@ button, input, textarea, select {
 }
 
 /* Popover — two-panel floating card */
-@keyframes mp-enter {
-  from {
-    opacity: 0;
-    transform: translateY(6px) scale(0.97);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
 .mp-popover {
   z-index: 9999;
   display: flex;
   width: 440px;
   max-width: calc(100vw - 16px);
   max-height: 380px;
-  border-radius: var(--radius-lg);
-  background: var(--bg-3);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-popover);
   overflow: hidden;
-  animation: mp-enter 150ms var(--ease-out) both;
 }
 
 .mp-popover-opencode {
@@ -9132,10 +9479,6 @@ button, input, textarea, select {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-3);
-}
-
-.mp-models-count {
-  display: none;
 }
 
 .mp-models-list {

--- a/src/i18n/resources/en/app.json
+++ b/src/i18n/resources/en/app.json
@@ -384,6 +384,17 @@
     "detectedCount": "{{installed}} of {{total}} tools detected",
     "loading": "Detecting installed harnesses...",
     "footerHint": "Installed harnesses appear as quick-launch options in your terminal + button",
+    "launchSettings": {
+      "title": "Launch options",
+      "description": "Flags appended whenever {{name}} opens in a terminal",
+      "argsLabel": "Additional flags",
+      "argsPlaceholder": "--flag",
+      "preview": "Launch command",
+      "save": "Save",
+      "cancel": "Cancel",
+      "saved": "Launch options saved",
+      "saveFailed": "Failed to save launch options"
+    },
     "descriptions": {
       "codex": "OpenAI's coding agent CLI, integrated natively with Panes chat and terminal workflows",
       "claude-code": "Anthropic's coding CLI, integrated natively with Panes for repo-aware and terminal-driven workflows",

--- a/src/i18n/resources/en/app.json
+++ b/src/i18n/resources/en/app.json
@@ -40,6 +40,7 @@
     "workspaceFallback": "Workspace",
     "noThreads": "No threads",
     "untitledThread": "Untitled thread",
+    "needsApproval": "Needs approval",
     "archiveThread": "Archive thread",
     "showMore": "Show {{count}} more",
     "archived": "Archived",

--- a/src/i18n/resources/en/app.json
+++ b/src/i18n/resources/en/app.json
@@ -394,7 +394,7 @@
       "save": "Save",
       "cancel": "Cancel",
       "saved": "Launch options saved",
-      "saveFailed": "Failed to save launch options"
+      "saveFailed": "Could not save. Use only letters, numbers, spaces, and - _ . / : = , +"
     },
     "descriptions": {
       "codex": "OpenAI's coding agent CLI, integrated natively with Panes chat and terminal workflows",

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -314,7 +314,7 @@
     "custom": "Custom",
     "presets": {
       "inherit": { "label": "Auto", "description": "Follow the repo trust policy." },
-      "read-only": { "label": "Read only", "description": "Inspect and answer. Every write or command asks." },
+      "read-only": { "label": "Read only", "description": "Inspect and answer. Safe reads run; nothing changes without your approval." },
       "ask": { "label": "Ask to act", "description": "Reads are free. Edits and commands ask first." },
       "auto": { "label": "Auto in workspace", "description": "Works freely inside the workspace sandbox. Asks only to leave it." },
       "full": { "label": "Full autonomy", "description": "Never asks. Full disk and network access." }
@@ -322,6 +322,7 @@
     "mapsTo": "Maps to {{engine}}",
     "claudeFullNote": "Claude has no full-access sandbox in Panes; full autonomy keeps workspace write.",
     "openCodeNote": "OpenCode exposes approvals only; sandbox and network are not configurable.",
+    "codexExternalSandboxNote": "Codex is running in external sandbox mode; Panes cannot restrict the filesystem here, so approvals gate changes instead.",
     "defaultForNewThreads": "Default for new threads",
     "advanced": "Advanced",
     "backToPresets": "Presets",

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -325,7 +325,6 @@
     "defaultForNewThreads": "Default for new threads",
     "advanced": "Advanced",
     "backToPresets": "Presets",
-    "armedStatus": "Full autonomy: never asks, full disk and network",
     "allowAll": "Allow all",
     "allowAllStopAsking": "Allow all & stop asking",
     "approvalToastTitle": "{{engine}} needs approval",

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -341,6 +341,27 @@
       "auto": { "label": "Auto in workspace", "description": "Works freely inside the workspace sandbox. Asks only to leave it." },
       "full": { "label": "Full autonomy", "description": "Never asks. Full disk and network access." }
     },
+    "engineDescriptions": {
+      "opencode": {
+        "inherit": "Follow the repo trust defaults for OpenCode.",
+        "read-only": "Block OpenCode tools. The agent can still answer without tools.",
+        "ask": "Ask before OpenCode runs a tool.",
+        "auto": "Allow OpenCode tools without approval. Panes does not add a filesystem or network sandbox.",
+        "full": "Allow OpenCode tools without approval. Panes does not add a filesystem or network sandbox."
+      },
+      "claude": {
+        "inherit": "Follow the repo trust defaults for Claude.",
+        "read-only": "Use restricted approvals with read-only files and no network.",
+        "ask": "Use standard approvals with workspace writes and no network.",
+        "auto": "Use trusted approvals and workspace writes. Network follows repo trust.",
+        "full": "Use trusted approvals with workspace writes and network enabled."
+      },
+      "codexExternal": {
+        "read-only": "Use untrusted approvals and block network. The external sandbox controls filesystem access.",
+        "ask": "Use on-request approvals and block network. The external sandbox controls filesystem access.",
+        "auto": "Use on-failure approvals with network enabled. The external sandbox controls filesystem access."
+      }
+    },
     "defaultForNewThreads": "Default for new threads",
     "advanced": "Advanced",
     "backToPresets": "Presets",

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -316,7 +316,6 @@
     "workspaceChatTitle": "Workspace Chat",
     "repoChatTitle": "{{name}} Chat",
     "renameThread": "Click to rename thread",
-    "approvalBannerTitle": "Pending approvals",
     "respondInCard": "Respond in the approval card below.",
     "respondInCustomCard": "This request requires custom JSON. Respond in the approval card below.",
     "claudeApprovalUnsupported": "This Claude approval type is not supported in Panes yet.",
@@ -416,8 +415,20 @@
       "planImplementationThreadUnavailable": "The original planning thread is no longer available. Reopen the thread and try again.",
       "invalidOutputSchema": "Output schema must be valid JSON Schema object or boolean: {{error}}",
       "invalidCustomApprovalPolicy": "Structured approval policy must be a JSON object.",
-      "invalidCustomApprovalPolicyWithError": "Structured approval policy is invalid JSON: {{error}}"
-    }
+      "invalidCustomApprovalPolicyWithError": "Structured approval policy is invalid JSON: {{error}}",
+      "fastToggleFailed": "Couldn't change the service tier",
+      "retry": "Retry"
+    },
+    "approvalBannerTitleCount_one": "{{count}} pending approval",
+    "approvalBannerTitleCount_other": "{{count}} pending approvals",
+    "editResend": "Edit and resend",
+    "attachShort": "Attach",
+    "emptyScopeRepo": "Messages run against {{repo}}",
+    "emptyScopeRepoBranch": "Messages run against {{repo}} on branch {{branch}}",
+    "emptySuggestionSummarize": "Summarize recent changes",
+    "emptySuggestionTests": "Fix the failing test",
+    "emptyHintCommands": "commands",
+    "emptyHintSlash": "slash actions"
   },
   "messageBlocks": {
     "diffFallback": "diff ({{scope}})",
@@ -425,7 +436,6 @@
     "parsingDiff": "Parsing diff...",
     "noChanges": "No changes",
     "thinking": "Thinking",
-    "thinkingDone": "Thought for {{seconds}}s",
     "actionStatus": {
       "done": "Done",
       "running": "Running",
@@ -440,19 +450,27 @@
     },
     "outputTruncated": "Showing latest action output only (older chunks truncated for performance).",
     "actionGroup": {
-      "summary_one": "{{count}} action completed",
-      "summary_other": "{{count}} actions completed",
+      "summary_one": "{{count}} action",
+      "summary_other": "{{count}} actions",
       "errorCount_one": "{{count}} error",
       "errorCount_other": "{{count}} errors",
       "types": {
-        "command": "cmd",
-        "file_read": "read",
-        "file_write": "write",
-        "file_edit": "edit",
-        "file_delete": "del",
-        "git": "git",
-        "search": "search",
-        "other": "other"
+        "command_one": "{{count}} command",
+        "command_other": "{{count}} commands",
+        "file_read_one": "{{count}} read",
+        "file_read_other": "{{count}} reads",
+        "file_write_one": "{{count}} write",
+        "file_write_other": "{{count}} writes",
+        "file_edit_one": "{{count}} edit",
+        "file_edit_other": "{{count}} edits",
+        "file_delete_one": "{{count}} delete",
+        "file_delete_other": "{{count}} deletes",
+        "git_one": "{{count}} git",
+        "git_other": "{{count}} git",
+        "search_one": "{{count}} search",
+        "search_other": "{{count}} searches",
+        "other_one": "{{count}} other",
+        "other_other": "{{count}} other"
       }
     },
     "approval": {
@@ -497,7 +515,14 @@
       "nextQuestion": "Next question",
       "otherAnswerPlaceholder": "Other answer (optional)",
       "sendAnswers": "Send answers"
-    }
+    },
+    "thought": "Thought",
+    "thinkingDuration": "{{seconds}}s",
+    "output": "output",
+    "copyOutput": "Copy output",
+    "expandOutput": "Expand output",
+    "collapseOutput": "Collapse output",
+    "openInEditor": "Open in editor"
   },
   "status": {
     "now": "now",
@@ -513,7 +538,9 @@
     "resets": "resets {{time}}",
     "usageAwaitingFirstMessage": "Send a message to load usage limits",
     "usageLoading": "Loading usage limits...",
-    "usageUnavailable": "Usage limits unavailable from server"
+    "usageUnavailable": "Usage limits unavailable from server",
+    "openUsageLimits": "Open usage limits",
+    "contextRingTitle": "Context left: {{percent}}. Open usage limits."
   },
   "slashCommands": {
     "panels": {

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -433,6 +433,7 @@
       "claudeSandboxUnsupported": "Claude supports only read-only and workspace-write sandbox modes.",
       "fullAccessNetworkWarning": "Full access sandbox temporarily enables network access.",
       "updateExecutionPolicyFailed": "Failed to update thread execution policy: {{error}}",
+      "approvalBatchFailed": "One or more approvals could not be accepted. The thread policy was not changed.",
       "updateCodexConfigFailed": "Failed to update Codex turn config: {{error}}",
       "updateOpenCodeConfigFailed": "Failed to update OpenCode turn config: {{error}}",
       "planImplementationThreadUnavailable": "The original planning thread is no longer available. Reopen the thread and try again.",

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -11,6 +11,14 @@
   },
   "modelPicker": {
     "selectModel": "Select model",
+    "runtimeConfiguration": "Runtime configuration",
+    "harness": "Harness",
+    "provider": "Provider",
+    "model": "Model",
+    "reasoning": "Reasoning",
+    "speed": "Speed",
+    "available": "Available",
+    "unavailable": "Unavailable",
     "engine": "Engine",
     "models": "Models",
     "providers": "Providers",
@@ -22,6 +30,20 @@
     "fastOn": "Fast",
     "supportsPersonality": "Personality",
     "upgradeAvailable": "Upgrade available: {{model}}",
+    "speedOptions": {
+      "standard": {
+        "label": "Standard",
+        "description": "Use the default service tier."
+      },
+      "fast": {
+        "label": "Fast",
+        "description": "Prioritize lower latency."
+      },
+      "flex": {
+        "label": "Flex",
+        "description": "Use flex capacity when available."
+      }
+    },
     "modalities": {
       "image": "Vision",
       "textOnly": "Text only"
@@ -440,7 +462,7 @@
       "invalidOutputSchema": "Output schema must be valid JSON Schema object or boolean: {{error}}",
       "invalidCustomApprovalPolicy": "Structured approval policy must be a JSON object.",
       "invalidCustomApprovalPolicyWithError": "Structured approval policy is invalid JSON: {{error}}",
-      "fastToggleFailed": "Couldn't change the service tier",
+      "speedChangeFailed": "Couldn't change the service tier",
       "retry": "Retry"
     },
     "approvalBannerTitleCount_one": "{{count}} pending approval",

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -309,6 +309,29 @@
     "openCodeDenyDescription": "Deny OpenCode tool permissions for this thread.",
     "permissionPolicyFallback": "Permission policy"
   },
+  "autonomy": {
+    "sectionTitle": "Autonomy",
+    "custom": "Custom",
+    "presets": {
+      "inherit": { "label": "Auto", "description": "Follow the repo trust policy." },
+      "read-only": { "label": "Read only", "description": "Inspect and answer. Every write or command asks." },
+      "ask": { "label": "Ask to act", "description": "Reads are free. Edits and commands ask first." },
+      "auto": { "label": "Auto in workspace", "description": "Works freely inside the workspace sandbox. Asks only to leave it." },
+      "full": { "label": "Full autonomy", "description": "Never asks. Full disk and network access." }
+    },
+    "mapsTo": "Maps to {{engine}}",
+    "claudeFullNote": "Claude has no full-access sandbox in Panes; full autonomy keeps workspace write.",
+    "openCodeNote": "OpenCode exposes approvals only; sandbox and network are not configurable.",
+    "defaultForNewThreads": "Default for new threads",
+    "advanced": "Advanced",
+    "backToPresets": "Presets",
+    "armedStatus": "Full autonomy: never asks, full disk and network",
+    "allowAll": "Allow all",
+    "allowAllStopAsking": "Allow all & stop asking",
+    "approvalToastTitle": "{{engine}} needs approval",
+    "openThread": "Open thread",
+    "defaultSaveFailed": "Failed to save the default autonomy: {{error}}"
+  },
   "panel": {
     "assistantFallback": "Assistant",
     "emptyHint": "Open a folder and send a message to begin",

--- a/src/i18n/resources/en/chat.json
+++ b/src/i18n/resources/en/chat.json
@@ -341,10 +341,6 @@
       "auto": { "label": "Auto in workspace", "description": "Works freely inside the workspace sandbox. Asks only to leave it." },
       "full": { "label": "Full autonomy", "description": "Never asks. Full disk and network access." }
     },
-    "mapsTo": "Maps to {{engine}}",
-    "claudeFullNote": "Claude has no full-access sandbox in Panes; full autonomy keeps workspace write.",
-    "openCodeNote": "OpenCode exposes approvals only; sandbox and network are not configurable.",
-    "codexExternalSandboxNote": "Codex is running in external sandbox mode; Panes cannot restrict the filesystem here, so approvals gate changes instead.",
     "defaultForNewThreads": "Default for new threads",
     "advanced": "Advanced",
     "backToPresets": "Presets",

--- a/src/i18n/resources/en/common.json
+++ b/src/i18n/resources/en/common.json
@@ -24,5 +24,9 @@
   },
   "labels": {
     "settings": "Settings"
+  },
+  "diff": {
+    "unchangedLines_one": "{{count}} unchanged line",
+    "unchangedLines_other": "{{count}} unchanged lines"
   }
 }

--- a/src/i18n/resources/pt-BR/app.json
+++ b/src/i18n/resources/pt-BR/app.json
@@ -394,7 +394,7 @@
       "save": "Salvar",
       "cancel": "Cancelar",
       "saved": "Opções de abertura salvas",
-      "saveFailed": "Falha ao salvar as opções de abertura"
+      "saveFailed": "Não foi possível salvar. Use apenas letras, números, espaços e - _ . / : = , +"
     },
     "descriptions": {
       "codex": "CLI de coding agent da OpenAI, integrado nativamente ao chat e aos fluxos de terminal do Panes",

--- a/src/i18n/resources/pt-BR/app.json
+++ b/src/i18n/resources/pt-BR/app.json
@@ -384,6 +384,17 @@
     "detectedCount": "{{installed}} de {{total}} ferramentas detectadas",
     "loading": "Detectando harnesses instalados...",
     "footerHint": "Harnesses instalados aparecem como opções de abertura rápida no botão + do terminal",
+    "launchSettings": {
+      "title": "Opções de abertura",
+      "description": "Flags adicionadas sempre que {{name}} abre em um terminal",
+      "argsLabel": "Flags adicionais",
+      "argsPlaceholder": "--flag",
+      "preview": "Comando de abertura",
+      "save": "Salvar",
+      "cancel": "Cancelar",
+      "saved": "Opções de abertura salvas",
+      "saveFailed": "Falha ao salvar as opções de abertura"
+    },
     "descriptions": {
       "codex": "CLI de coding agent da OpenAI, integrado nativamente ao chat e aos fluxos de terminal do Panes",
       "claude-code": "CLI de coding da Anthropic, integrada nativamente ao Panes para fluxos em repo e no terminal",

--- a/src/i18n/resources/pt-BR/app.json
+++ b/src/i18n/resources/pt-BR/app.json
@@ -40,6 +40,7 @@
     "workspaceFallback": "Workspace",
     "noThreads": "Nenhuma thread",
     "untitledThread": "Thread sem título",
+    "needsApproval": "Precisa de aprovação",
     "archiveThread": "Arquivar thread",
     "showMore": "Mostrar mais {{count}}",
     "archived": "Arquivados",

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -341,6 +341,27 @@
       "auto": { "label": "Autônomo no workspace", "description": "Trabalha livre dentro do sandbox do workspace. Só pede para sair dele." },
       "full": { "label": "Autonomia total", "description": "Nunca pergunta. Acesso total a disco e rede." }
     },
+    "engineDescriptions": {
+      "opencode": {
+        "inherit": "Segue os padrões de confiança do repo para o OpenCode.",
+        "read-only": "Bloqueia as ferramentas do OpenCode. O agente ainda pode responder sem ferramentas.",
+        "ask": "Pede aprovação antes de o OpenCode executar uma ferramenta.",
+        "auto": "Permite ferramentas do OpenCode sem aprovação. O Panes não adiciona sandbox de arquivos ou rede.",
+        "full": "Permite ferramentas do OpenCode sem aprovação. O Panes não adiciona sandbox de arquivos ou rede."
+      },
+      "claude": {
+        "inherit": "Segue os padrões de confiança do repo para o Claude.",
+        "read-only": "Usa aprovações restritas com arquivos somente leitura e sem rede.",
+        "ask": "Usa aprovações padrão com escrita no workspace e sem rede.",
+        "auto": "Usa aprovações confiáveis e escrita no workspace. A rede segue a confiança do repo.",
+        "full": "Usa aprovações confiáveis com escrita no workspace e rede habilitada."
+      },
+      "codexExternal": {
+        "read-only": "Usa aprovações não confiáveis e bloqueia a rede. O sandbox externo controla o acesso aos arquivos.",
+        "ask": "Usa aprovações sob demanda e bloqueia a rede. O sandbox externo controla o acesso aos arquivos.",
+        "auto": "Usa aprovações ao falhar com rede habilitada. O sandbox externo controla o acesso aos arquivos."
+      }
+    },
     "defaultForNewThreads": "Padrão para novas conversas",
     "advanced": "Avançado",
     "backToPresets": "Presets",

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -314,7 +314,7 @@
     "custom": "Personalizado",
     "presets": {
       "inherit": { "label": "Automático", "description": "Segue a política de confiança do repo." },
-      "read-only": { "label": "Somente leitura", "description": "Inspeciona e responde. Toda escrita ou comando pede aprovação." },
+      "read-only": { "label": "Somente leitura", "description": "Inspeciona e responde. Leituras seguras rodam; nada muda sem a sua aprovação." },
       "ask": { "label": "Pedir para agir", "description": "Leituras são livres. Edições e comandos pedem antes." },
       "auto": { "label": "Autônomo no workspace", "description": "Trabalha livre dentro do sandbox do workspace. Só pede para sair dele." },
       "full": { "label": "Autonomia total", "description": "Nunca pergunta. Acesso total a disco e rede." }
@@ -322,6 +322,7 @@
     "mapsTo": "Mapeamento para {{engine}}",
     "claudeFullNote": "O Claude não tem sandbox de acesso total no Panes; autonomia total mantém workspace-write.",
     "openCodeNote": "O OpenCode expõe apenas aprovações; sandbox e rede não são configuráveis.",
+    "codexExternalSandboxNote": "O Codex está em modo de sandbox externo; o Panes não consegue restringir o filesystem aqui, então as aprovações controlam as mudanças.",
     "defaultForNewThreads": "Padrão para novas conversas",
     "advanced": "Avançado",
     "backToPresets": "Presets",

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -316,7 +316,6 @@
     "workspaceChatTitle": "Chat do workspace",
     "repoChatTitle": "Chat de {{name}}",
     "renameThread": "Clique para renomear a thread",
-    "approvalBannerTitle": "Aprovações pendentes",
     "respondInCard": "Responda no card de aprovação abaixo.",
     "respondInCustomCard": "Esta solicitação exige JSON personalizado. Responda no card de aprovação abaixo.",
     "claudeApprovalUnsupported": "Esse tipo de approval do Claude ainda não é suportado no Panes.",
@@ -416,8 +415,20 @@
       "planImplementationThreadUnavailable": "A thread original de planejamento não está mais disponível. Reabra a thread e tente novamente.",
       "invalidOutputSchema": "O schema de saída deve ser um objeto ou booleano JSON Schema válido: {{error}}",
       "invalidCustomApprovalPolicy": "A política de aprovação estruturada deve ser um objeto JSON.",
-      "invalidCustomApprovalPolicyWithError": "A política de aprovação estruturada contém JSON inválido: {{error}}"
-    }
+      "invalidCustomApprovalPolicyWithError": "A política de aprovação estruturada contém JSON inválido: {{error}}",
+      "fastToggleFailed": "Não foi possível alterar o nível de serviço",
+      "retry": "Tentar novamente"
+    },
+    "approvalBannerTitleCount_one": "{{count}} aprovação pendente",
+    "approvalBannerTitleCount_other": "{{count}} aprovações pendentes",
+    "editResend": "Editar e reenviar",
+    "attachShort": "Anexar",
+    "emptyScopeRepo": "As mensagens rodam em {{repo}}",
+    "emptyScopeRepoBranch": "As mensagens rodam em {{repo}} no branch {{branch}}",
+    "emptySuggestionSummarize": "Resumir as mudanças recentes",
+    "emptySuggestionTests": "Corrigir o teste que está falhando",
+    "emptyHintCommands": "comandos",
+    "emptyHintSlash": "ações de barra"
   },
   "messageBlocks": {
     "diffFallback": "diff ({{scope}})",
@@ -425,7 +436,6 @@
     "parsingDiff": "Analisando diff...",
     "noChanges": "Sem alterações",
     "thinking": "Raciocínio",
-    "thinkingDone": "Pensou por {{seconds}}s",
     "actionStatus": {
       "done": "Concluído",
       "running": "Em andamento",
@@ -440,19 +450,27 @@
     },
     "outputTruncated": "Mostrando apenas a saída mais recente da ação (blocos anteriores truncados por desempenho).",
     "actionGroup": {
-      "summary_one": "{{count}} ação concluída",
-      "summary_other": "{{count}} ações concluídas",
+      "summary_one": "{{count}} ação",
+      "summary_other": "{{count}} ações",
       "errorCount_one": "{{count}} erro",
       "errorCount_other": "{{count}} erros",
       "types": {
-        "command": "cmd",
-        "file_read": "leitura",
-        "file_write": "escrita",
-        "file_edit": "edição",
-        "file_delete": "excl.",
-        "git": "git",
-        "search": "busca",
-        "other": "outro"
+        "command_one": "{{count}} comando",
+        "command_other": "{{count}} comandos",
+        "file_read_one": "{{count}} leitura",
+        "file_read_other": "{{count}} leituras",
+        "file_write_one": "{{count}} escrita",
+        "file_write_other": "{{count}} escritas",
+        "file_edit_one": "{{count}} edição",
+        "file_edit_other": "{{count}} edições",
+        "file_delete_one": "{{count}} exclusão",
+        "file_delete_other": "{{count}} exclusões",
+        "git_one": "{{count}} git",
+        "git_other": "{{count}} git",
+        "search_one": "{{count}} busca",
+        "search_other": "{{count}} buscas",
+        "other_one": "{{count}} outro",
+        "other_other": "{{count}} outros"
       }
     },
     "approval": {
@@ -497,7 +515,14 @@
       "nextQuestion": "Próxima pergunta",
       "otherAnswerPlaceholder": "Outra resposta (opcional)",
       "sendAnswers": "Enviar respostas"
-    }
+    },
+    "thought": "Pensou",
+    "thinkingDuration": "{{seconds}}s",
+    "output": "saída",
+    "copyOutput": "Copiar saída",
+    "expandOutput": "Expandir saída",
+    "collapseOutput": "Recolher saída",
+    "openInEditor": "Abrir no editor"
   },
   "status": {
     "now": "agora",
@@ -513,7 +538,9 @@
     "resets": "reinicia {{time}}",
     "usageAwaitingFirstMessage": "Envie uma mensagem para carregar os limites de uso",
     "usageLoading": "Carregando limites de uso...",
-    "usageUnavailable": "Limites de uso indisponíveis no servidor"
+    "usageUnavailable": "Limites de uso indisponíveis no servidor",
+    "openUsageLimits": "Abrir limites de uso",
+    "contextRingTitle": "Contexto restante: {{percent}}. Abrir limites de uso."
   },
   "slashCommands": {
     "panels": {

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -309,6 +309,29 @@
     "openCodeDenyDescription": "Nega permissões de ferramenta do OpenCode para esta thread.",
     "permissionPolicyFallback": "Política de permissão"
   },
+  "autonomy": {
+    "sectionTitle": "Autonomia",
+    "custom": "Personalizado",
+    "presets": {
+      "inherit": { "label": "Automático", "description": "Segue a política de confiança do repo." },
+      "read-only": { "label": "Somente leitura", "description": "Inspeciona e responde. Toda escrita ou comando pede aprovação." },
+      "ask": { "label": "Pedir para agir", "description": "Leituras são livres. Edições e comandos pedem antes." },
+      "auto": { "label": "Autônomo no workspace", "description": "Trabalha livre dentro do sandbox do workspace. Só pede para sair dele." },
+      "full": { "label": "Autonomia total", "description": "Nunca pergunta. Acesso total a disco e rede." }
+    },
+    "mapsTo": "Mapeamento para {{engine}}",
+    "claudeFullNote": "O Claude não tem sandbox de acesso total no Panes; autonomia total mantém workspace-write.",
+    "openCodeNote": "O OpenCode expõe apenas aprovações; sandbox e rede não são configuráveis.",
+    "defaultForNewThreads": "Padrão para novas conversas",
+    "advanced": "Avançado",
+    "backToPresets": "Presets",
+    "armedStatus": "Autonomia total: nunca pergunta, disco e rede completos",
+    "allowAll": "Permitir tudo",
+    "allowAllStopAsking": "Permitir tudo e parar de perguntar",
+    "approvalToastTitle": "{{engine}} precisa de aprovação",
+    "openThread": "Abrir conversa",
+    "defaultSaveFailed": "Falha ao salvar a autonomia padrão: {{error}}"
+  },
   "panel": {
     "assistantFallback": "Assistente",
     "emptyHint": "Abra uma pasta e envie uma mensagem para começar",

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -11,6 +11,14 @@
   },
   "modelPicker": {
     "selectModel": "Selecionar modelo",
+    "runtimeConfiguration": "Configuração de runtime",
+    "harness": "Harness",
+    "provider": "Provedor",
+    "model": "Modelo",
+    "reasoning": "Raciocínio",
+    "speed": "Velocidade",
+    "available": "Disponível",
+    "unavailable": "Indisponível",
     "engine": "Engine",
     "models": "Modelos",
     "providers": "Provedores",
@@ -22,6 +30,20 @@
     "fastOn": "Fast",
     "supportsPersonality": "Personalidade",
     "upgradeAvailable": "Upgrade disponível: {{model}}",
+    "speedOptions": {
+      "standard": {
+        "label": "Padrão",
+        "description": "Usa a camada de serviço padrão."
+      },
+      "fast": {
+        "label": "Fast",
+        "description": "Prioriza menor latência."
+      },
+      "flex": {
+        "label": "Flex",
+        "description": "Usa capacidade flex quando disponível."
+      }
+    },
     "modalities": {
       "image": "Visão",
       "textOnly": "Só texto"
@@ -440,7 +462,7 @@
       "invalidOutputSchema": "O schema de saída deve ser um objeto ou booleano JSON Schema válido: {{error}}",
       "invalidCustomApprovalPolicy": "A política de aprovação estruturada deve ser um objeto JSON.",
       "invalidCustomApprovalPolicyWithError": "A política de aprovação estruturada contém JSON inválido: {{error}}",
-      "fastToggleFailed": "Não foi possível alterar o nível de serviço",
+      "speedChangeFailed": "Não foi possível alterar o nível de serviço",
       "retry": "Tentar novamente"
     },
     "approvalBannerTitleCount_one": "{{count}} aprovação pendente",

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -341,10 +341,6 @@
       "auto": { "label": "Autônomo no workspace", "description": "Trabalha livre dentro do sandbox do workspace. Só pede para sair dele." },
       "full": { "label": "Autonomia total", "description": "Nunca pergunta. Acesso total a disco e rede." }
     },
-    "mapsTo": "Mapeamento para {{engine}}",
-    "claudeFullNote": "O Claude não tem sandbox de acesso total no Panes; autonomia total mantém workspace-write.",
-    "openCodeNote": "O OpenCode expõe apenas aprovações; sandbox e rede não são configuráveis.",
-    "codexExternalSandboxNote": "O Codex está em modo de sandbox externo; o Panes não consegue restringir o filesystem aqui, então as aprovações controlam as mudanças.",
     "defaultForNewThreads": "Padrão para novas conversas",
     "advanced": "Avançado",
     "backToPresets": "Presets",

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -433,6 +433,7 @@
       "claudeSandboxUnsupported": "Claude suporta apenas os modos de sandbox somente leitura e escrita no workspace.",
       "fullAccessNetworkWarning": "O modo acesso total habilita temporariamente o acesso à rede.",
       "updateExecutionPolicyFailed": "Falha ao atualizar a política de execução da thread: {{error}}",
+      "approvalBatchFailed": "Uma ou mais aprovações não puderam ser aceitas. A política da thread não foi alterada.",
       "updateCodexConfigFailed": "Falha ao atualizar a configuração de turno do Codex: {{error}}",
       "updateOpenCodeConfigFailed": "Falha ao atualizar a configuração de turno do OpenCode: {{error}}",
       "planImplementationThreadUnavailable": "A thread original de planejamento não está mais disponível. Reabra a thread e tente novamente.",

--- a/src/i18n/resources/pt-BR/chat.json
+++ b/src/i18n/resources/pt-BR/chat.json
@@ -325,7 +325,6 @@
     "defaultForNewThreads": "Padrão para novas conversas",
     "advanced": "Avançado",
     "backToPresets": "Presets",
-    "armedStatus": "Autonomia total: nunca pergunta, disco e rede completos",
     "allowAll": "Permitir tudo",
     "allowAllStopAsking": "Permitir tudo e parar de perguntar",
     "approvalToastTitle": "{{engine}} precisa de aprovação",

--- a/src/i18n/resources/pt-BR/common.json
+++ b/src/i18n/resources/pt-BR/common.json
@@ -24,5 +24,9 @@
   },
   "labels": {
     "settings": "Configurações"
+  },
+  "diff": {
+    "unchangedLines_one": "{{count}} linha inalterada",
+    "unchangedLines_other": "{{count}} linhas inalteradas"
   }
 }

--- a/src/lib/autonomyPresets.test.ts
+++ b/src/lib/autonomyPresets.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
   availableAutonomyPresets,
+  autonomyPresetDescriptionKey,
   autonomyPresetExecutionPolicyRequest,
   autonomyPresetPatch,
   detectAutonomyPreset,
+  isDefaultAutonomyPreset,
+  resolveDefaultAutonomyPreset,
 } from "./autonomyPresets";
 import type { AutonomyPresetId } from "./autonomyPresets";
 import type { ChatEngineId } from "../types";
@@ -188,5 +191,34 @@ describe("autonomyPresetExecutionPolicyRequest", () => {
         expect(autonomyPresetExecutionPolicyRequest(preset, engineId)).not.toBeNull();
       }
     }
+  });
+});
+
+describe("autonomy preset presentation", () => {
+  it("uses engine-specific descriptions where the permission model differs", () => {
+    expect(autonomyPresetDescriptionKey("read-only", "opencode")).toBe(
+      "autonomy.engineDescriptions.opencode.read-only",
+    );
+    expect(autonomyPresetDescriptionKey("full", "claude")).toBe(
+      "autonomy.engineDescriptions.claude.full",
+    );
+    expect(
+      autonomyPresetDescriptionKey("auto", "codex", { codexExternalSandbox: true }),
+    ).toBe("autonomy.engineDescriptions.codexExternal.auto");
+  });
+
+  it("keeps the standard Codex descriptions outside external sandbox mode", () => {
+    expect(autonomyPresetDescriptionKey("ask", "codex")).toBe(
+      "autonomy.presets.ask.description",
+    );
+  });
+
+  it("treats an unset stored default as inherit", () => {
+    expect(resolveDefaultAutonomyPreset(null)).toBe("inherit");
+    expect(resolveDefaultAutonomyPreset(undefined)).toBe("inherit");
+    expect(resolveDefaultAutonomyPreset("auto")).toBe("auto");
+    expect(isDefaultAutonomyPreset("inherit", null)).toBe(true);
+    expect(isDefaultAutonomyPreset("auto", null)).toBe(false);
+    expect(isDefaultAutonomyPreset("auto", "auto")).toBe(true);
   });
 });

--- a/src/lib/autonomyPresets.test.ts
+++ b/src/lib/autonomyPresets.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  availableAutonomyPresets,
+  autonomyPresetExecutionPolicyRequest,
+  autonomyPresetPatch,
+  detectAutonomyPreset,
+} from "./autonomyPresets";
+import type { AutonomyPresetId } from "./autonomyPresets";
+import type { ChatEngineId } from "../types";
+
+describe("autonomyPresetPatch", () => {
+  it("maps full autonomy per engine", () => {
+    expect(autonomyPresetPatch("full", "codex")).toEqual({
+      approvalPolicy: "never",
+      sandboxMode: "danger-full-access",
+      networkPolicy: "enabled",
+    });
+    expect(autonomyPresetPatch("full", "claude")).toEqual({
+      approvalPolicy: "trusted",
+      sandboxMode: "workspace-write",
+      networkPolicy: "enabled",
+    });
+    expect(autonomyPresetPatch("full", "opencode")).toEqual({
+      approvalPolicy: "allow",
+    });
+  });
+
+  it("never emits sandbox or network keys for opencode", () => {
+    for (const preset of availableAutonomyPresets("opencode")) {
+      const patch = autonomyPresetPatch(preset, "opencode");
+      expect("sandboxMode" in patch).toBe(false);
+      expect("networkPolicy" in patch).toBe(false);
+    }
+  });
+
+  it("never requests a full-access sandbox for claude", () => {
+    for (const preset of availableAutonomyPresets("claude")) {
+      expect(autonomyPresetPatch(preset, "claude").sandboxMode).not.toBe(
+        "danger-full-access",
+      );
+    }
+  });
+});
+
+describe("detectAutonomyPreset", () => {
+  it("round-trips every available preset for every engine", () => {
+    const engines: ChatEngineId[] = ["codex", "claude", "opencode"];
+    for (const engineId of engines) {
+      for (const preset of availableAutonomyPresets(engineId)) {
+        const patch = autonomyPresetPatch(preset, engineId);
+        const snapshot = {
+          approvalPolicy: patch.approvalPolicy,
+          sandboxMode: patch.sandboxMode ?? "inherit",
+          networkPolicy: patch.networkPolicy ?? "inherit",
+        };
+        const detected = detectAutonomyPreset(engineId, snapshot);
+        if (engineId === "opencode" && preset === "auto") {
+          expect(detected).toBe("full");
+        } else {
+          expect(detected).toBe(preset);
+        }
+      }
+    }
+  });
+
+  it("detects codex full autonomy regardless of the stored network value", () => {
+    expect(
+      detectAutonomyPreset("codex", {
+        approvalPolicy: "never",
+        sandboxMode: "danger-full-access",
+        networkPolicy: "inherit",
+      }),
+    ).toBe("full");
+  });
+
+  it("distinguishes claude auto from full by the network override", () => {
+    expect(
+      detectAutonomyPreset("claude", {
+        approvalPolicy: "trusted",
+        sandboxMode: "workspace-write",
+        networkPolicy: "inherit",
+      }),
+    ).toBe("auto");
+    expect(
+      detectAutonomyPreset("claude", {
+        approvalPolicy: "trusted",
+        sandboxMode: "workspace-write",
+        networkPolicy: "enabled",
+      }),
+    ).toBe("full");
+  });
+
+  it("returns null for combinations off the ladder", () => {
+    expect(
+      detectAutonomyPreset("codex", {
+        approvalPolicy: "never",
+        sandboxMode: "read-only",
+        networkPolicy: "inherit",
+      }),
+    ).toBeNull();
+    expect(
+      detectAutonomyPreset("claude", {
+        approvalPolicy: "standard",
+        sandboxMode: "inherit",
+        networkPolicy: "inherit",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("autonomyPresetExecutionPolicyRequest", () => {
+  it("returns null for inherit", () => {
+    expect(autonomyPresetExecutionPolicyRequest("inherit", "codex")).toBeNull();
+  });
+
+  it("builds engine-appropriate requests", () => {
+    expect(autonomyPresetExecutionPolicyRequest("full", "codex")).toEqual({
+      approvalPolicy: "never",
+      sandboxMode: "danger-full-access",
+      allowNetwork: true,
+    });
+    expect(autonomyPresetExecutionPolicyRequest("auto", "claude")).toEqual({
+      approvalPolicy: "trusted",
+      sandboxMode: "workspace-write",
+      allowNetwork: null,
+    });
+    expect(autonomyPresetExecutionPolicyRequest("read-only", "opencode")).toEqual({
+      approvalPolicy: "deny",
+    });
+  });
+
+  it("covers every non-inherit preset", () => {
+    const engines: ChatEngineId[] = ["codex", "claude", "opencode"];
+    for (const engineId of engines) {
+      const presets = availableAutonomyPresets(engineId).filter(
+        (preset): preset is Exclude<AutonomyPresetId, "inherit"> => preset !== "inherit",
+      );
+      for (const preset of presets) {
+        expect(autonomyPresetExecutionPolicyRequest(preset, engineId)).not.toBeNull();
+      }
+    }
+  });
+});

--- a/src/lib/autonomyPresets.test.ts
+++ b/src/lib/autonomyPresets.test.ts
@@ -108,6 +108,55 @@ describe("detectAutonomyPreset", () => {
   });
 });
 
+describe("codex external sandbox mode", () => {
+  const options = { codexExternalSandbox: true };
+
+  it("leaves the sandbox on inherit for the constrained rungs", () => {
+    expect(autonomyPresetPatch("read-only", "codex", options).sandboxMode).toBe("inherit");
+    expect(autonomyPresetPatch("ask", "codex", options).sandboxMode).toBe("inherit");
+    expect(autonomyPresetPatch("auto", "codex", options).sandboxMode).toBe("inherit");
+    expect(autonomyPresetPatch("full", "codex", options).sandboxMode).toBe(
+      "danger-full-access",
+    );
+  });
+
+  it("round-trips detection with the same flag", () => {
+    for (const preset of availableAutonomyPresets("codex")) {
+      const patch = autonomyPresetPatch(preset, "codex", options);
+      expect(
+        detectAutonomyPreset(
+          "codex",
+          {
+            approvalPolicy: patch.approvalPolicy,
+            sandboxMode: patch.sandboxMode ?? "inherit",
+            networkPolicy: patch.networkPolicy ?? "inherit",
+          },
+          options,
+        ),
+      ).toBe(preset);
+    }
+  });
+
+  it("never issues a request with a blocked sandbox override", () => {
+    for (const preset of availableAutonomyPresets("codex")) {
+      const request = autonomyPresetExecutionPolicyRequest(preset, "codex", options);
+      if (request) {
+        expect(request.sandboxMode).not.toBe("read-only");
+        expect(request.sandboxMode).not.toBe("workspace-write");
+      }
+    }
+  });
+
+  it("does not change claude or opencode mappings", () => {
+    expect(autonomyPresetPatch("ask", "claude", options)).toEqual(
+      autonomyPresetPatch("ask", "claude"),
+    );
+    expect(autonomyPresetPatch("full", "opencode", options)).toEqual(
+      autonomyPresetPatch("full", "opencode"),
+    );
+  });
+});
+
 describe("autonomyPresetExecutionPolicyRequest", () => {
   it("returns null for inherit", () => {
     expect(autonomyPresetExecutionPolicyRequest("inherit", "codex")).toBeNull();

--- a/src/lib/autonomyPresets.ts
+++ b/src/lib/autonomyPresets.ts
@@ -14,6 +14,15 @@ export interface AutonomyPresetPatch {
   networkPolicy?: "inherit" | "enabled" | "restricted";
 }
 
+export interface AutonomyPresetOptions {
+  /**
+   * Codex rejects read-only and workspace-write sandbox overrides while Panes
+   * runs in external sandbox mode; presets then leave the sandbox on inherit
+   * and steer through the approval policy alone.
+   */
+  codexExternalSandbox?: boolean;
+}
+
 export const AUTONOMY_PRESET_IDS: readonly AutonomyPresetId[] = [
   "inherit",
   "read-only",
@@ -47,6 +56,7 @@ export function availableAutonomyPresets(engineId: ChatEngineId): AutonomyPreset
 export function autonomyPresetPatch(
   preset: AutonomyPresetId,
   engineId: ChatEngineId,
+  options?: AutonomyPresetOptions,
 ): AutonomyPresetPatch {
   if (engineId === "opencode") {
     switch (preset) {
@@ -81,13 +91,26 @@ export function autonomyPresetPatch(
     }
   }
 
+  const externalSandbox = options?.codexExternalSandbox === true;
   switch (preset) {
     case "read-only":
-      return { approvalPolicy: "untrusted", sandboxMode: "read-only", networkPolicy: "restricted" };
+      return {
+        approvalPolicy: "untrusted",
+        sandboxMode: externalSandbox ? "inherit" : "read-only",
+        networkPolicy: "restricted",
+      };
     case "ask":
-      return { approvalPolicy: "on-request", sandboxMode: "workspace-write", networkPolicy: "restricted" };
+      return {
+        approvalPolicy: "on-request",
+        sandboxMode: externalSandbox ? "inherit" : "workspace-write",
+        networkPolicy: "restricted",
+      };
     case "auto":
-      return { approvalPolicy: "on-failure", sandboxMode: "workspace-write", networkPolicy: "enabled" };
+      return {
+        approvalPolicy: "on-failure",
+        sandboxMode: externalSandbox ? "inherit" : "workspace-write",
+        networkPolicy: "enabled",
+      };
     case "full":
       return { approvalPolicy: "never", sandboxMode: "danger-full-access", networkPolicy: "enabled" };
     default:
@@ -102,6 +125,7 @@ export function autonomyPresetPatch(
 export function detectAutonomyPreset(
   engineId: ChatEngineId,
   snapshot: AutonomyPolicySnapshot,
+  options?: AutonomyPresetOptions,
 ): AutonomyPresetId | null {
   if (engineId === "opencode") {
     switch (snapshot.approvalPolicy) {
@@ -132,7 +156,7 @@ export function detectAutonomyPreset(
     if (engineId === "codex" && preset === "full") {
       continue;
     }
-    const patch = autonomyPresetPatch(preset, engineId);
+    const patch = autonomyPresetPatch(preset, engineId, options);
     if (
       patch.approvalPolicy === snapshot.approvalPolicy &&
       patch.sandboxMode === snapshot.sandboxMode &&
@@ -152,6 +176,7 @@ export function detectAutonomyPreset(
 export function autonomyPresetExecutionPolicyRequest(
   preset: AutonomyPresetId,
   engineId: ChatEngineId,
+  options?: AutonomyPresetOptions,
 ): {
   approvalPolicy?: unknown;
   sandboxMode?: string | null;
@@ -161,7 +186,7 @@ export function autonomyPresetExecutionPolicyRequest(
     return null;
   }
 
-  const patch = autonomyPresetPatch(preset, engineId);
+  const patch = autonomyPresetPatch(preset, engineId, options);
   if (engineId === "opencode") {
     return { approvalPolicy: patch.approvalPolicy };
   }

--- a/src/lib/autonomyPresets.ts
+++ b/src/lib/autonomyPresets.ts
@@ -41,6 +41,39 @@ export function isAutonomyPresetId(value: unknown): value is AutonomyPresetId {
   );
 }
 
+export function resolveDefaultAutonomyPreset(
+  preset: AutonomyPresetId | null | undefined,
+): AutonomyPresetId {
+  return preset ?? "inherit";
+}
+
+export function isDefaultAutonomyPreset(
+  preset: AutonomyPresetId | null | undefined,
+  storedDefault: AutonomyPresetId | null | undefined,
+): boolean {
+  return preset != null && resolveDefaultAutonomyPreset(storedDefault) === preset;
+}
+
+export function autonomyPresetDescriptionKey(
+  preset: AutonomyPresetId,
+  engineId: ChatEngineId,
+  options?: AutonomyPresetOptions,
+): string {
+  if (engineId === "opencode") {
+    return `autonomy.engineDescriptions.opencode.${preset}`;
+  }
+  if (engineId === "claude") {
+    return `autonomy.engineDescriptions.claude.${preset}`;
+  }
+  if (
+    options?.codexExternalSandbox === true &&
+    (preset === "read-only" || preset === "ask" || preset === "auto")
+  ) {
+    return `autonomy.engineDescriptions.codexExternal.${preset}`;
+  }
+  return `autonomy.presets.${preset}.description`;
+}
+
 /**
  * OpenCode exposes approvals only, and its `allow` mode never asks, so a
  * separate "auto in workspace" rung would be indistinguishable from full

--- a/src/lib/autonomyPresets.ts
+++ b/src/lib/autonomyPresets.ts
@@ -1,0 +1,175 @@
+import type { ChatEngineId } from "../types";
+
+export type AutonomyPresetId = "inherit" | "read-only" | "ask" | "auto" | "full";
+
+export interface AutonomyPolicySnapshot {
+  approvalPolicy: string;
+  sandboxMode: string;
+  networkPolicy: string;
+}
+
+export interface AutonomyPresetPatch {
+  approvalPolicy: string;
+  sandboxMode?: "inherit" | "read-only" | "workspace-write" | "danger-full-access";
+  networkPolicy?: "inherit" | "enabled" | "restricted";
+}
+
+export const AUTONOMY_PRESET_IDS: readonly AutonomyPresetId[] = [
+  "inherit",
+  "read-only",
+  "ask",
+  "auto",
+  "full",
+];
+
+export function isAutonomyPresetId(value: unknown): value is AutonomyPresetId {
+  return (
+    value === "inherit" ||
+    value === "read-only" ||
+    value === "ask" ||
+    value === "auto" ||
+    value === "full"
+  );
+}
+
+/**
+ * OpenCode exposes approvals only, and its `allow` mode never asks, so a
+ * separate "auto in workspace" rung would be indistinguishable from full
+ * autonomy there.
+ */
+export function availableAutonomyPresets(engineId: ChatEngineId): AutonomyPresetId[] {
+  if (engineId === "opencode") {
+    return ["inherit", "read-only", "ask", "full"];
+  }
+  return [...AUTONOMY_PRESET_IDS];
+}
+
+export function autonomyPresetPatch(
+  preset: AutonomyPresetId,
+  engineId: ChatEngineId,
+): AutonomyPresetPatch {
+  if (engineId === "opencode") {
+    switch (preset) {
+      case "read-only":
+        return { approvalPolicy: "deny" };
+      case "ask":
+        return { approvalPolicy: "ask" };
+      case "auto":
+      case "full":
+        return { approvalPolicy: "allow" };
+      default:
+        return { approvalPolicy: "inherit" };
+    }
+  }
+
+  if (engineId === "claude") {
+    switch (preset) {
+      case "read-only":
+        return { approvalPolicy: "restricted", sandboxMode: "read-only", networkPolicy: "restricted" };
+      case "ask":
+        return { approvalPolicy: "standard", sandboxMode: "workspace-write", networkPolicy: "restricted" };
+      case "auto":
+        // Network stays on inherit so this rung remains distinguishable from
+        // full autonomy, which pins the network on.
+        return { approvalPolicy: "trusted", sandboxMode: "workspace-write", networkPolicy: "inherit" };
+      case "full":
+        // Claude has no full-access sandbox in Panes; full autonomy keeps
+        // workspace-write.
+        return { approvalPolicy: "trusted", sandboxMode: "workspace-write", networkPolicy: "enabled" };
+      default:
+        return { approvalPolicy: "inherit", sandboxMode: "inherit", networkPolicy: "inherit" };
+    }
+  }
+
+  switch (preset) {
+    case "read-only":
+      return { approvalPolicy: "untrusted", sandboxMode: "read-only", networkPolicy: "restricted" };
+    case "ask":
+      return { approvalPolicy: "on-request", sandboxMode: "workspace-write", networkPolicy: "restricted" };
+    case "auto":
+      return { approvalPolicy: "on-failure", sandboxMode: "workspace-write", networkPolicy: "enabled" };
+    case "full":
+      return { approvalPolicy: "never", sandboxMode: "danger-full-access", networkPolicy: "enabled" };
+    default:
+      return { approvalPolicy: "inherit", sandboxMode: "inherit", networkPolicy: "inherit" };
+  }
+}
+
+/**
+ * Map the thread's current execution policy back onto a preset, or `null`
+ * when the combination does not match any rung (a custom setup).
+ */
+export function detectAutonomyPreset(
+  engineId: ChatEngineId,
+  snapshot: AutonomyPolicySnapshot,
+): AutonomyPresetId | null {
+  if (engineId === "opencode") {
+    switch (snapshot.approvalPolicy) {
+      case "inherit":
+        return "inherit";
+      case "deny":
+        return "read-only";
+      case "ask":
+        return "ask";
+      case "allow":
+        return "full";
+      default:
+        return null;
+    }
+  }
+
+  // Full access forces the network on for Codex, so the stored network value
+  // is irrelevant on that rung.
+  if (
+    engineId === "codex" &&
+    snapshot.approvalPolicy === "never" &&
+    snapshot.sandboxMode === "danger-full-access"
+  ) {
+    return "full";
+  }
+
+  for (const preset of availableAutonomyPresets(engineId)) {
+    if (engineId === "codex" && preset === "full") {
+      continue;
+    }
+    const patch = autonomyPresetPatch(preset, engineId);
+    if (
+      patch.approvalPolicy === snapshot.approvalPolicy &&
+      patch.sandboxMode === snapshot.sandboxMode &&
+      patch.networkPolicy === snapshot.networkPolicy
+    ) {
+      return preset;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * The `set_thread_execution_policy` request for a preset, or `null` for
+ * `inherit`, which means "leave the thread on trust defaults".
+ */
+export function autonomyPresetExecutionPolicyRequest(
+  preset: AutonomyPresetId,
+  engineId: ChatEngineId,
+): {
+  approvalPolicy?: unknown;
+  sandboxMode?: string | null;
+  allowNetwork?: boolean | null;
+} | null {
+  if (preset === "inherit") {
+    return null;
+  }
+
+  const patch = autonomyPresetPatch(preset, engineId);
+  if (engineId === "opencode") {
+    return { approvalPolicy: patch.approvalPolicy };
+  }
+
+  return {
+    approvalPolicy: patch.approvalPolicy,
+    sandboxMode: patch.sandboxMode === "inherit" ? null : patch.sandboxMode ?? null,
+    allowNetwork:
+      patch.networkPolicy === "inherit" ? null : patch.networkPolicy === "enabled",
+  };
+}

--- a/src/lib/codexSandbox.ts
+++ b/src/lib/codexSandbox.ts
@@ -1,0 +1,21 @@
+import type { EngineHealth } from "../types";
+
+export function isCodexExternalSandboxWarning(message?: string): boolean {
+  if (typeof message !== "string") {
+    return false;
+  }
+
+  const normalized = message.toLowerCase();
+  return normalized.includes("external sandbox mode");
+}
+
+export function codexUsesExternalSandbox(health: Record<string, EngineHealth>): boolean {
+  const codexHealth = health.codex;
+  if (!codexHealth?.available) {
+    return false;
+  }
+
+  return (codexHealth.warnings ?? []).some((warning) =>
+    isCodexExternalSandboxWarning(warning),
+  );
+}

--- a/src/lib/fileRootUtils.test.ts
+++ b/src/lib/fileRootUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveThreadFileRootPath } from "./fileRootUtils";
+
+const repos = [
+  { id: "repo-a", path: "/workspace/repo-a" },
+  { id: "repo-b", path: "/workspace/repo-b" },
+];
+
+describe("resolveThreadFileRootPath", () => {
+  it("uses the thread repository instead of an independently selected repo", () => {
+    expect(
+      resolveThreadFileRootPath(
+        { repoId: "repo-a" },
+        repos,
+        "/workspace",
+      ),
+    ).toBe("/workspace/repo-a");
+  });
+
+  it("uses the workspace root for workspace-scoped threads", () => {
+    expect(
+      resolveThreadFileRootPath({ repoId: null }, repos, "/workspace"),
+    ).toBe("/workspace");
+  });
+
+  it("does not fall back to another root when the thread repository is missing", () => {
+    expect(
+      resolveThreadFileRootPath(
+        { repoId: "missing" },
+        repos,
+        "/workspace",
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/fileRootUtils.ts
+++ b/src/lib/fileRootUtils.ts
@@ -1,10 +1,24 @@
-import type { Repo } from "../types";
+import type { Repo, Thread } from "../types";
 
 type RepoRoot = Pick<Repo, "id" | "path">;
 
 export interface RepoOwnership {
   repo: RepoRoot;
   filePath: string;
+}
+
+export function resolveThreadFileRootPath(
+  thread: Pick<Thread, "repoId"> | null,
+  repos: RepoRoot[],
+  workspaceRootPath: string | null,
+): string | null {
+  if (!thread) {
+    return null;
+  }
+  if (!thread.repoId) {
+    return workspaceRootPath;
+  }
+  return repos.find((repo) => repo.id === thread.repoId)?.path ?? null;
 }
 
 function isWindowsDrivePath(path: string): boolean {

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -637,6 +637,10 @@ export const ipc = {
     invoke<Record<string, string>>("get_harness_launch_args"),
   setHarnessLaunchArgs: (harnessId: string, args: string) =>
     invoke<string>("set_harness_launch_args", { harnessId, args }),
+  getDefaultAutonomyPreset: () =>
+    invoke<string | null>("get_default_autonomy_preset"),
+  setDefaultAutonomyPreset: (preset: string | null) =>
+    invoke<string | null>("set_default_autonomy_preset", { preset }),
 };
 
 export async function listenThreadEvents(
@@ -681,6 +685,23 @@ export async function listenChatTurnFinished(
   onEvent: (event: ChatTurnFinishedEvent) => void
 ): Promise<UnlistenFn> {
   return listen<ChatTurnFinishedEvent>("chat-turn-finished", ({ payload }) => onEvent(payload));
+}
+
+export interface ChatApprovalRequestedEvent {
+  threadId: string;
+  workspaceId: string;
+  engineId: ChatEngineId;
+  threadTitle: string;
+  summary: string;
+}
+
+export async function listenChatApprovalRequested(
+  onEvent: (event: ChatApprovalRequestedEvent) => void
+): Promise<UnlistenFn> {
+  return listen<ChatApprovalRequestedEvent>(
+    "chat-approval-requested",
+    ({ payload }) => onEvent(payload)
+  );
 }
 
 export async function listenEngineRuntimeUpdated(

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -641,6 +641,8 @@ export const ipc = {
     invoke<string | null>("get_default_autonomy_preset"),
   setDefaultAutonomyPreset: (preset: string | null) =>
     invoke<string | null>("set_default_autonomy_preset", { preset }),
+  codexUsesExternalSandbox: () =>
+    invoke<boolean>("codex_uses_external_sandbox"),
 };
 
 export async function listenThreadEvents(

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -633,6 +633,10 @@ export const ipc = {
     invoke<InstallResult>("install_harness", { harnessId }),
   launchHarness: (harnessId: string) =>
     invoke<string>("launch_harness", { harnessId }),
+  getHarnessLaunchArgs: () =>
+    invoke<Record<string, string>>("get_harness_launch_args"),
+  setHarnessLaunchArgs: (harnessId: string, args: string) =>
+    invoke<string>("set_harness_launch_args", { harnessId, args }),
 };
 
 export async function listenThreadEvents(

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -1406,4 +1406,76 @@ describe("chatStore send", () => {
     ]);
   });
 
+  it("returns failure and rolls back when an approval response is rejected", async () => {
+    mockIpc.respondApproval.mockRejectedValueOnce(new Error("approval failed"));
+    useChatStore.setState({
+      threadId: "thread-1",
+      messages: [
+        {
+          id: "assistant-1",
+          threadId: "thread-1",
+          role: "assistant",
+          status: "completed",
+          schemaVersion: 1,
+          blocks: [
+            {
+              type: "approval",
+              approvalId: "approval-1",
+              actionType: "command",
+              summary: "Run command",
+              details: {},
+              status: "pending",
+            },
+          ],
+          createdAt: new Date().toISOString(),
+          hydration: "full",
+          hasDeferredContent: false,
+        },
+      ],
+      error: undefined,
+    });
+
+    const accepted = await useChatStore
+      .getState()
+      .respondApproval("approval-1", { decision: "accept" }, "thread-1");
+
+    expect(accepted).toBe(false);
+    expect(useChatStore.getState().messages[0]?.blocks).toMatchObject([
+      { approvalId: "approval-1", status: "pending" },
+    ]);
+    expect(useChatStore.getState().error).toContain("approval failed");
+  });
+
+  it("targets an explicit thread without mutating another visible transcript", async () => {
+    mockIpc.respondApproval.mockResolvedValueOnce(undefined);
+    const visibleMessages = [
+      {
+        id: "assistant-2",
+        threadId: "thread-2",
+        role: "assistant" as const,
+        status: "completed" as const,
+        schemaVersion: 1,
+        blocks: [],
+        createdAt: new Date().toISOString(),
+        hydration: "full" as const,
+        hasDeferredContent: false,
+      },
+    ];
+    useChatStore.setState({
+      threadId: "thread-2",
+      messages: visibleMessages,
+      error: undefined,
+    });
+
+    const accepted = await useChatStore
+      .getState()
+      .respondApproval("approval-1", { decision: "accept" }, "thread-1");
+
+    expect(accepted).toBe(true);
+    expect(mockIpc.respondApproval).toHaveBeenCalledWith("thread-1", "approval-1", {
+      decision: "accept",
+    });
+    expect(useChatStore.getState().messages).toBe(visibleMessages);
+  });
+
 });

--- a/src/stores/chatStore.test.ts
+++ b/src/stores/chatStore.test.ts
@@ -1446,6 +1446,72 @@ describe("chatStore send", () => {
     expect(useChatStore.getState().error).toContain("approval failed");
   });
 
+  it("preserves concurrent message updates when an approval response is rejected", async () => {
+    const response = deferred<void>();
+    mockIpc.respondApproval.mockReturnValueOnce(response.promise);
+    useChatStore.setState({
+      threadId: "thread-1",
+      messages: [
+        {
+          id: "assistant-1",
+          threadId: "thread-1",
+          role: "assistant",
+          status: "streaming",
+          schemaVersion: 1,
+          blocks: [
+            {
+              type: "approval",
+              approvalId: "approval-1",
+              actionType: "command",
+              summary: "Run command",
+              details: {},
+              status: "pending",
+            },
+          ],
+          createdAt: new Date().toISOString(),
+          hydration: "full",
+          hasDeferredContent: false,
+        },
+      ],
+      error: undefined,
+    });
+
+    const pendingResponse = useChatStore
+      .getState()
+      .respondApproval("approval-1", { decision: "accept" }, "thread-1");
+
+    expect(useChatStore.getState().messages[0]?.blocks).toMatchObject([
+      { approvalId: "approval-1", status: "answered" },
+    ]);
+
+    useChatStore.setState((state) => ({
+      messages: [
+        ...state.messages,
+        {
+          id: "assistant-2",
+          threadId: "thread-1",
+          role: "assistant",
+          status: "streaming",
+          schemaVersion: 1,
+          blocks: [{ type: "text", content: "Still working" }],
+          createdAt: new Date().toISOString(),
+          hydration: "full",
+          hasDeferredContent: false,
+        },
+      ],
+    }));
+    response.reject(new Error("approval failed"));
+
+    await expect(pendingResponse).resolves.toBe(false);
+    expect(useChatStore.getState().messages).toHaveLength(2);
+    expect(useChatStore.getState().messages[0]?.blocks).toMatchObject([
+      { approvalId: "approval-1", status: "pending" },
+    ]);
+    expect(useChatStore.getState().messages[1]?.blocks).toMatchObject([
+      { type: "text", content: "Still working" },
+    ]);
+  });
+
   it("targets an explicit thread without mutating another visible transcript", async () => {
     mockIpc.respondApproval.mockResolvedValueOnce(undefined);
     const visibleMessages = [

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -404,6 +404,42 @@ function resolveApprovalInMessages(
   return messages;
 }
 
+function restoreApprovalInMessages(
+  messages: Message[],
+  approvalId: string,
+  previousApproval: ApprovalBlock,
+): Message[] {
+  for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
+    const message = messages[messageIndex];
+    const blocks = message.blocks;
+    if (!blocks || blocks.length === 0) {
+      continue;
+    }
+
+    const approvalIndex = blocks.findIndex(
+      (block) => block.type === "approval" && block.approvalId === approvalId,
+    );
+    if (approvalIndex < 0) {
+      continue;
+    }
+
+    if (blocks[approvalIndex] === previousApproval) {
+      return messages;
+    }
+
+    const nextBlocks = [...blocks];
+    nextBlocks[approvalIndex] = previousApproval;
+    const nextMessages = [...messages];
+    nextMessages[messageIndex] = {
+      ...message,
+      blocks: nextBlocks,
+    };
+    return nextMessages;
+  }
+
+  return messages;
+}
+
 function trimActionOutputChunks(
   chunks: ActionBlock["outputChunks"],
 ): {
@@ -2218,16 +2254,23 @@ export const useChatStore = create<ChatState>((set, get) => ({
     const responseData = typeof response === "object" && response !== null && !Array.isArray(response)
       ? response as Record<string, unknown>
       : undefined;
-    let previousMessages: Message[] | null = null;
-    let optimisticMessages: Message[] | null = null;
+    let previousApproval: ApprovalBlock | null = null;
     if (get().threadId === threadId) {
       set((state) => {
+        for (const message of state.messages) {
+          const approval = message.blocks?.find(
+            (block): block is ApprovalBlock =>
+              block.type === "approval" && block.approvalId === approvalId,
+          );
+          if (approval) {
+            previousApproval = approval;
+            break;
+          }
+        }
         const nextMessages = resolveApprovalInMessages(state.messages, approvalId, decision, responseData);
         if (nextMessages === state.messages) {
           return state;
         }
-        previousMessages = state.messages;
-        optimisticMessages = nextMessages;
         return { ...state, messages: nextMessages };
       });
     }
@@ -2237,8 +2280,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return true;
     } catch (error) {
       set((state) => ({
-        ...(previousMessages && optimisticMessages && state.messages === optimisticMessages
-          ? { messages: previousMessages }
+        ...(previousApproval && state.threadId === threadId
+          ? { messages: restoreApprovalInMessages(state.messages, approvalId, previousApproval) }
           : {}),
         error: String(error),
       }));

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -59,7 +59,11 @@ interface ChatState {
     },
   ) => Promise<boolean>;
   cancel: () => Promise<void>;
-  respondApproval: (approvalId: string, response: ApprovalResponse) => Promise<void>;
+  respondApproval: (
+    approvalId: string,
+    response: ApprovalResponse,
+    threadIdOverride?: string,
+  ) => Promise<boolean>;
   hydrateActionOutput: (messageId: string, actionId: string) => Promise<void>;
 }
 
@@ -2202,32 +2206,43 @@ export const useChatStore = create<ChatState>((set, get) => ({
       set({ error: String(error) });
     }
   },
-  respondApproval: async (approvalId, response) => {
-    const threadId = get().threadId;
+  respondApproval: async (approvalId, response, threadIdOverride) => {
+    const threadId = threadIdOverride ?? get().threadId;
     if (!threadId) {
       set({ error: "No active thread selected" });
-      return;
+      return false;
     }
 
-    // Apply optimistic update BEFORE the IPC call
+    // Only mutate the visible transcript when it belongs to the target thread.
     const decision = resolveApprovalDecision(response);
     const responseData = typeof response === "object" && response !== null && !Array.isArray(response)
       ? response as Record<string, unknown>
       : undefined;
-    const previousMessages = get().messages;
-    set((state) => {
-      const nextMessages = resolveApprovalInMessages(state.messages, approvalId, decision, responseData);
-      if (nextMessages === state.messages) {
-        return state;
-      }
-      return { ...state, messages: nextMessages };
-    });
+    let previousMessages: Message[] | null = null;
+    let optimisticMessages: Message[] | null = null;
+    if (get().threadId === threadId) {
+      set((state) => {
+        const nextMessages = resolveApprovalInMessages(state.messages, approvalId, decision, responseData);
+        if (nextMessages === state.messages) {
+          return state;
+        }
+        previousMessages = state.messages;
+        optimisticMessages = nextMessages;
+        return { ...state, messages: nextMessages };
+      });
+    }
 
     try {
       await ipc.respondApproval(threadId, approvalId, response);
+      return true;
     } catch (error) {
-      // Roll back the optimistic update on failure
-      set({ messages: previousMessages, error: String(error) });
+      set((state) => ({
+        ...(previousMessages && optimisticMessages && state.messages === optimisticMessages
+          ? { messages: previousMessages }
+          : {}),
+        error: String(error),
+      }));
+      return false;
     }
   },
   hydrateActionOutput: async (messageId, actionId) => {

--- a/src/stores/harnessStore.ts
+++ b/src/stores/harnessStore.ts
@@ -11,11 +11,15 @@ interface HarnessStore {
   preferredInstallMethod: string | null;
   error: string | null;
   loadedOnce: boolean;
+  launchArgs: Record<string, string>;
+  launchArgsLoaded: boolean;
 
   scan: () => Promise<void>;
   ensureScanned: () => Promise<void>;
   launch: (harnessId: string) => Promise<string | null>;
   getInstalledHarnesses: () => HarnessInfo[];
+  loadLaunchArgs: () => Promise<void>;
+  saveLaunchArgs: (harnessId: string, args: string) => Promise<boolean>;
 }
 
 let pendingHarnessScan: Promise<void> | null = null;
@@ -66,6 +70,8 @@ export const useHarnessStore = create<HarnessStore>((set, get) => ({
   preferredInstallMethod: null,
   error: null,
   loadedOnce: false,
+  launchArgs: {},
+  launchArgsLoaded: false,
 
   scan: async () => requestHarnessScan(set, get),
 
@@ -87,5 +93,30 @@ export const useHarnessStore = create<HarnessStore>((set, get) => ({
   getInstalledHarnesses: () => {
     const { harnesses } = get();
     return harnesses.filter((h) => h.found);
+  },
+
+  loadLaunchArgs: async () => {
+    try {
+      const launchArgs = await ipc.getHarnessLaunchArgs();
+      set({ launchArgs, launchArgsLoaded: true });
+    } catch {
+      set({ launchArgsLoaded: true });
+    }
+  },
+
+  saveLaunchArgs: async (harnessId: string, args: string) => {
+    try {
+      const saved = await ipc.setHarnessLaunchArgs(harnessId, args);
+      const launchArgs = { ...get().launchArgs };
+      if (saved) {
+        launchArgs[harnessId] = saved;
+      } else {
+        delete launchArgs[harnessId];
+      }
+      set({ launchArgs });
+      return true;
+    } catch {
+      return false;
+    }
   },
 }));

--- a/src/stores/threadStore.ts
+++ b/src/stores/threadStore.ts
@@ -10,6 +10,7 @@ import {
   autonomyPresetExecutionPolicyRequest,
   isAutonomyPresetId,
 } from "../lib/autonomyPresets";
+import { codexUsesExternalSandbox } from "../lib/codexSandbox";
 import type { Thread } from "../types";
 import { useChatComposerStore } from "./chatComposerStore";
 import { useEngineStore } from "./engineStore";
@@ -210,6 +211,11 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
           const request = autonomyPresetExecutionPolicyRequest(
             defaultPreset,
             created.engineId,
+            {
+              codexExternalSandbox: codexUsesExternalSandbox(
+                useEngineStore.getState().health,
+              ),
+            },
           );
           if (request) {
             created = await ipc.setThreadExecutionPolicy(created.id, request);

--- a/src/stores/threadStore.ts
+++ b/src/stores/threadStore.ts
@@ -6,6 +6,10 @@ import {
   type NewThreadServiceTier,
 } from "../lib/newThreadRuntime";
 import { resolvePreferredOnboardingChatSelection } from "../lib/onboarding";
+import {
+  autonomyPresetExecutionPolicyRequest,
+  isAutonomyPresetId,
+} from "../lib/autonomyPresets";
 import type { Thread } from "../types";
 import { useChatComposerStore } from "./chatComposerStore";
 import { useEngineStore } from "./engineStore";
@@ -62,6 +66,7 @@ interface ThreadState {
   ) => Promise<Thread | null>;
   setActiveThread: (threadId: string | null) => void;
   applyThreadUpdateLocal: (thread: Thread) => boolean;
+  markThreadAwaitingApproval: (threadId: string) => void;
   setThreadReasoningEffortLocal: (threadId: string, reasoningEffort: string | null) => void;
   setThreadLastModelLocal: (threadId: string, modelId: string | null) => void;
 }
@@ -189,7 +194,7 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
     set({ loading: true, error: undefined });
 
     try {
-      const created = await ipc.createThread(
+      let created = await ipc.createThread(
         workspaceId,
         repoId,
         effectiveRuntime.engineId,
@@ -198,6 +203,21 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
         effectiveRuntime.reasoningEffort,
         effectiveRuntime.serviceTier,
       );
+
+      try {
+        const defaultPreset = await ipc.getDefaultAutonomyPreset();
+        if (isAutonomyPresetId(defaultPreset)) {
+          const request = autonomyPresetExecutionPolicyRequest(
+            defaultPreset,
+            created.engineId,
+          );
+          if (request) {
+            created = await ipc.setThreadExecutionPolicy(created.id, request);
+          }
+        }
+      } catch {
+        // The thread still works on trust defaults if the preset cannot apply.
+      }
 
       const existingWorkspaceThreads = get().threadsByWorkspace[workspaceId] ?? [];
       const workspaceThreads = [created, ...existingWorkspaceThreads.filter((thread) => thread.id !== created.id)];
@@ -671,6 +691,25 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
 
     return applied;
   },
+  markThreadAwaitingApproval: (threadId) =>
+    set((state) => {
+      const updateThread = (thread: Thread) =>
+        thread.id === threadId && thread.status !== "awaiting_approval"
+          ? { ...thread, status: "awaiting_approval" as const }
+          : thread;
+
+      const threadsByWorkspace = Object.entries(state.threadsByWorkspace).reduce<
+        Record<string, Thread[]>
+      >((acc, [workspaceId, threads]) => {
+        acc[workspaceId] = threads.map(updateThread);
+        return acc;
+      }, {});
+
+      return {
+        threadsByWorkspace,
+        threads: flattenThreadsByWorkspace(threadsByWorkspace),
+      };
+    }),
   setThreadReasoningEffortLocal: (threadId, reasoningEffort) =>
     set((state) => {
       const updateThread = (thread: Thread) =>

--- a/src/stores/threadStore.ts
+++ b/src/stores/threadStore.ts
@@ -6,10 +6,6 @@ import {
   type NewThreadServiceTier,
 } from "../lib/newThreadRuntime";
 import { resolvePreferredOnboardingChatSelection } from "../lib/onboarding";
-import {
-  autonomyPresetExecutionPolicyRequest,
-  isAutonomyPresetId,
-} from "../lib/autonomyPresets";
 import type { Thread } from "../types";
 import { useChatComposerStore } from "./chatComposerStore";
 import { useEngineStore } from "./engineStore";
@@ -194,7 +190,7 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
     set({ loading: true, error: undefined });
 
     try {
-      let created = await ipc.createThread(
+      const created = await ipc.createThread(
         workspaceId,
         repoId,
         effectiveRuntime.engineId,
@@ -203,26 +199,6 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
         effectiveRuntime.reasoningEffort,
         effectiveRuntime.serviceTier,
       );
-
-      try {
-        const defaultPreset = await ipc.getDefaultAutonomyPreset();
-        if (isAutonomyPresetId(defaultPreset)) {
-          const codexExternalSandbox =
-            created.engineId === "codex"
-              ? await ipc.codexUsesExternalSandbox().catch(() => false)
-              : false;
-          const request = autonomyPresetExecutionPolicyRequest(
-            defaultPreset,
-            created.engineId,
-            { codexExternalSandbox },
-          );
-          if (request) {
-            created = await ipc.setThreadExecutionPolicy(created.id, request);
-          }
-        }
-      } catch {
-        // The thread still works on trust defaults if the preset cannot apply.
-      }
 
       const existingWorkspaceThreads = get().threadsByWorkspace[workspaceId] ?? [];
       const workspaceThreads = [created, ...existingWorkspaceThreads.filter((thread) => thread.id !== created.id)];

--- a/src/stores/threadStore.ts
+++ b/src/stores/threadStore.ts
@@ -10,7 +10,6 @@ import {
   autonomyPresetExecutionPolicyRequest,
   isAutonomyPresetId,
 } from "../lib/autonomyPresets";
-import { codexUsesExternalSandbox } from "../lib/codexSandbox";
 import type { Thread } from "../types";
 import { useChatComposerStore } from "./chatComposerStore";
 import { useEngineStore } from "./engineStore";
@@ -208,14 +207,14 @@ export const useThreadStore = create<ThreadState>((set, get) => ({
       try {
         const defaultPreset = await ipc.getDefaultAutonomyPreset();
         if (isAutonomyPresetId(defaultPreset)) {
+          const codexExternalSandbox =
+            created.engineId === "codex"
+              ? await ipc.codexUsesExternalSandbox().catch(() => false)
+              : false;
           const request = autonomyPresetExecutionPolicyRequest(
             defaultPreset,
             created.engineId,
-            {
-              codexExternalSandbox: codexUsesExternalSandbox(
-                useEngineStore.getState().health,
-              ),
-            },
+            { codexExternalSandbox },
           );
           if (request) {
             created = await ipc.setThreadExecutionPolicy(created.id, request);

--- a/src/stores/toastStore.ts
+++ b/src/stores/toastStore.ts
@@ -1,10 +1,23 @@
 import { create } from "zustand";
 
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface Toast {
   id: string;
   variant: "success" | "error" | "warning" | "info";
   message: string;
+  title?: string;
+  action?: ToastAction;
   duration: number;
+}
+
+interface ToastOptions {
+  title?: string;
+  action?: ToastAction;
+  duration?: number;
 }
 
 interface ToastState {
@@ -12,6 +25,8 @@ interface ToastState {
   addToast: (opts: {
     variant: Toast["variant"];
     message: string;
+    title?: string;
+    action?: ToastAction;
     duration?: number;
   }) => string;
   dismissToast: (id: string) => void;
@@ -31,12 +46,12 @@ let nextId = 0;
 export const useToastStore = create<ToastState>((set) => ({
   toasts: [],
 
-  addToast: ({ variant, message, duration }) => {
+  addToast: ({ variant, message, title, action, duration }) => {
     const id = String(++nextId);
     const ms = duration ?? DEFAULT_DURATIONS[variant];
 
     set((state) => {
-      let toasts = [...state.toasts, { id, variant, message, duration: ms }];
+      let toasts = [...state.toasts, { id, variant, message, title, action, duration: ms }];
       if (toasts.length > MAX_TOASTS) {
         toasts = toasts.slice(1);
       }
@@ -53,13 +68,20 @@ export const useToastStore = create<ToastState>((set) => ({
   },
 }));
 
+function normalizeOptions(options?: ToastOptions | number): ToastOptions {
+  if (typeof options === "number") {
+    return { duration: options };
+  }
+  return options ?? {};
+}
+
 export const toast = {
-  success: (message: string, duration?: number) =>
-    useToastStore.getState().addToast({ variant: "success", message, duration }),
-  error: (message: string, duration?: number) =>
-    useToastStore.getState().addToast({ variant: "error", message, duration }),
-  warning: (message: string, duration?: number) =>
-    useToastStore.getState().addToast({ variant: "warning", message, duration }),
-  info: (message: string, duration?: number) =>
-    useToastStore.getState().addToast({ variant: "info", message, duration }),
+  success: (message: string, options?: ToastOptions | number) =>
+    useToastStore.getState().addToast({ variant: "success", message, ...normalizeOptions(options) }),
+  error: (message: string, options?: ToastOptions | number) =>
+    useToastStore.getState().addToast({ variant: "error", message, ...normalizeOptions(options) }),
+  warning: (message: string, options?: ToastOptions | number) =>
+    useToastStore.getState().addToast({ variant: "warning", message, ...normalizeOptions(options) }),
+  info: (message: string, options?: ToastOptions | number) =>
+    useToastStore.getState().addToast({ variant: "info", message, ...normalizeOptions(options) }),
 };


### PR DESCRIPTION
## Summary

Three workstreams on the chat surface. The transcript and composer move onto one component system; the permissions experience is rebuilt around a single autonomy ladder shared by Codex, Claude, and OpenCode; and the agents menu gains per-harness launch flags so terminal sessions can always open with flags like `--yolo` or `--dangerously-skip-permissions`.

## 1. Chat component system

- One block grammar in MessageBlocks: unified 28px headers with icon tiles, labels, and meta; the expandable and static action rows share one implementation; grouped actions read "4 commands, 2 edits" with per-type plurals instead of "4 cmd, 2 write".
- Thinking blocks render markdown from the first streamed token, show a shimmer label while live, and move the duration into the meta slot.
- Action output sits in a titled well with copy and expand-fully controls, replacing the silent 260px scroll cap.
- Chat diffs get an open-in-editor button wired to the existing editor open flow, and long unchanged runs fold behind an explicit "n unchanged lines" row (virtualization-aware; git panel behavior unchanged behind the same flag).
- Approvals: transcript decision pills become CSS variants instead of JS-computed inline colors; the composer banner becomes stacked cards with a count in the header and a stable button order.
- Messages: neutral user bubble with asymmetric radius, visually typed file/mention/skill chips, edit-and-resend on user messages, engine-attributed assistant turn headers.
- Composer: labeled attach pill, classed stop and send buttons, a context ring that amber- and red-shifts with remaining context, clickable usage segments, and the plan banner retired in favor of the violet ring plus active pill.
- One popover primitive replaces five divergent chromes and three duplicate keyframes; toasts support a title, wrapping body, and an optional action.
- Dead code and dead i18n keys removed. All new copy ships in both en and pt-BR.

## 2. Autonomy presets (permissions revamp)

- New `autonomyPresets` model: one ordered ladder (Auto, Read only, Ask to act, Auto in workspace, Full autonomy) that maps onto each engine's native execution policy. Detection maps stored thread policy back to a rung; anything else reads as Custom. The mapping is honest about engine limits: Claude keeps workspace-write on the full rung, and OpenCode exposes approvals only (its allow mode is already full autonomy, so the workspace rung is hidden there).
- The permission picker now opens on the preset ladder with a mapping strip showing the exact native settings the selected rung applies for the thread's engine. The previous per-section rails (trust, approval policy, sandbox, network) remain intact under Advanced.
- Full autonomy is impossible to miss: the trigger pill tints amber, the composer takes the same ring treatment plan mode uses, and the status bar states "never asks, full disk and network".
- The approval banner gains batch actions: "Allow all" answers the stack, "Allow all & stop asking" answers it and escalates the thread to full autonomy.
- Background approvals are no longer invisible: the backend emits an unscoped `chat-approval-requested` event next to the existing per-thread topic; the app listens once, flips the thread to awaiting-approval so the sidebar shows a pulsing "Needs approval" badge, raises a toast with an open-thread action, and fires a native notification when the window is unfocused.
- A `default_autonomy_preset` config value (config.toml) applies the chosen rung to newly created threads, so autonomy no longer resets on every new thread. It is editable via the "Default for new threads" checkbox in the picker.

## 3. Per-harness launch flags

- Each tile in the agents menu has a launch-options editor storing extra CLI flags in config.toml under `[harnesses.launch_args]`, keyed by harness id (for example `codex = "--yolo"`, `claude-code = "--dangerously-skip-permissions"`).
- `launch_harness` composes the final command in the backend, so every launch path picks the flags up: the harness panel, the terminal new-tab menu, multi-launch groups, the command palette, and workspace startup presets.
- Flags are sanitized (control characters stripped) before being written to the PTY, and configured flags show as a chip on the tile.

## Validation

- pnpm typecheck: pass
- pnpm test: 442 passed (60 files), including locale resource parity and 10 new autonomy preset tests
- pnpm build: pass
- cargo check: pass
- cargo test: config and harness suites pass (15 + 5), covering the new config fields, launch-command composition, and sanitization

## Notes for review

- Reference renderings: `prototypes/chat-components-sheet.html` and `prototypes/permissions-autonomy-sheet.html` (local, untracked).
- Deliberate autonomy follow-ups, not in this PR: a real session allowlist in the Claude sidecar (Allow for session still only forwards SDK suggestions), a dismiss affordance for stale post-restart approvals, per-engine default overrides and a settings-page section for the default (the picker checkbox is the only editor today), and skipping the multi-repo write confirmation when a thread is in full autonomy.
- Component-system follow-ups unchanged from before: fork-from-here and regenerate need engine support; the approval banner and transcript card share visual language but remain two components.
- A manual visual pass of the running app is still worthwhile, especially the picker preset flow and the background approval toast.
